### PR TITLE
rm overmatching tacacs-server idempotency rule for nxos

### DIFF
--- a/hier_config/options.py
+++ b/hier_config/options.py
@@ -350,7 +350,6 @@ nxos_options: dict = {
                         "ip telnet source-interface",
                         "ip tacacs source-interface",
                         "logging source-interface",
-                        "tacacs-server",
                     ],
                     "re_search": "^spanning-tree vlan ([\\d,-]+) priority",
                 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,12 @@
 [tool.poetry]
 name = "hier-config"
-version = "2.2.0"
+version = "2.2.1"
 description = "A network configuration comparison tool, used to build remediation configurations."
 packages = [
     { include="hier_config", from="."},
 ]
 authors = [
-    "Andrew Edwards <andrew.edwards@rackspace.com>",
+    "Andrew Edwards <edwards.andrew@heb.com>",
     "James Williams <james.williams@networktocode.com",
     "Jan Brooks <jan.brooks@rackspace.com"
 ]

--- a/tests/test_various.py
+++ b/tests/test_various.py
@@ -1,0 +1,26 @@
+from hier_config import HConfig, Host
+
+
+def test_issue104() -> None:
+    running_config_raw = (
+        "tacacs-server deadtime 3\n" "tacacs-server host 192.168.1.99 key 7 Test12345\n"
+    )
+    generated_config_raw = (
+        "tacacs-server host 192.168.1.98 key 0 Test135 timeout 3\n"
+        "tacacs-server host 192.168.100.98 key 0 test135 timeout 3\n"
+    )
+
+    host = Host(hostname="test", os="nxos")
+    running_config = HConfig(host=host)
+    running_config.load_from_string(running_config_raw)
+    generated_config = HConfig(host=host)
+    generated_config.load_from_string(generated_config_raw)
+    rem = running_config.config_to_get_to(generated_config)
+    expected_rem_lines = {
+        "no tacacs-server deadtime 3",
+        "no tacacs-server host 192.168.1.99 key 7 Test12345",
+        "tacacs-server host 192.168.1.98 key 0 Test135 timeout 3",
+        "tacacs-server host 192.168.100.98 key 0 test135 timeout 3",
+    }
+    rem_lines = {line.cisco_style_text() for line in rem.all_children()}
+    assert expected_rem_lines == rem_lines


### PR DESCRIPTION
This rule was an attempt at addressing idempotency in tacacs-server commands but is far too broad. A working solution would require comparing the ip address of the tacacs-server in the command between the generated and running config lines. There isn't a mechanism for this included in the project, yet. In the past, I have addressed these types of issues with a series of functions that fix up specific problems after the remediations config has been built.

closes #104 
