### PR TITLE
Future config

### DIFF
--- a/docs/experimental-features.md
+++ b/docs/experimental-features.md
@@ -66,3 +66,114 @@ Out[1]:
  '  + no shutdown']
 ```
         
+
+
+## Future Config
+
+Starting in version 2.2.0, a featured called future config was introduced. It attempts to predict the running config after a change is applied.
+
+This feature is useful in cases where you need to determine what the configuration state will be after a change is applied. Such as:
+- Ensuring that a configuration change was applied successfully to a device.
+  - i.e. Does the post-change config match the predicted future config?
+- Providing a future state config that can be fed into batfish, or similar, to predict if a change will cause an impact.
+
+In its current state, this algorithm does not consider:
+- negate a numbered ACL when removing an item
+- sectional exiting
+- negate with
+- idempotent command blacklist
+- idempotent_acl_check
+- and likely others
+
+```bash
+In [1]: from hier_config import HConfig, Host
+   ...:
+   ...:
+   ...: host = Host("test.dfw1", "ios")
+   ...: running_config = HConfig(host)
+   ...: running_config.load_from_file("./tests/fixtures/running_config.conf")
+   ...: remediation_config = HConfig(host)
+   ...: remediation_config.load_from_file("./tests/fixtures/remediation_config_without_tags.conf")
+   ...: future_config = running_config.future(remediation_config)
+   ...:
+   ...: print("\n##### running config")
+   ...: for line in running_config.all_children():
+   ...:     print(line.cisco_style_text())
+   ...:
+   ...: print("\n##### remediation config")
+   ...: for line in remediation_config.all_children():
+   ...:     print(line.cisco_style_text())
+   ...:
+   ...: print("\n##### future config")
+   ...: for line in future_config.all_children():
+   ...:     print(line.cisco_style_text())
+   ...:
+
+##### running config
+hostname aggr-example.rtr
+ip access-list extended TEST
+  10 permit ip 10.0.0.0 0.0.0.7 any
+vlan 2
+  name switch_mgmt_10.0.2.0/24
+vlan 3
+  name switch_mgmt_10.0.4.0/24
+interface Vlan2
+  descripton switch_10.0.2.0/24
+  ip address 10.0.2.1 255.255.255.0
+  shutdown
+interface Vlan3
+  mtu 9000
+  description switch_mgmt_10.0.4.0/24
+  ip address 10.0.4.1 255.255.0.0
+  ip access-group TEST in
+  no shutdown
+
+##### remediation config
+vlan 3
+  name switch_mgmt_10.0.3.0/24
+vlan 4
+  name switch_mgmt_10.0.4.0/24
+interface Vlan2
+  mtu 9000
+  ip access-group TEST in
+  no shutdown
+interface Vlan3
+  description switch_mgmt_10.0.3.0/24
+  ip address 10.0.3.1 255.255.0.0
+interface Vlan4
+  mtu 9000
+  description switch_mgmt_10.0.4.0/24
+  ip address 10.0.4.1 255.255.0.0
+  ip access-group TEST in
+  no shutdown
+
+##### future config
+vlan 3
+  name switch_mgmt_10.0.3.0/24
+vlan 4
+  name switch_mgmt_10.0.4.0/24
+interface Vlan2
+  mtu 9000
+  ip access-group TEST in
+  descripton switch_10.0.2.0/24
+  ip address 10.0.2.1 255.255.255.0
+interface Vlan3
+  description switch_mgmt_10.0.3.0/24
+  ip address 10.0.3.1 255.255.0.0
+  mtu 9000
+  ip address 10.0.4.1 255.255.0.0
+  ip access-group TEST in
+  no shutdown
+interface Vlan4
+  mtu 9000
+  description switch_mgmt_10.0.4.0/24
+  ip address 10.0.4.1 255.255.0.0
+  ip access-group TEST in
+  no shutdown
+hostname aggr-example.rtr
+ip access-list extended TEST
+  10 permit ip 10.0.0.0 0.0.0.7 any
+vlan 2
+  name switch_mgmt_10.0.2.0/24
+```
+        

--- a/hier_config/base.py
+++ b/hier_config/base.py
@@ -309,6 +309,10 @@ class HConfigBase(ABC):  # pylint: disable=too-many-public-methods
             # sectional_overwrite_no_negate
             elif config_child.sectional_overwrite_no_negate_check():
                 future_config.add_deep_copy_of(config_child)
+            # Idempotent commands
+            elif self_child := config_child.idempotent_for(self.children):
+                future_config.add_deep_copy_of(config_child)
+                negated_or_recursed.add(self_child.text)
             # The config_child being applied is already in self
             elif self_child := self.get_child("equals", config_child.text):
                 future_child = future_config.add_shallow_copy_of(self_child)

--- a/hier_config/base.py
+++ b/hier_config/base.py
@@ -293,23 +293,17 @@ class HConfigBase(ABC):  # pylint: disable=too-many-public-methods
         future_config: Union[HConfig, HConfigChild],
     ) -> None:
         """
-        TODO
-        This initial draft focuses on simple declaration and negation which still leaves much to do:
-        Account for these cases
+        The below cases still need to be accounted for:
         - negate a numbered ACL when removing an item
-        - idempotent commands
-          - This will imply that all idempotent command handling be done in
-            hier_config and not by outside modules
         - sectional exiting
         - negate with
-        - remediation fixups
-        - sectional_overwrite
-        - sectional_overwrite with no negate
+        - idempotent command blacklist
+        - idempotent_acl_check
+        - and likely others
         """
         negated_or_recursed = set()
         for config_child in config.children:
             # sectional_overwrite
-            # account for the negation
             if config_child.sectional_overwrite_check():
                 future_config.add_deep_copy_of(config_child)
             # sectional_overwrite_no_negate

--- a/hier_config/base.py
+++ b/hier_config/base.py
@@ -316,6 +316,7 @@ class HConfigBase(ABC):  # pylint: disable=too-many-public-methods
             # The config_child being applied is already in self
             elif self_child := self.get_child("equals", config_child.text):
                 future_child = future_config.add_shallow_copy_of(self_child)
+                # pylint: disable=protected-access
                 self_child._future(config_child, future_child)
                 negated_or_recursed.add(config_child.text)
             # The a child is being negated

--- a/hier_config/base.py
+++ b/hier_config/base.py
@@ -292,19 +292,20 @@ class HConfigBase(ABC):  # pylint: disable=too-many-public-methods
         config: Union[HConfig, HConfigChild],
         future_config: Union[HConfig, HConfigChild],
     ) -> None:
-        # TODO
-        # The initial draft should focus on simple declaration and negation
-        # Use this as the new write_verify mechanism. This will ensure the results are accurate.
-        # Account for special cases
-        # - negate a numbered ACL when removing an item
-        # - idempotent commands
-        #   - This will imply that all idempotent command handling be done in hier_config and not by outside modules
-        # - sectional exiting
-        # - negate with
-        # - remediation fixups
-        # - sectional_overwrite
-        # - sectional_overwrite with no negate
-
+        """
+        TODO
+        This initial draft focuses on simple declaration and negation which still leaves much to do:
+        Account for these cases
+        - negate a numbered ACL when removing an item
+        - idempotent commands
+          - This will imply that all idempotent command handling be done in
+            hier_config and not by outside modules
+        - sectional exiting
+        - negate with
+        - remediation fixups
+        - sectional_overwrite
+        - sectional_overwrite with no negate
+        """
         negated_or_recursed = set()
         for config_child in config.children:
             # sectional_overwrite
@@ -333,12 +334,7 @@ class HConfigBase(ABC):  # pylint: disable=too-many-public-methods
         for self_child in self.children:
             if self_child.text in negated_or_recursed:
                 continue
-            else:
-                future_config.add_deep_copy_of(self_child)
-
-
-        # elif self_child.sectional_overwrite_no_negate_check():
-        #   target_child.overwrite_with(self_child, delta, False)
+            future_config.add_deep_copy_of(self_child)
 
     def delete_all_children(self) -> None:
         """Delete all children"""

--- a/hier_config/child.py
+++ b/hier_config/child.py
@@ -272,13 +272,15 @@ class HConfigChild(HConfigBase):
                         return True
 
         # Idempotent command identification
+        return bool(self.idempotent_for(other_children))
+
+    def idempotent_for(self, other_children: Iterable[HConfigChild]) -> Optional[HConfigChild]:
         for rule in self.options["idempotent_commands"]:
             if self.lineage_test(rule, True):
                 for other_child in other_children:
                     if other_child.lineage_test(rule, True):
-                        return True
-
-        return False
+                        return other_child
+        return None
 
     def sectional_overwrite_no_negate_check(self) -> bool:
         """

--- a/hier_config/root.py
+++ b/hier_config/root.py
@@ -281,7 +281,13 @@ class HConfig(HConfigBase):  # pylint: disable=too-many-public-methods
                     exit_line.order_weight = 999
 
     def future(self, config: HConfig) -> HConfig:
-        """EXPERIMENTAL - predict the future config after config is applied to self"""
+        """
+        EXPERIMENTAL - predict the future config after config is applied to self
+
+        The quality of the this method's output will in part depend on how well
+        the OS options are tuned. Ensuring that idempotency rules are accurate is
+        especially important.
+        """
         future_config = HConfig(host=self.host)
         self._future(config, future_config)
         return future_config

--- a/hier_config/root.py
+++ b/hier_config/root.py
@@ -281,11 +281,7 @@ class HConfig(HConfigBase):  # pylint: disable=too-many-public-methods
                     exit_line.order_weight = 999
 
     def future(self, config: HConfig) -> HConfig:
-        # TODO
-        # The initial draft should focus on simple declaration and negation
-        # Account for special cases
-        # - negate a numbered ACL when removing an item
-        # - idempotent commands
+        """EXPERIMENTAL - predict the future config after config is applied to self"""
         future_config = HConfig(host=self.host)
         self._future(config, future_config)
         return future_config

--- a/hier_config/root.py
+++ b/hier_config/root.py
@@ -280,6 +280,16 @@ class HConfig(HConfigBase):  # pylint: disable=too-many-public-methods
                     exit_line.tags = child.tags
                     exit_line.order_weight = 999
 
+    def future(self, config: HConfig) -> HConfig:
+        # TODO
+        # The initial draft should focus on simple declaration and negation
+        # Account for special cases
+        # - negate a numbered ACL when removing an item
+        # - idempotent commands
+        future_config = HConfig(host=self.host)
+        self._future(config, future_config)
+        return future_config
+
     def with_tags(self, tags: Set[str]) -> HConfig:
         """
         Returns a new instance containing only sub-objects

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hier-config"
-version = "2.1.0"
+version = "2.2.0"
 description = "A network configuration comparison tool, used to build remediation configurations."
 packages = [
     { include="hier_config", from="."},

--- a/tests/test_hier_config.py
+++ b/tests/test_hier_config.py
@@ -450,6 +450,25 @@ class TestHConfig:
     def test_lineage_test(self):
         pass
 
+    def test_future_config(self):
+        running_config = HConfig(host=self.host_a)
+        running_config.add_children_deep(["a", "aa", "aaa", "aaaa"])
+        running_config.add_children_deep(["a", "ab", "aba", "abaa"])
+        config = HConfig(host=self.host_a)
+        config.add_children_deep(["a", "ac"])
+        config.add_children_deep(["a", "no ab"])
+        config.add_children_deep(["a", "no az"])
+
+        future_config = running_config.future(config)
+        assert list(c.cisco_style_text() for c in future_config.all_children()) == [
+            "a",
+            "  ac",  # config lines are added first
+            "  no az",
+            "  aa",  # self lines not in config are added last
+            "    aaa",
+            "      aaaa",
+        ]
+
     def test_difference1(self):
         rc = ["a", " a1", " a2", " a3", "b"]
         step = ["a", " a1", " a2", " a3", " a4", " a5", "b", "c", "d", " d1"]


### PR DESCRIPTION
Add a method to predict the running config after a change is applied

This feature is useful in cases where you need to determine what the configuration state will be after a change is applied. Such as:
- Ensuring that a configuration change was applied successfully to a device.
  - i.e. Does the post-change config match the predicted future config?
- Providing a future state config that can be fed into batfish, or similar, to predict if a change will cause an impact.


```
In [1]: from hier_config import HConfig, Host
   ...:
   ...:
   ...: host = Host("test.dfw1", "ios")
   ...: running_config = HConfig(host)
   ...: running_config.load_from_file("./tests/fixtures/running_config.conf")
   ...: remediation_config = HConfig(host)
   ...: remediation_config.load_from_file("./tests/fixtures/remediation_config_without_tags.conf")
   ...: future_config = running_config.future(remediation_config)
   ...:
   ...: print("\n##### running config")
   ...: for line in running_config.all_children():
   ...:     print(line.cisco_style_text())
   ...:
   ...: print("\n##### remediation config")
   ...: for line in remediation_config.all_children():
   ...:     print(line.cisco_style_text())
   ...:
   ...: print("\n##### future config")
   ...: for line in future_config.all_children():
   ...:     print(line.cisco_style_text())
   ...:

##### running config
hostname aggr-example.rtr
ip access-list extended TEST
  10 permit ip 10.0.0.0 0.0.0.7 any
vlan 2
  name switch_mgmt_10.0.2.0/24
vlan 3
  name switch_mgmt_10.0.4.0/24
interface Vlan2
  descripton switch_10.0.2.0/24
  ip address 10.0.2.1 255.255.255.0
  shutdown
interface Vlan3
  mtu 9000
  description switch_mgmt_10.0.4.0/24
  ip address 10.0.4.1 255.255.0.0
  ip access-group TEST in
  no shutdown

##### remediation config
vlan 3
  name switch_mgmt_10.0.3.0/24
vlan 4
  name switch_mgmt_10.0.4.0/24
interface Vlan2
  mtu 9000
  ip access-group TEST in
  no shutdown
interface Vlan3
  description switch_mgmt_10.0.3.0/24
  ip address 10.0.3.1 255.255.0.0
interface Vlan4
  mtu 9000
  description switch_mgmt_10.0.4.0/24
  ip address 10.0.4.1 255.255.0.0
  ip access-group TEST in
  no shutdown

##### future config
vlan 3
  name switch_mgmt_10.0.3.0/24
vlan 4
  name switch_mgmt_10.0.4.0/24
interface Vlan2
  mtu 9000
  ip access-group TEST in
  descripton switch_10.0.2.0/24
  ip address 10.0.2.1 255.255.255.0
interface Vlan3
  description switch_mgmt_10.0.3.0/24
  ip address 10.0.3.1 255.255.0.0
  mtu 9000
  ip address 10.0.4.1 255.255.0.0
  ip access-group TEST in
  no shutdown
interface Vlan4
  mtu 9000
  description switch_mgmt_10.0.4.0/24
  ip address 10.0.4.1 255.255.0.0
  ip access-group TEST in
  no shutdown
hostname aggr-example.rtr
ip access-list extended TEST
  10 permit ip 10.0.0.0 0.0.0.7 any
vlan 2
  name switch_mgmt_10.0.2.0/24
```