### PR TITLE
add support for other negations as "no"

### DIFF
--- a/hier_config/__init__.py
+++ b/hier_config/__init__.py
@@ -74,8 +74,7 @@ class HConfig(HConfigBase):
             raise AttributeError('Error determining host object')
 
         self._options = self.host.hconfig_options
-        if 'negation' not in self._options:
-            self._options['negation'] = 'no'
+        self._options.set_default("negation", "no")
         self._logs = list()
 
     @property

--- a/hier_config/__init__.py
+++ b/hier_config/__init__.py
@@ -74,7 +74,7 @@ class HConfig(HConfigBase):
             raise AttributeError('Error determining host object')
 
         self._options = self.host.hconfig_options
-        self._options.set_default("negation", "no")
+        self._options.setdefault("negation", "no")
         self._logs = list()
 
     @property

--- a/hier_config/__init__.py
+++ b/hier_config/__init__.py
@@ -74,6 +74,8 @@ class HConfig(HConfigBase):
             raise AttributeError('Error determining host object')
 
         self._options = self.host.hconfig_options
+        if 'negation' not in self._options:
+            self._options['negation'] = 'no'
         self._logs = list()
 
     @property

--- a/hier_config/base.py
+++ b/hier_config/base.py
@@ -265,8 +265,8 @@ class HConfigBase(object):
             # This removes negations for each section but honestly,
             # we really only need to do this on the last one
             if strip_negation:
-                if section.text.startswith('no '):
-                    text = section.text[3:]
+                if section.text.startswith(self.options['negation'] + ' '):
+                    text = section.text[len(self.options['negation'] + ' '):]
                 elif section.text.startswith('default '):
                     text = section.text[8:]
                 else:
@@ -336,7 +336,7 @@ class HConfigBase(object):
 
         for self_child in self.children:
             # Not dealing with negations and defaults for now
-            if self_child.text.startswith(('no ', 'default ')):
+            if self_child.text.startswith((self.options['negation'] + ' ', 'default ')):
                 continue
 
             target_child = target.get_child('equals', self_child.text)

--- a/hier_config/hc_child.py
+++ b/hier_config/hc_child.py
@@ -243,17 +243,17 @@ class HConfigChild(HConfigBase):
     def _swap_negation(self):
         """ Swap negation of a self.text """
 
-        if self.text.startswith('no '):
-            self.text = self.text[3:]
+        if self.text.startswith(self.options['negation'] + ' '):
+            self.text = self.text[len(self.options['negation'] + ' '):]
         else:
-            self.text = 'no ' + self.text
+            self.text = self.options['negation'] + ' ' + self.text
         return self
 
     def _default(self):
         """ Default self.text """
 
-        if self.text.startswith('no '):
-            self.text = 'default ' + self.text[3:]
+        if self.text.startswith(self.options['negation'] + ' '):
+            self.text = 'default ' + self.text[len(self.options['negation'] + ' '):]
         else:
             self.text = 'default ' + self.text
         return self

--- a/tests/files/test_options_negate_with_undo.yml
+++ b/tests/files/test_options_negate_with_undo.yml
@@ -1,0 +1,19 @@
+---
+# Indicates the style of the configuration
+style: comware5
+
+# negation prefix
+negation: 'undo'
+
+sectional_overwrite: []
+sectional_overwrite_no_negate: []
+ordering: []
+indent_adjust: []
+parent_allows_duplicate_child: []
+sectional_exiting: []
+full_text_sub: []
+per_line_sub: []
+idempotent_commands_blacklist: []
+idempotent_commands: []
+negation_default_when: []
+negation_negate_with: []

--- a/tests/test_negate_with_undo.py
+++ b/tests/test_negate_with_undo.py
@@ -1,0 +1,38 @@
+import unittest
+import tempfile
+import os
+import yaml
+import types
+
+from hier_config import HConfig
+from hier_config.host import Host
+
+
+class TestNegateWithUndo(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.os = 'comware5'
+        cls.options_file = os.path.join(
+            os.path.dirname(os.path.realpath(__file__)),
+            'files',
+            'test_options_negate_with_undo.yml',
+        )
+        cls.running_cfg = 'test_for_undo\nundo test_for_redo\n'
+        cls.compiled_cfg = 'undo test_for_undo\ntest_for_redo\n'
+        cls.remediation = 'undo test_for_undo\ntest_for_redo\n'
+
+        with open(cls.options_file) as f:
+            cls.options = yaml.safe_load(f.read())
+
+        cls.host_a = Host('example1.rtr', cls.os, cls.options)
+
+    def test_merge(self):
+        self.host_a.load_config_from(config_type="running", name=self.running_cfg, load_file=False)
+        self.host_a.load_config_from(config_type="compiled", name=self.compiled_cfg, load_file=False)
+        self.host_a.load_remediation()
+
+        self.assertEqual(self.remediation, self.host_a.facts['remediation_config_raw'])
+
+if __name__ == "__main__":
+    unittest.main(failfast=True)

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -9,12 +9,14 @@ def all_tests():
     from test_host import TestHost
     from test_hier_config import TestHConfig
     from test_text_match import TestTextMatch
+    from test_negate_with_undo import TestNegateWithUndo
 
     suite = unittest.TestSuite()
     suite.addTest(unittest.makeSuite(TestPep8))
     suite.addTest(unittest.makeSuite(TestHost))
     suite.addTest(unittest.makeSuite(TestHConfig))
     suite.addTest(unittest.makeSuite(TestTextMatch))
+    suite.addTest(unittest.makeSuite(TestNegateWithUndo))
 
     return suite
 


### PR DESCRIPTION
I am using a bunch of comware 5/comware 7 switches where negation is "undo" instead of "no". This PR adds a configuration parameter to change the negation prefix