### PR TITLE
Bug Fix: Python2 does not accurately compare running and compiled configs

### DIFF
--- a/hier_config/__init__.py
+++ b/hier_config/__init__.py
@@ -2,7 +2,7 @@ from hier_config.hc_child import HConfigChild
 
 import re
 
-__version__ = '1.4.1'
+__version__ = '1.4.2'
 
 
 class HConfig(HConfigChild):

--- a/hier_config/hc_child.py
+++ b/hier_config/hc_child.py
@@ -593,7 +593,7 @@ class HConfigChild:
         for target_child in target.children:
             # if the child exist, recurse into its children
             self_child = self.get_child('equals', target_child.text)
-            if self_child:
+            if self_child is not None:
                 # This creates a new HConfigChild object just in case there are some delta children
                 # Not very efficient, think of a way to not do this
                 subtree = delta.add_child(target_child.text)

--- a/hier_config/hc_child.py
+++ b/hier_config/hc_child.py
@@ -54,6 +54,9 @@ class HConfigChild:
     def __bool__(self):
         return True
 
+    def __nonzero__(self):
+        return self.__bool__()
+
     def __contains__(self, item):
         return str(item) in self.children_dict
 

--- a/tests/test_hier_config.py
+++ b/tests/test_hier_config.py
@@ -43,6 +43,9 @@ class TestHConfig(unittest.TestCase):
         cls.host_a = Host('example1.rtr', cls.os, cls.options)
         cls.host_b = Host('example2.rtr', cls.os, cls.options)
 
+    def test_bool(self):
+        self.assertTrue(HConfig(host=self.host_a))
+
     def test_merge(self):
         hier1 = HConfig(host=self.host_a)
         hier1.add_child('interface Vlan2')

--- a/tests/test_hier_config.py
+++ b/tests/test_hier_config.py
@@ -335,6 +335,17 @@ class TestHConfig(unittest.TestCase):
         remediation_config_hier = running_config_hier.config_to_get_to(compiled_config_hier)
         self.assertEqual(2, len(list(remediation_config_hier.all_children())))
 
+    def test_config_to_get_to_right(self):
+        running_config_hier = HConfig(host=self.host_a)
+        running_config_hier.add_child('do not add me')
+        compiled_config_hier = HConfig(host=self.host_a)
+        compiled_config_hier.add_child('do not add me')
+        compiled_config_hier.add_child('add me')
+        delta = HConfig(host=self.host_a)
+        running_config_hier._config_to_get_to_right(compiled_config_hier, delta)
+        self.assertNotIn('do not add me', delta)
+        self.assertIn('add me', delta)
+
     def test_is_idempotent_command(self):
         pass
 


### PR DESCRIPTION
Python2 does not accurately recognize compiled configs being present in running config.

I identified the issue in the truth test in `HConfigChild._config_to_get_to_right()`.
  1. I believe the test is meant to identify whether an HConfig.child object or `None` is returned
  2. Based on above, change test to only test for `None` and not all truth tests
  3. HConfig.Child implements `__bool__()` magic method, which replaces Python2's `__nonzero__()` method.
  4. Add `__nonzero__()` magic method which returns `__bool__()`
  5. Add test that verifies `HConfigChild` objects evaluate to `True`
  6. Add test that validates `HConfigChild._config_to_get_to_right()` doesn't include a config line that is present in both running and compiled configs, and that a config line in compiled, but absent in running, is added.