### PR TITLE
Add difference

### DIFF
--- a/hier_config/__init__.py
+++ b/hier_config/__init__.py
@@ -2,7 +2,7 @@ from hier_config.base import HConfigBase
 
 import re
 
-__version__ = '1.5.1'
+__version__ = '1.6.0'
 
 
 class HConfig(HConfigBase):
@@ -91,6 +91,26 @@ class HConfig(HConfigBase):
     @property
     def root(self):
         return self
+
+    @property
+    def is_leaf(self):
+        return False
+
+    @property
+    def is_branch(self):
+        return True
+
+    @property
+    def tags(self):
+        t = set()
+        for child in self.children:
+            t.update(child.tags)
+        return t
+
+    @tags.setter
+    def tags(self, value):
+        for child in self.children:
+            child.tags = value
 
     def __repr__(self):
         return 'HConfig(host={})'.format(self.host)
@@ -317,22 +337,19 @@ class HConfig(HConfigBase):
         """
         Handler for tagging sections of Hierarchical Configuration data structure
         for inclusion and exclusion.
-
         """
-
         for rule in tag_rules:
             for child in self.all_children():
                 if child.lineage_test(rule, strip_negation):
                     if 'add_tags' in rule:
-                        child.deep_append_tags(rule['add_tags'])
-                        for ancestor in child.lineage():
-                            ancestor.append_tags(rule['add_tags'])
+                        child.append_tags(rule['add_tags'])
                     if 'remove_tags' in rule:
-                        child.deep_remove_tags(rule['remove_tags'])
+                        child.remove_tags(rule['remove_tags'])
 
         return self
 
-    def depth(self):
+    @staticmethod
+    def depth():
         return 0
 
     def _add_acl_sequence_numbers(self):

--- a/hier_config/base.py
+++ b/hier_config/base.py
@@ -138,7 +138,7 @@ class HConfigBase(object):
         """ Yield all children recursively that are untagged """
 
         for child in self.all_children_sorted():
-            if not child.tags:
+            if None in child.tags:
                 yield child
 
     def all_children_sorted_by_tags(self, include_tags, exclude_tags):

--- a/hier_config/base.py
+++ b/hier_config/base.py
@@ -318,6 +318,39 @@ class HConfigBase(object):
 
         return delta
 
+    def difference(self, target, delta=None):
+        """
+        Creates a new HConfig object with the config from self that is not in target
+
+        Example usage:
+        whats in the config.lines v.s. in running config
+        i.e. did all my configuration changes get written to the running config
+
+        :param target: HConfig - The configuration to check against
+        :param delta: HConfig - The elements from self that are not in target
+        :return: HConfig - missing config additions
+        """
+        if delta is None:
+            from hier_config import HConfig
+            delta = HConfig(host=self.host)
+
+        for self_child in self.children:
+            # Not dealing with negations and defaults for now
+            if self_child.text.startswith(('no ', 'default ')):
+                continue
+
+            target_child = target.get_child('equals', self_child.text)
+
+            if target_child:
+                delta_child = delta.add_child(self_child.text)
+                self_child.difference(target_child, delta_child)
+                if not delta_child.children:
+                    delta_child.delete()
+            else:
+                delta.add_deep_copy_of(self_child)
+
+        return delta
+
     def _config_to_get_to_left(self, target, delta):
         # find self.children that are not in target.children - i.e. what needs to be negated or defaulted
         # Also, find out if another command in self.children will overwrite -

--- a/hier_config/hc_child.py
+++ b/hier_config/hc_child.py
@@ -13,7 +13,7 @@ class HConfigChild(HConfigBase):
         # The intent is for self.order_weight values to range from 1 to 999
         # with the default weight being 500
         self.order_weight = 500
-        self.tags = set()
+        self._tags = set()
         self.comments = set()
         self.new_in_config = False
         self.instances = []
@@ -175,63 +175,29 @@ class HConfigChild(HConfigBase):
         # TODO find a way to remove this when sub-classing in HCRoot
         self.parent.del_child(self)
 
-    def ancestor_append_tags(self, tags):
-        """
-        Append tags to self.tags and for all ancestors
-
-        """
-
-        for ancestor in self.lineage():
-            ancestor.append_tags(tags)
-
-    def ancestor_remove_tags(self, tags):
-        """
-        Remove tags to self.tags and for all ancestors
-
-        """
-
-        for ancestor in self.lineage():
-            ancestor.remove_tags(tags)
-
-    def deep_append_tags(self, tags):
-        """
-        Append tags to self.tags and recursively for all children
-
-        """
-
-        self.append_tags(tags)
-        for child in self.all_children():
-            child.append_tags(tags)
-
-    def deep_remove_tags(self, tags):
-        """
-        Remove tags from self.tags and recursively for all children
-
-        """
-
-        self.remove_tags(tags)
-        for child in self.all_children():
-            child.remove_tags(tags)
-
     def append_tags(self, tags):
         """
         Add tags to self.tags
-
         """
-
-        tags = H.to_list(tags)
-        # self._tags.update(tags)
-        self.tags.update(tags)
+        from hier_config.helpers import to_list
+        tags = to_list(tags)
+        if self.is_branch:
+            for child in self.children:
+                child.append_tags(tags)
+        else:
+            self._tags.update(tags)
 
     def remove_tags(self, tags):
         """
         Remove tags from self.tags
-
         """
-
-        tags = H.to_list(tags)
-        # self._tags.difference_update(tags)
-        self.tags.difference_update(tags)
+        from hier_config.helpers import to_list
+        tags = to_list(tags)
+        if self.is_branch:
+            for child in self.children:
+                child.remove_tags(tags)
+        else:
+            self._tags.difference_update(tags)
 
     def negate(self):
         """ Negate self.text """
@@ -246,6 +212,33 @@ class HConfigChild(HConfigBase):
                 return self._default()
 
         return self._swap_negation()
+
+    @property
+    def is_leaf(self):
+        return not self.is_branch
+
+    @property
+    def is_branch(self):
+        return bool(self.children)
+
+    @property
+    def tags(self):
+        if self.is_branch:
+            t = set()
+            for child in self.children:
+                t.update(child.tags)
+            return t
+
+        return self._tags
+
+    @tags.setter
+    def tags(self, value):
+        if self.is_branch:
+            for child in self.children:
+                child.tags = value
+        else:
+            assert isinstance(value, set)
+            self._tags = value
 
     def _swap_negation(self):
         """ Swap negation of a self.text """
@@ -352,14 +345,14 @@ class HConfigChild(HConfigBase):
         """
         Given the line_tags, include_tags, and exclude_tags,
         determine if the line should be included
-
         """
-
         include_line = False
+
         if include_tags:
             set_include_tags = set(include_tags)
             include_line = bool(self.tags.intersection(set_include_tags))
-
-        if include_line:
+        elif exclude_tags and (include_line or not include_tags):
             set_exclude_tags = set(exclude_tags)
-            return not bool(self.tags.intersection(set_exclude_tags))
+            include_line = not bool(self.tags.intersection(set_exclude_tags))
+
+        return include_line

--- a/hier_config/hc_child.py
+++ b/hier_config/hc_child.py
@@ -229,7 +229,7 @@ class HConfigChild(HConfigBase):
                 t.update(child.tags)
             return t
 
-        return self._tags
+        return self._tags or {None}
 
     @tags.setter
     def tags(self, value):
@@ -346,13 +346,11 @@ class HConfigChild(HConfigBase):
         Given the line_tags, include_tags, and exclude_tags,
         determine if the line should be included
         """
-        include_line = False
-
-        if include_tags:
-            set_include_tags = set(include_tags)
-            include_line = bool(self.tags.intersection(set_include_tags))
-        elif exclude_tags and (include_line or not include_tags):
-            set_exclude_tags = set(exclude_tags)
-            include_line = not bool(self.tags.intersection(set_exclude_tags))
-
-        return include_line
+        from hier_config.helpers import to_list
+        include_tags_set = set(to_list(include_tags))
+        if self.tags.intersection(include_tags_set):
+            if self.is_leaf and exclude_tags:
+                exclude_tags_set = set(to_list(exclude_tags))
+                return not bool(self.tags.intersection(exclude_tags_set))
+            return True
+        return False

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ setup(
     python_requires='>=2.7',
     install_requires=[
         "PyYAML>=3.12",
+        "pep8",
     ],
     classifiers=[
         'Development Status :: 4 - Beta',

--- a/tests/test_hier_config.py
+++ b/tests/test_hier_config.py
@@ -262,10 +262,29 @@ class TestHConfig(unittest.TestCase):
         self.assertFalse(isinstance(ip_address.cisco_style_text(), list))
 
     def test_all_children_sorted_untagged(self):
-        pass
+        config = HConfig(host=self.host_a)
+        interface = config.add_child('interface Vlan2')
+        ip_address_a = interface.add_child('ip address 192.168.1.1/24')
+        ip_address_a.append_tags('a')
+        ip_address_none = interface.add_child('ip address 192.168.2.1/24')
+
+        self.assertIs(ip_address_none, list(config.all_children_sorted_untagged())[1])
+        self.assertEqual(2, len(list(config.all_children_sorted_untagged())))
+        self.assertIs(ip_address_none, list(config.all_children_sorted_untagged())[1])
 
     def test_all_children_sorted_by_tags(self):
-        pass
+        config = HConfig(host=self.host_a)
+        interface = config.add_child('interface Vlan2')
+        ip_address_a = interface.add_child('ip address 192.168.1.1/24')
+        ip_address_a.append_tags('a')
+        ip_address_ab = interface.add_child('ip address 192.168.2.1/24')
+        ip_address_ab.append_tags(['a', 'b'])
+
+        self.assertEqual(2, len(list(config.all_children_sorted_by_tags('a', 'b'))))
+        self.assertIs(ip_address_a, list(config.all_children_sorted_by_tags('a', 'b'))[1])
+        self.assertEqual(3, len(list(config.all_children_sorted_by_tags('a', ''))))
+        self.assertEqual(0, len(list(config.all_children_sorted_by_tags('', 'a'))))
+        self.assertEqual(0, len(list(config.all_children_sorted_by_tags('', ''))))
 
     def test_all_children_sorted(self):
         hier = HConfig(host=self.host_a)
@@ -298,6 +317,18 @@ class TestHConfig(unittest.TestCase):
 
     def test_to_tag_spec(self):
         pass
+
+    def test_tags(self):
+        config = HConfig(host=self.host_a)
+        interface = config.add_child('interface Vlan2')
+        ip_address = interface.add_child('ip address 192.168.1.1/24')
+        self.assertTrue(None in interface.tags)
+        self.assertTrue(None in ip_address.tags)
+        ip_address.append_tags('a')
+        self.assertTrue('a' in interface.tags)
+        self.assertTrue('a' in ip_address.tags)
+        self.assertFalse('b' in interface.tags)
+        self.assertFalse('b' in ip_address.tags)
 
     def test_append_tags(self):
         config = HConfig(host=self.host_a)
@@ -366,7 +397,15 @@ class TestHConfig(unittest.TestCase):
         pass
 
     def test_line_inclusion_test(self):
-        pass
+        config = HConfig(host=self.host_a)
+        interface = config.add_child('interface Vlan2')
+        ip_address_ab = interface.add_child('ip address 192.168.2.1/24')
+        ip_address_ab.append_tags(['a', 'b'])
+
+        self.assertFalse(ip_address_ab.line_inclusion_test('a', 'b'))
+        self.assertFalse(ip_address_ab.line_inclusion_test('', 'a'))
+        self.assertTrue(ip_address_ab.line_inclusion_test('a', ''))
+        self.assertFalse(ip_address_ab.line_inclusion_test('', ''))
 
     def test_lineage_test(self):
         pass

--- a/tests/test_hier_config.py
+++ b/tests/test_hier_config.py
@@ -299,23 +299,27 @@ class TestHConfig(unittest.TestCase):
     def test_to_tag_spec(self):
         pass
 
-    def test_ancestor_append_tags(self):
-        pass
-
-    def test_ancestor_remove_tags(self):
-        pass
-
-    def test_deep_append_tags(self):
-        pass
-
-    def test_deep_remove_tags(self):
-        pass
-
     def test_append_tags(self):
-        pass
+        config = HConfig(host=self.host_a)
+        interface = config.add_child('interface Vlan2')
+        ip_address = interface.add_child('ip address 192.168.1.1/24')
+        ip_address.append_tags('test_tag')
+        self.assertIn('test_tag', config.tags)
+        self.assertIn('test_tag', interface.tags)
+        self.assertIn('test_tag', ip_address.tags)
 
     def test_remove_tags(self):
-        pass
+        config = HConfig(host=self.host_a)
+        interface = config.add_child('interface Vlan2')
+        ip_address = interface.add_child('ip address 192.168.1.1/24')
+        ip_address.append_tags('test_tag')
+        self.assertIn('test_tag', config.tags)
+        self.assertIn('test_tag', interface.tags)
+        self.assertIn('test_tag', ip_address.tags)
+        ip_address.remove_tags('test_tag')
+        self.assertNotIn('test_tag', config.tags)
+        self.assertNotIn('test_tag', interface.tags)
+        self.assertNotIn('test_tag', ip_address.tags)
 
     def test_with_tags(self):
         pass
@@ -366,6 +370,23 @@ class TestHConfig(unittest.TestCase):
 
     def test_lineage_test(self):
         pass
+
+    def test_difference(self):
+        rc = ['a', ' a1', ' a2', ' a3', 'b']
+        step = ['a', ' a1', ' a2', ' a3', ' a4', ' a5', 'b', 'c', 'd', ' d1']
+        rc_hier = HConfig(host=self.host_a)
+        rc_hier.load_from_string("\n".join(rc))
+        step_hier = HConfig(host=self.host_a)
+        step_hier.load_from_string("\n".join(step))
+
+        difference = step_hier.difference(rc_hier)
+        difference_children = list(c.cisco_style_text() for c in difference.all_children_sorted())
+        self.assertEqual(len(difference_children), 6)
+        self.assertIn('c', difference)
+        self.assertIn('d', difference)
+        self.assertIn('a4', difference.get_child('equals', 'a'))
+        self.assertIn('a5', difference.get_child('equals', 'a'))
+        self.assertIn('d1', difference.get_child('equals', 'd'))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION

- Add `difference()`
  - Returns a new `HConfig` object with all children from `self` that are not in `target`
- Fix `line_inclusion_test()`, it was ignoring exclude_tags
- Bump version
- Tags are now leaf node only, branches recurse to leaves to return tags