### PR TITLE
Fix Issue #77 - PyYaml not supported on Python 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,10 @@ language: python
 
 python:
 - "2.7"
-- "3.4"
 - "3.5"
 - "3.6"
+- "3.7"
+- "3.8"
 
 install:
 - "pip install pycodestyle pyyaml"


### PR DESCRIPTION
Removed Python 3.4 from travis config.
Also added Python 3.7 and 3.8 as these are currently standard on some modern mainline distributions