### PR TITLE
Fix YAML unsafe Loader and unclosed File Warnings

### DIFF
--- a/tests/test_host.py
+++ b/tests/test_host.py
@@ -29,8 +29,10 @@ class TestHost(unittest.TestCase):
             'files',
             'test_tags_ios.yml'
         )
-        cls.hconfig_tags = yaml.load(open(cls.tags_file))
-        cls.hconfig_options = yaml.load(open(cls.options_file))
+        with open(cls.tags_file, "r") as f:
+            cls.hconfig_tags = yaml.load(f, Loader=yaml.SafeLoader)
+        with open(cls.options_file, "r") as f:
+            cls.hconfig_options = yaml.load(f, Loader=yaml.SafeLoader)
         cls.host = Host('example.rtr', 'ios', cls.hconfig_options)
 
         with open(cls.compiled_file) as f:


### PR DESCRIPTION
Tests warn about using the unsafe YAML loaded.  the `Loader=yaml.SafeLoader` parameter is required for safe loading.

The file open for the loader was not closed. 

both give the errors:
```
C:\Users\Rich\PycharmProjects\hier_config\tests\test_host.py:32: YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.
  cls.hconfig_tags = yaml.load(open(cls.tags_file))
C:\Users\Rich\PycharmProjects\hier_config\tests\test_host.py:32: ResourceWarning: unclosed file <_io.TextIOWrapper name='C:\\Users\\Rich\\PycharmProjects\\hier_config\\tests\\files\\test_tags_ios.yml' mode='r' encoding='cp1252'>
  cls.hconfig_tags = yaml.load(open(cls.tags_file))
C:\Users\Rich\PycharmProjects\hier_config\tests\test_host.py:33: YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.
  cls.hconfig_options = yaml.load(open(cls.options_file))
C:\Users\Rich\PycharmProjects\hier_config\tests\test_host.py:33: ResourceWarning: unclosed file <_io.TextIOWrapper name='C:\\Users\\Rich\\PycharmProjects\\hier_config\\tests\\files\\test_options_ios.yml' mode='r' encoding='cp1252'>
  cls.hconfig_options = yaml.load(open(cls.options_file))
```

