### PR TITLE
Fix Issue #75 - Windows File Locking Permission Denied Error on test_load_from_file

### DIFF
--- a/tests/test_hier_config.py
+++ b/tests/test_hier_config.py
@@ -63,10 +63,12 @@ class TestHConfig(unittest.TestCase):
         hier = HConfig(host=self.host_a)
         config = 'interface Vlan2\n ip address 1.1.1.1 255.255.255.0'
 
-        with tempfile.NamedTemporaryFile(mode='r+') as myfile:
+        with tempfile.NamedTemporaryFile(mode='r+', delete=False) as myfile:
             myfile.file.write(config)
             myfile.file.flush()
+            myfile.close()
             hier.load_from_file(myfile.name)
+            os.remove(myfile.name)
 
         self.assertEqual(2, len(list(hier.all_children())))
 


### PR DESCRIPTION
Fixes an issue with the fact that Windows handles temp file locking differently to Linux.  This makes the `tempfile.NamedTemporaryFile` difficult to use as it behaves inconsistently.  

Windows was unable to access the temporary test file, due to the locking [issue14243](https://bugs.python.org/issue14243)

For the test to run, the initial write must be closed first, without deleting the file. 
The test can then run. 
Then the file must be manually cleaned up.
