### PR TITLE
Abstract children list and dict collections into a class

### DIFF
--- a/hier_config/base.py
+++ b/hier_config/base.py
@@ -378,7 +378,7 @@ class HConfigBase(ABC):  # noqa: PLR0904
 
     def _difference(
         self,
-        target: Union[HConfig, HConfigChild],
+        target: _HConfigRootOrChildT,
         delta: _HConfigRootOrChildT,
         target_acl_children: Optional[dict[str, HConfigChild]] = None,
         *,

--- a/hier_config/base.py
+++ b/hier_config/base.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from itertools import chain
 from logging import getLogger
-from typing import TYPE_CHECKING, Optional, Union
+from typing import TYPE_CHECKING, Optional, Union, overload
 
 from .children import Children
 from .exceptions import DuplicateChildError
@@ -337,6 +337,20 @@ class HConfigBase(ABC):  # noqa: PLR0904
     def _is_duplicate_child_allowed(self) -> bool:
         pass
 
+    @overload
+    def _with_tags(
+        self,
+        tags: frozenset[str],
+        new_instance: HConfig,
+    ) -> HConfig: ...
+
+    @overload
+    def _with_tags(
+        self,
+        tags: frozenset[str],
+        new_instance: HConfigChild,
+    ) -> HConfigChild: ...
+
     def _with_tags(
         self,
         tags: frozenset[str],
@@ -349,6 +363,20 @@ class HConfigBase(ABC):  # noqa: PLR0904
                 child._with_tags(tags, new_instance=new_child)  # noqa: SLF001
 
         return new_instance
+
+    @overload
+    def _config_to_get_to(
+        self,
+        target: HConfig,
+        delta: HConfig,
+    ) -> HConfig: ...
+
+    @overload
+    def _config_to_get_to(
+        self,
+        target: HConfigChild,
+        delta: HConfigChild,
+    ) -> HConfigChild: ...
 
     def _config_to_get_to(
         self,
@@ -371,6 +399,26 @@ class HConfigBase(ABC):  # noqa: PLR0904
         if words[0].isdecimal():
             words.pop(0)
         return " ".join(words)
+
+    @overload
+    def _difference(
+        self,
+        target: Union[HConfig, HConfigChild],
+        delta: HConfig,
+        target_acl_children: Optional[dict[str, HConfigChild]] = None,
+        *,
+        in_acl: bool = False,
+    ) -> HConfig: ...
+
+    @overload
+    def _difference(
+        self,
+        target: Union[HConfig, HConfigChild],
+        delta: HConfigChild,
+        target_acl_children: Optional[dict[str, HConfigChild]] = None,
+        *,
+        in_acl: bool = False,
+    ) -> HConfigChild: ...
 
     def _difference(
         self,

--- a/hier_config/base.py
+++ b/hier_config/base.py
@@ -80,7 +80,7 @@ class HConfigBase(ABC):  # noqa: PLR0904
         if check_if_present and (child := self.children.get(text)):
             if self._is_duplicate_child_allowed():
                 new_child = self._instantiate_child(text)
-                self.children.append(new_child, update_mapping="disabled")
+                self.children.append(new_child, update_mapping=False)
                 return new_child
             if return_if_present:
                 return child
@@ -88,7 +88,7 @@ class HConfigBase(ABC):  # noqa: PLR0904
             raise DuplicateChildError(message)
 
         new_child = self._instantiate_child(text)
-        self.children.append(new_child, update_mapping="fast")
+        self.children.append(new_child)
         return new_child
 
     def path(self) -> Iterator[str]:  # noqa: PLR6301

--- a/hier_config/base.py
+++ b/hier_config/base.py
@@ -449,9 +449,9 @@ class HConfigBase(ABC):  # noqa: PLR0904
         target: Union[HConfig, HConfigChild],
         delta: Union[HConfig, HConfigChild],
     ) -> None:
-        # find what would need to be added to source_config to get to self
+        # Find what would need to be added to source_config to get to self
         for target_child in target.children:
-            # if the child exist, recurse into its children
+            # If the child exist, recurse into its children
             if self_child := self.children.get(target_child.text):
                 # Do we need to rewrite the child and its children as well?
                 if self_child.use_sectional_overwrite():
@@ -460,20 +460,19 @@ class HConfigBase(ABC):  # noqa: PLR0904
                 if self_child.use_sectional_overwrite_without_negation():
                     self_child.overwrite_with(target_child, delta, negate=False)
                     continue
-                # This creates a new HConfigChild object just in case there are some delta children
-                # Not very efficient, think of a way to not do this
+                # This creates a new HConfigChild object just in case there are some delta children.
+                # This is not very efficient, think of a way to not do this.
                 subtree = self._instantiate_child(target_child.text)
                 self_child._config_to_get_to(target_child, subtree)  # noqa: SLF001
-                if not subtree.children:
-                    continue
-                delta.children.append(subtree)
-            # the child is absent, add it
+                if subtree.children:
+                    delta.children.append(subtree)
+            # The child is absent, add it.
             else:
                 # If the target_child is already in the delta, that means it was negated in the target config
                 if target_child.text in delta.children:
                     continue
                 new_item = delta.add_deep_copy_of(target_child)
-                # mark the new item and all of its children as new_in_config
+                # Mark the new item and all of its children as new_in_config.
                 new_item.new_in_config = True
                 for child in new_item.all_children():
                     child.new_in_config = True

--- a/hier_config/base.py
+++ b/hier_config/base.py
@@ -5,7 +5,7 @@ from itertools import chain
 from logging import getLogger
 from typing import TYPE_CHECKING, Optional, Union, overload
 
-from .children import Children
+from .children import HConfigChildren
 from .exceptions import DuplicateChildError
 
 if TYPE_CHECKING:
@@ -23,7 +23,7 @@ class HConfigBase(ABC):  # noqa: PLR0904
     __slots__ = ("children",)
 
     def __init__(self) -> None:
-        self.children = Children()
+        self.children = HConfigChildren()
 
     def __len__(self) -> int:
         return len(tuple(self.all_children()))

--- a/hier_config/base.py
+++ b/hier_config/base.py
@@ -64,17 +64,22 @@ class HConfigBase(ABC):  # noqa: PLR0904
     def add_child(
         self,
         text: str,
+        *,
+        return_if_present: bool = False,
+        check_if_present: bool = True,
     ) -> HConfigChild:
         """Add a child instance of HConfigChild."""
         if not text:
             message = "text was empty"
             raise ValueError(message)
 
-        if text in self.children:
+        if check_if_present and (child := self.children.get(text)):
             if self._is_duplicate_child_allowed():
                 new_child = self._instantiate_child(text)
                 self.children.append(new_child, update_mapping="disabled")
                 return new_child
+            if return_if_present:
+                return child
             message = f"Found a duplicate section: {(*self.path(), text)}"
             raise DuplicateChildError(message)
 

--- a/hier_config/base.py
+++ b/hier_config/base.py
@@ -443,20 +443,26 @@ class HConfigBase(ABC):  # noqa: PLR0904
         # find what would need to be added to source_config to get to self
         for target_child in target.children:
             # if the child exist, recurse into its children
-            if self_child := self.get_child(equals=target_child.text):
+            if self_child := self.children.get(target_child.text):
+                # Do we need to rewrite the child and its children as well?
+                if self_child.use_sectional_overwrite():
+                    self_child.overwrite_with(target_child, delta)
+                    continue
+                if self_child.use_sectional_overwrite_without_negation():
+                    self_child.overwrite_with(target_child, delta, negate=False)
+                    continue
                 # This creates a new HConfigChild object just in case there are some delta children
                 # Not very efficient, think of a way to not do this
-                subtree = delta.add_child(target_child.text)
+                subtree = self._instantiate_child(target_child.text)
                 self_child._config_to_get_to(target_child, subtree)  # noqa: SLF001
                 if not subtree.children:
-                    subtree.delete()
-                # Do we need to rewrite the child and its children as well?
-                elif self_child.use_sectional_overwrite():
-                    target_child.overwrite_with(self_child, delta)
-                elif self_child.use_sectional_overwrite_without_negation():
-                    target_child.overwrite_with(self_child, delta, negate=False)
+                    continue
+                delta.children.append(subtree)
             # the child is absent, add it
             else:
+                # If the target_child is already in the delta, that means it was negated in the target config
+                if target_child.text in delta.children:
+                    continue
                 new_item = delta.add_deep_copy_of(target_child)
                 # mark the new item and all of its children as new_in_config
                 new_item.new_in_config = True

--- a/hier_config/child.py
+++ b/hier_config/child.py
@@ -302,20 +302,26 @@ class HConfigChild(  # noqa: PLR0904  pylint: disable=too-many-instance-attribut
 
     def overwrite_with(
         self,
-        other: HConfigChild,
+        target: HConfigChild,
         delta: Union[HConfig, HConfigChild],
         *,
         negate: bool = True,
     ) -> None:
         """Deletes delta.child[self.text], adds a deep copy of self to delta."""
-        if other.children != self.children:
+        if self.children != target.children:
             if negate:
+                if negated := delta.children.get(self.text):
+                    negated.negate()
+                else:
+                    negated = delta.add_child(
+                        self.text, check_if_present=False
+                    ).negate()
+
+                negated.comments.add("dropping section")
+            else:
                 delta.children.delete(self.text)
-                deleted = delta.add_child(self.text).negate()
-                deleted.comments.add("dropping section")
             if self.children:
-                delta.children.delete(self.text)
-                new_item = delta.add_deep_copy_of(self)
+                new_item = delta.add_deep_copy_of(target)
                 new_item.comments.add("re-create section")
 
     def line_inclusion_test(

--- a/hier_config/child.py
+++ b/hier_config/child.py
@@ -108,7 +108,7 @@ class HConfigChild(  # noqa: PLR0904  pylint: disable=too-many-instance-attribut
         is instantiated to rebuild the children dictionary.
         """
         self._text = value.strip()
-        self.parent.rebuild_children_dict()
+        self.parent.children.rebuild_mapping()
 
     @property
     def text_without_negation(self) -> str:
@@ -169,7 +169,6 @@ class HConfigChild(  # noqa: PLR0904  pylint: disable=too-many-instance-attribut
         :param new_parent: HConfigChild object -> type list
         """
         new_parent.children.append(self)
-        new_parent.rebuild_children_dict()
         self.delete()
 
     def lineage(self) -> Iterator[HConfigChild]:
@@ -217,7 +216,7 @@ class HConfigChild(  # noqa: PLR0904  pylint: disable=too-many-instance-attribut
 
     def delete(self) -> None:
         """Delete the current object from its parent."""
-        self.parent.delete_child(self)
+        self.parent.children.delete(self)
 
     def tags_add(self, tag: Union[str, Iterable[str]]) -> None:
         """Add a tag to self._tags on all leaf nodes."""
@@ -322,11 +321,11 @@ class HConfigChild(  # noqa: PLR0904  pylint: disable=too-many-instance-attribut
         """Deletes delta.child[self.text], adds a deep copy of self to delta."""
         if other.children != self.children:
             if negate:
-                delta.delete_child_by_text(self.text)
+                delta.children.delete(self.text)
                 deleted = delta.add_child(self.text).negate()
                 deleted.comments.add("dropping section")
             if self.children:
-                delta.delete_child_by_text(self.text)
+                delta.children.delete(self.text)
                 new_item = delta.add_deep_copy_of(self)
                 new_item.comments.add("re-create section")
 

--- a/hier_config/child.py
+++ b/hier_config/child.py
@@ -73,23 +73,12 @@ class HConfigChild(  # noqa: PLR0904  pylint: disable=too-many-instance-attribut
         if not isinstance(other, HConfigChild):
             return NotImplemented
 
-        if (
-            self.text != other.text
-            or self.tags != other.tags
-            or self.comments != other.comments
-        ):
+        # We are intentionally not including the
+        # comments, facts, instances, new_in_config, order_weight attributes.
+        if self.text != other.text or self.tags != other.tags:
             return False
 
-        if len(self.children) != len(other.children):
-            return False
-
-        return all(
-            self_child == other_child
-            for self_child, other_child in zip(
-                sorted(self.children),
-                sorted(other.children),
-            )
-        )
+        return self.children == other.children
 
     def __ne__(self, other: object) -> bool:
         return not self.__eq__(other)

--- a/hier_config/child.py
+++ b/hier_config/child.py
@@ -307,7 +307,7 @@ class HConfigChild(  # noqa: PLR0904  pylint: disable=too-many-instance-attribut
         *,
         negate: bool = True,
     ) -> None:
-        """Deletes delta.child[self.text], adds a deep copy of self to delta."""
+        """Deletes delta.child[self.text], adds a deep copy of target to delta."""
         if self.children != target.children:
             if negate:
                 if negated := delta.children.get(self.text):

--- a/hier_config/children.py
+++ b/hier_config/children.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Literal, Optional, TypeVar, Union, overload
+from typing import TYPE_CHECKING, Optional, TypeVar, Union, overload
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Iterator
@@ -79,13 +79,11 @@ class HConfigChildren:
         self,
         child: HConfigChild,
         *,
-        update_mapping: Literal["normal", "fast", "disabled"] = "normal",
+        update_mapping: bool = True,
     ) -> HConfigChild:
         self.data.append(child)
-        if update_mapping == "normal":
-            self.rebuild_mapping()
-        elif update_mapping == "fast":
-            self.mapping[child.text] = child
+        if update_mapping:
+            self.mapping.setdefault(child.text, child)
 
         return child
 
@@ -109,7 +107,8 @@ class HConfigChildren:
     def extend(self, children: Iterable[HConfigChild]) -> None:
         """Add child instances of HConfigChild."""
         self.data.extend(children)
-        self.rebuild_mapping()
+        for child in children:
+            self.mapping.setdefault(child.text, child)
 
     def get(
         self, key: str, default: Optional[_D] = None

--- a/hier_config/children.py
+++ b/hier_config/children.py
@@ -12,8 +12,8 @@ _D = TypeVar("_D")
 
 class HConfigChildren:
     def __init__(self) -> None:
-        self.data: list[HConfigChild] = []
-        self.mapping: dict[str, HConfigChild] = {}
+        self._data: list[HConfigChild] = []
+        self._mapping: dict[str, HConfigChild] = {}
 
     @overload
     def __getitem__(self, subscript: Union[int, str]) -> HConfigChild: ...
@@ -25,30 +25,30 @@ class HConfigChildren:
         self, subscript: Union[slice, int, str]
     ) -> Union[HConfigChild, list[HConfigChild]]:
         if isinstance(subscript, slice):
-            return self.data[subscript]
+            return self._data[subscript]
         if isinstance(subscript, int):
-            return self.data[subscript]
-        return self.mapping[subscript]
+            return self._data[subscript]
+        return self._mapping[subscript]
 
     def __setitem__(self, index: int, child: HConfigChild) -> None:
-        self.data[index] = child
+        self._data[index] = child
         self.rebuild_mapping()
 
     def __contains__(self, item: str) -> bool:
-        return item in self.mapping
+        return item in self._mapping
 
     def __iter__(self) -> Iterator[HConfigChild]:
-        return iter(self.data)
+        return iter(self._data)
 
     def __len__(self) -> int:
-        return len(self.data)
+        return len(self._data)
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, HConfigChildren):
             return NotImplemented
 
-        self_len = len(self.data)
-        other_len = len(other.data)
+        self_len = len(self._data)
+        other_len = len(other._data)
         # Superfast succeed method for no children
         if self_len == other_len == 0:
             return True
@@ -58,21 +58,21 @@ class HConfigChildren:
             return False
 
         # Fast fail method
-        if self.mapping.keys() != other.mapping.keys():
+        if self._mapping.keys() != other._mapping.keys():
             return False
 
         # Slower full comparison
         return all(
             self_child == other_child
             for self_child, other_child in zip(
-                sorted(self.data),
-                sorted(other.data),
+                sorted(self._data),
+                sorted(other._data),
             )
         )
 
     def __hash__(self) -> int:
         return hash(
-            (*self.data,),
+            (*self._data,),
         )
 
     def append(
@@ -81,45 +81,45 @@ class HConfigChildren:
         *,
         update_mapping: bool = True,
     ) -> HConfigChild:
-        self.data.append(child)
+        self._data.append(child)
         if update_mapping:
-            self.mapping.setdefault(child.text, child)
+            self._mapping.setdefault(child.text, child)
 
         return child
 
     def clear(self) -> None:
         """Delete all children."""
-        self.data.clear()
-        self.mapping.clear()
+        self._data.clear()
+        self._mapping.clear()
 
     def delete(self, child_or_text: Union[HConfigChild, str]) -> None:
-        """Delete a child from self.data and self.mapping."""
+        """Delete a child from self._data and self._mapping."""
         if isinstance(child_or_text, str):
-            if child_or_text in self.mapping:
-                self.data[:] = [c for c in self.data if c.text != child_or_text]
+            if child_or_text in self._mapping:
+                self._data[:] = [c for c in self._data if c.text != child_or_text]
                 self.rebuild_mapping()
         else:
-            old_len = len(self.data)
-            self.data = [c for c in self.data if c is not child_or_text]
-            if old_len != len(self.data):
+            old_len = len(self._data)
+            self._data = [c for c in self._data if c is not child_or_text]
+            if old_len != len(self._data):
                 self.rebuild_mapping()
 
     def extend(self, children: Iterable[HConfigChild]) -> None:
         """Add child instances of HConfigChild."""
-        self.data.extend(children)
+        self._data.extend(children)
         for child in children:
-            self.mapping.setdefault(child.text, child)
+            self._mapping.setdefault(child.text, child)
 
     def get(
         self, key: str, default: Optional[_D] = None
     ) -> Union[HConfigChild, _D, None]:
-        return self.mapping.get(key, default)
+        return self._mapping.get(key, default)
 
     def index(self, child: HConfigChild) -> int:
-        return self.data.index(child)
+        return self._data.index(child)
 
     def rebuild_mapping(self) -> None:
-        """Rebuild self.mapping."""
-        self.mapping.clear()
-        for child in self.data:
-            self.mapping.setdefault(child.text, child)
+        """Rebuild self._mapping."""
+        self._mapping.clear()
+        for child in self._data:
+            self._mapping.setdefault(child.text, child)

--- a/hier_config/children.py
+++ b/hier_config/children.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Literal, Optional, TypeVar, Union, overload
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Iterator
+
+    from hier_config import HConfigChild
+
+_D = TypeVar("_D")
+
+
+class Children:
+    def __init__(self) -> None:
+        self._children: list[HConfigChild] = []
+        self._children_dict: dict[str, HConfigChild] = {}
+
+    @overload
+    def __getitem__(self, subscript: Union[int, str]) -> HConfigChild: ...
+
+    @overload
+    def __getitem__(self, subscript: slice) -> list[HConfigChild]: ...
+
+    def __getitem__(
+        self, subscript: Union[slice, int, str]
+    ) -> Union[HConfigChild, list[HConfigChild]]:
+        if isinstance(subscript, slice):
+            return self._children[subscript]
+        if isinstance(subscript, int):
+            return self._children[subscript]
+        return self._children_dict[subscript]
+
+    def __setitem__(self, index: int, child: HConfigChild) -> None:
+        self._children[index] = child
+        self.rebuild_mapping()
+
+    def __contains__(self, item: str) -> bool:
+        return item in self._children_dict
+
+    def __iter__(self) -> Iterator[HConfigChild]:
+        return iter(self._children)
+
+    def __len__(self) -> int:
+        return len(self._children)
+
+    def append(
+        self,
+        child: HConfigChild,
+        *,
+        update_mapping: Literal["normal", "fast", "disabled"] = "normal",
+    ) -> None:
+        self._children.append(child)
+        if update_mapping == "normal":
+            self.rebuild_mapping()
+        elif update_mapping == "fast":
+            self._children_dict[child.text] = child
+
+    def clear(self) -> None:
+        """Delete all children."""
+        self._children.clear()
+        self._children_dict.clear()
+
+    def delete(self, child_or_text: Union[HConfigChild, str]) -> None:
+        """Delete a child from self._children and self._children_dict."""
+        if isinstance(child_or_text, str):
+            if child_or_text in self._children_dict:
+                self._children[:] = [
+                    c for c in self._children if c.text != child_or_text
+                ]
+                self.rebuild_mapping()
+        else:
+            old_len = len(self._children)
+            self._children = [c for c in self._children if c is not child_or_text]
+            if old_len != len(self._children):
+                self.rebuild_mapping()
+
+    def extend(self, children: Iterable[HConfigChild]) -> None:
+        """Add child instances of HConfigChild."""
+        self._children.extend(children)
+        self.rebuild_mapping()
+
+    def get(
+        self, key: str, default: Optional[_D] = None
+    ) -> Union[HConfigChild, _D, None]:
+        return self._children_dict.get(key, default)
+
+    def index(self, child: HConfigChild) -> int:
+        return self._children.index(child)
+
+    def rebuild_mapping(self) -> None:
+        """Rebuild self._children_dict."""
+        self._children_dict.clear()
+        for child in self._children:
+            self._children_dict.setdefault(child.text, child)

--- a/hier_config/children.py
+++ b/hier_config/children.py
@@ -10,7 +10,7 @@ if TYPE_CHECKING:
 _D = TypeVar("_D")
 
 
-class Children:
+class HConfigChildren:
     def __init__(self) -> None:
         self.data: list[HConfigChild] = []
         self.mapping: dict[str, HConfigChild] = {}
@@ -44,7 +44,7 @@ class Children:
         return len(self.data)
 
     def __eq__(self, other: object) -> bool:
-        if not isinstance(other, Children):
+        if not isinstance(other, HConfigChildren):
             return NotImplemented
 
         self_len = len(self.data)

--- a/hier_config/children.py
+++ b/hier_config/children.py
@@ -41,7 +41,39 @@ class Children:
         return iter(self._children)
 
     def __len__(self) -> int:
-        return len(self._children)
+        return len(self.data)
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, Children):
+            return NotImplemented
+
+        self_len = len(self.data)
+        other_len = len(other.data)
+        # Superfast succeed method for no children
+        if self_len == other_len == 0:
+            return True
+
+        # Superfast fail method
+        if self_len != other_len:
+            return False
+
+        # Fast fail method
+        if self.mapping.keys() != other.mapping.keys():
+            return False
+
+        # Slower full comparison
+        return all(
+            self_child == other_child
+            for self_child, other_child in zip(
+                sorted(self.data),
+                sorted(other.data),
+            )
+        )
+
+    def __hash__(self) -> int:
+        return hash(
+            (*self.data,),
+        )
 
     def append(
         self,

--- a/hier_config/constructors.py
+++ b/hier_config/constructors.py
@@ -116,7 +116,7 @@ def get_hconfig_from_dump(
         # has a parent somewhere closer to the root but not the root
         else:
             parent = next(islice(last_item.lineage(), item.depth - 2, item.depth - 1))
-        obj = parent.add_child(item.text, force_duplicate=True)
+        obj = parent.add_child(item.text)
         obj.tags = frozenset(item.tags)
         obj.comments = set(item.comments)
         obj.new_in_config = item.new_in_config
@@ -184,7 +184,7 @@ def _analyze_indent(
     if indent > most_recent_item.real_indent_level:
         current_section = most_recent_item
 
-    most_recent_item = current_section.add_child(line, raise_on_duplicate=True)
+    most_recent_item = current_section.add_child(line)
     most_recent_item.real_indent_level = indent
 
     return most_recent_item, current_section
@@ -242,7 +242,6 @@ def _load_from_string_lines(config: HConfig, config_text: str) -> None:  # noqa:
                 in_banner = False
                 most_recent_item = config.add_child(
                     "\n".join(temp_banner),
-                    raise_on_duplicate=True,
                 )
                 most_recent_item.real_indent_level = 0
                 current_section = config

--- a/hier_config/platforms/cisco_ios/driver.py
+++ b/hier_config/platforms/cisco_ios/driver.py
@@ -26,7 +26,7 @@ def _remove_ipv4_acl_remarks(config: HConfig) -> None:
     for acl in config.get_children(startswith="ip access-list "):
         for entry in tuple(acl.children):
             if entry.text.startswith("remark"):
-                acl.children.remove(entry)
+                entry.delete()
 
 
 def _add_acl_sequence_numbers(config: HConfig) -> None:

--- a/hier_config/platforms/cisco_ios/view.py
+++ b/hier_config/platforms/cisco_ios/view.py
@@ -54,7 +54,7 @@ class ConfigViewInterfaceCiscoIOS(ConfigViewInterfaceBase):  # noqa: PLR0904
     @property
     def has_nac(self) -> bool:
         return any(
-            line in self.config.children_dict
+            line in self.config.children
             for line in (
                 "authentication port-control auto",
                 "mab",
@@ -100,7 +100,7 @@ class ConfigViewInterfaceCiscoIOS(ConfigViewInterfaceBase):  # noqa: PLR0904
     @property
     def nac_control_direction_in(self) -> bool:
         """Determine if the interface has NAC control direction in configured."""
-        return "authentication control-direction in" in self.config.children_dict
+        return "authentication control-direction in" in self.config.children
 
     @property
     def nac_host_mode(self) -> Optional[NACHostMode]:

--- a/hier_config/platforms/hp_procurve/view.py
+++ b/hier_config/platforms/hp_procurve/view.py
@@ -73,7 +73,7 @@ class ConfigViewInterfaceHPProcurve(  # noqa: PLR0904 pylint: disable=abstract-m
     def has_nac(self) -> bool:
         """Determine if the interface has NAC configured."""
         return any(
-            line in self.config.parent.children_dict
+            line in self.config.parent.children
             for line in (
                 f"aaa port-access authenticator {self.name}",
                 f"aaa port-access mac-based {self.name}",
@@ -121,7 +121,7 @@ class ConfigViewInterfaceHPProcurve(  # noqa: PLR0904 pylint: disable=abstract-m
         """Determine if the interface has NAC control direction in configured."""
         return (
             f"aaa port-access {self.name} controlled-direction in"
-            in self.config.parent.children_dict
+            in self.config.parent.children
         )
 
     @property

--- a/hier_config/root.py
+++ b/hier_config/root.py
@@ -112,7 +112,7 @@ class HConfig(HConfigBase):  # noqa: PLR0904
         """Add child instances of HConfigChild deeply."""
         base: Union[HConfig, HConfigChild] = self
         for line in lines:
-            base = base.add_child(line)
+            base = base.children.get(line) or base.add_child(line)
         if isinstance(base, HConfig):
             message = "base was an HConfig object for some reason."
             raise TypeError(message)

--- a/hier_config/root.py
+++ b/hier_config/root.py
@@ -141,12 +141,7 @@ class HConfig(HConfigBase):  # noqa: PLR0904
 
     def difference(self, target: HConfig) -> HConfig:
         """Creates a new HConfig object with the config from self that is not in target."""
-        delta = HConfig(self.driver)
-        difference = self._difference(target, delta)
-        # Makes mypy happy
-        if not isinstance(difference, HConfig):
-            raise TypeError
-        return difference
+        return self._difference(target, HConfig(self.driver))
 
     def config_to_get_to(
         self,
@@ -161,12 +156,7 @@ class HConfig(HConfigBase):  # noqa: PLR0904
         if delta is None:
             delta = HConfig(self.driver)
 
-        root_config = self._config_to_get_to(target, delta)
-        # Makes mypy happy
-        if not isinstance(root_config, HConfig):
-            raise TypeError
-
-        return root_config
+        return self._config_to_get_to(target, delta)
 
     def add_ancestor_copy_of(
         self,
@@ -202,12 +192,7 @@ class HConfig(HConfigBase):  # noqa: PLR0904
 
     def with_tags(self, tags: Iterable[str]) -> HConfig:
         """Returns a new instance recursively containing children that only have a subset of tags."""
-        new_instance = HConfig(self.driver)
-        result = self._with_tags(frozenset(tags), new_instance)
-        # Makes mypy happy
-        if not isinstance(result, HConfig):
-            raise TypeError
-        return new_instance
+        return self._with_tags(frozenset(tags), HConfig(self.driver))
 
     def all_children_sorted_by_tags(
         self,

--- a/hier_config/root.py
+++ b/hier_config/root.py
@@ -103,7 +103,7 @@ class HConfig(HConfigBase):  # noqa: PLR0904
         """Add child instances of HConfigChild deeply."""
         base: Union[HConfig, HConfigChild] = self
         for line in lines:
-            base = base.children.get(line) or base.add_child(line)
+            base = base.add_child(line, return_if_present=True)
         if isinstance(base, HConfig):
             message = "base was an HConfig object for some reason."
             raise TypeError(message)
@@ -151,7 +151,6 @@ class HConfig(HConfigBase):  # noqa: PLR0904
         """Figures out what commands need to be executed to transition from self to target.
         self is the source data structure(i.e. the running_config),
         target is the destination(i.e. generated_config).
-
         """
         if delta is None:
             delta = HConfig(self.driver)

--- a/hier_config/root.py
+++ b/hier_config/root.py
@@ -15,7 +15,6 @@ if TYPE_CHECKING:
 logger = getLogger(__name__)
 
 # Refactoring ideas:
-# - What if children were moved into its own class? e.g. child.children.add()
 # - Cases of children.index() could be replaced with an identity based approach.
 
 

--- a/hier_config/root.py
+++ b/hier_config/root.py
@@ -43,16 +43,7 @@ class HConfig(HConfigBase):  # noqa: PLR0904
         if not isinstance(other, HConfig):
             return NotImplemented
 
-        if len(self.children) != len(other.children):
-            return False
-
-        return all(
-            self_child == other_child
-            for self_child, other_child in zip(
-                sorted(self.children),
-                sorted(other.children),
-            )
-        )
+        return self.children == other.children
 
     @property
     def driver(self) -> HConfigDriverBase:

--- a/hier_config/workflows.py
+++ b/hier_config/workflows.py
@@ -81,7 +81,7 @@ class WorkflowRemediation:
             return self._remediation_config
 
         remediation_config = self.running_config.config_to_get_to(
-            self.generated_config, HConfig(self.running_config.driver)
+            self.generated_config
         ).set_order_weight()
 
         self._remediation_config = remediation_config

--- a/poetry.lock
+++ b/poetry.lock
@@ -657,8 +657,8 @@ files = [
 annotated-types = ">=0.6.0"
 pydantic-core = "2.23.4"
 typing-extensions = [
-    {version = ">=4.12.2", markers = "python_version >= \"3.13\""},
     {version = ">=4.6.1", markers = "python_version < \"3.13\""},
+    {version = ">=4.12.2", markers = "python_version >= \"3.13\""},
 ]
 
 [package.extras]
@@ -795,8 +795,8 @@ files = [
 astroid = ">=3.3.4,<=3.4.0-dev0"
 colorama = {version = ">=0.4.5", markers = "sys_platform == \"win32\""}
 dill = [
-    {version = ">=0.3.7", markers = "python_version >= \"3.12\""},
     {version = ">=0.2", markers = "python_version < \"3.11\""},
+    {version = ">=0.3.7", markers = "python_version >= \"3.12\""},
     {version = ">=0.3.6", markers = "python_version >= \"3.11\" and python_version < \"3.12\""},
 ]
 isort = ">=4.2.5,<5.13.0 || >5.13.0,<6"
@@ -1268,4 +1268,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9.0,<4.0"
-content-hash = "2dd923fecc8838cf2d3fb9b513937a4f8bdb551dad3d9e433eedca78bb1746be"
+content-hash = "bb5271133ee0c5daa0512458b4890fd19b0c6bfee4f2a706573c74b740e001d3"

--- a/poetry.lock
+++ b/poetry.lock
@@ -498,13 +498,13 @@ pyyaml = ">=5.1"
 
 [[package]]
 name = "mkdocs-include-markdown-plugin"
-version = "7.0.0"
+version = "7.0.1"
 description = "Mkdocs Markdown includer plugin."
 optional = false
 python-versions = ">=3.9"
 files = [
-    {file = "mkdocs_include_markdown_plugin-7.0.0-py3-none-any.whl", hash = "sha256:bf8d19245ae3fb2eea395888e80c60bc91806a0d879279707d707896c24319c3"},
-    {file = "mkdocs_include_markdown_plugin-7.0.0.tar.gz", hash = "sha256:a8eac8f2e6aa391d82d1d5e473b819b52393d91464060c02db5741834fe9008b"},
+    {file = "mkdocs_include_markdown_plugin-7.0.1-py3-none-any.whl", hash = "sha256:4abd341cb1c5eac60ddd1a21540fdff714f1acc99e3b26f37641db60cd175a8d"},
+    {file = "mkdocs_include_markdown_plugin-7.0.1.tar.gz", hash = "sha256:d619c206109dab4bab281e2d29b645838d55b0576c761b1fbb17e6bff1170206"},
 ]
 
 [package.dependencies]
@@ -1135,13 +1135,13 @@ files = [
 
 [[package]]
 name = "typer"
-version = "0.13.0"
+version = "0.13.1"
 description = "Typer, build great CLIs. Easy to code. Based on Python type hints."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "typer-0.13.0-py3-none-any.whl", hash = "sha256:d85fe0b777b2517cc99c8055ed735452f2659cd45e451507c76f48ce5c1d00e2"},
-    {file = "typer-0.13.0.tar.gz", hash = "sha256:f1c7198347939361eec90139ffa0fd8b3df3a2259d5852a0f7400e476d95985c"},
+    {file = "typer-0.13.1-py3-none-any.whl", hash = "sha256:5b59580fd925e89463a29d363e0a43245ec02765bde9fb77d39e5d0f29dd7157"},
+    {file = "typer-0.13.1.tar.gz", hash = "sha256:9d444cb96cc268ce6f8b94e13b4335084cef4c079998a9f4851a90229a3bd25c"},
 ]
 
 [package.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
 ]
 [tool.poetry.dependencies]
 python = ">=3.9.0,<4.0"
-pydantic = "^2.9.2"
+pydantic = "^2.9"
 
 [tool.poetry.group.dev.dependencies]
 flynt = "*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hier-config"
-version = "3.0.0"
+version = "3.1.0"
 description = "A network configuration query and comparison library, used to build remediation configurations."
 packages = [
     { include="hier_config", from="."},

--- a/tests/test_hier_config.py
+++ b/tests/test_hier_config.py
@@ -75,15 +75,13 @@ def test_dump_and_load_from_dump_and_compare(platform_a: Platform) -> None:
 
 
 def test_add_ancestor_copy_of(platform_a: Platform) -> None:
-    hier1 = get_hconfig(platform_a)
-    interface = hier1.add_child("interface Vlan2")
-    interface.add_children(
-        ("description switch-mgmt-192.168.1.0/24", "ip address 192.168.1.0/24"),
-    )
-    hier1.add_ancestor_copy_of(interface)
+    source_config = get_hconfig(platform_a)
+    ipv4_address = source_config.add_children_deep(("interface Vlan2", "ip address 192.168.1.0/24"))
+    destination_config = get_hconfig(platform_a)
+    destination_config.add_ancestor_copy_of(ipv4_address)
 
-    assert len(tuple(hier1.all_children())) == 3
-    assert isinstance(hier1.all_children(), types.GeneratorType)
+    assert len(tuple(destination_config.all_children())) == 2
+    assert isinstance(destination_config.all_children(), types.GeneratorType)
 
 
 def test_depth(platform_a: Platform) -> None:
@@ -206,7 +204,7 @@ def test_move(platform_a: Platform, platform_b: Platform) -> None:
 def test_del_child_by_text(platform_a: Platform) -> None:
     hier = get_hconfig(platform_a)
     hier.add_child("interface Vlan2")
-    hier.delete_child_by_text("interface Vlan2")
+    hier.children.delete("interface Vlan2")
 
     assert not tuple(hier.all_children())
 
@@ -219,7 +217,7 @@ def test_del_child(platform_a: Platform) -> None:
 
     child_to_delete = hier1.get_child(startswith="interface")
     assert child_to_delete is not None
-    hier1.delete_child(child_to_delete)
+    hier1.children.delete(child_to_delete)
 
     assert not tuple(hier1.all_children())
 
@@ -231,7 +229,7 @@ def test_rebuild_children_dict(platform_a: Platform) -> None:
         ("description switch-mgmt-192.168.1.0/24", "ip address 192.168.1.0/24"),
     )
     delta_a = hier1
-    hier1.rebuild_children_dict()
+    hier1.children.rebuild_mapping()
     delta_b = hier1
 
     assert tuple(delta_a.all_children()) == tuple(delta_b.all_children())
@@ -414,8 +412,8 @@ def test_config_to_get_to2(platform_a: Platform) -> None:
         generated_config_hier,
         delta,
     )
-    assert "do not add me" not in delta
-    assert "add me" in delta
+    assert "do not add me" not in delta.children
+    assert "add me" in delta.children
 
 
 def test_add_shallow_copy_of(platform_a: Platform, platform_b: Platform) -> None:
@@ -507,15 +505,15 @@ def test_difference1(platform_a: Platform) -> None:
     )
 
     assert len(difference_children) == 6
-    assert "c" in difference
-    assert "d" in difference
+    assert "c" in difference.children
+    assert "d" in difference.children
     difference_a = difference.get_child(equals="a")
     assert isinstance(difference_a, HConfigChild)
-    assert "a4" in difference_a
-    assert "a5" in difference_a
+    assert "a4" in difference_a.children
+    assert "a5" in difference_a.children
     difference_d = difference.get_child(equals="d")
     assert isinstance(difference_d, HConfigChild)
-    assert "d1" in difference_d
+    assert "d1" in difference_d.children
 
 
 def test_difference2() -> None:

--- a/tests/test_hier_config.py
+++ b/tests/test_hier_config.py
@@ -267,7 +267,7 @@ def test_add_child(platform_a: Platform) -> None:
     assert interface.text == "interface Vlan2"
     with pytest.raises(DuplicateChildError):
         config.add_child("interface Vlan2")
-    assert config.children.mapping == {"interface Vlan2": interface}
+    assert config.children.get("interface Vlan2") is interface
 
 
 def test_add_deep_copy_of(platform_a: Platform, platform_b: Platform) -> None:
@@ -402,7 +402,7 @@ def test_negate(platform_a: Platform) -> None:
     interface = config.add_child("interface Vlan2")
     interface.negate()
     assert interface.text == "no interface Vlan2"
-    assert config.children.mapping == {"no interface Vlan2": interface}
+    assert config.children.get("no interface Vlan2") is interface
 
 
 def test_config_to_get_to(platform_a: Platform) -> None:

--- a/tests/test_hier_config.py
+++ b/tests/test_hier_config.py
@@ -2,13 +2,17 @@ import tempfile
 import types
 from pathlib import Path
 
+import pytest
+
 from hier_config import (
     HConfigChild,
+    WorkflowRemediation,
     get_hconfig,
     get_hconfig_driver,
     get_hconfig_fast_load,
     get_hconfig_from_dump,
 )
+from hier_config.exceptions import DuplicateChildError
 from hier_config.models import Instance, MatchRule, Platform
 
 
@@ -76,7 +80,9 @@ def test_dump_and_load_from_dump_and_compare(platform_a: Platform) -> None:
 
 def test_add_ancestor_copy_of(platform_a: Platform) -> None:
     source_config = get_hconfig(platform_a)
-    ipv4_address = source_config.add_children_deep(("interface Vlan2", "ip address 192.168.1.0/24"))
+    ipv4_address = source_config.add_children_deep(
+        ("interface Vlan2", "ip address 192.168.1.0/24")
+    )
     destination_config = get_hconfig(platform_a)
     destination_config.add_ancestor_copy_of(ipv4_address)
 
@@ -255,9 +261,13 @@ def test_add_children(platform_a: Platform) -> None:
 
 
 def test_add_child(platform_a: Platform) -> None:
-    interface = get_hconfig(platform_a).add_child("interface Vlan2")
+    config = get_hconfig(platform_a)
+    interface = config.add_child("interface Vlan2")
     assert interface.depth() == 1
     assert interface.text == "interface Vlan2"
+    with pytest.raises(DuplicateChildError):
+        config.add_child("interface Vlan2")
+    assert config.children.mapping == {"interface Vlan2": interface}
 
 
 def test_add_deep_copy_of(platform_a: Platform, platform_b: Platform) -> None:
@@ -347,7 +357,7 @@ def test_set_order_weight(platform_a: Platform) -> None:
     assert child.order_weight == 200
 
 
-def test_tags(platform_a: Platform) -> None:
+def test_tags_add(platform_a: Platform) -> None:
     interface = get_hconfig(platform_a).add_child("interface Vlan2")
     ip_address = interface.add_child("ip address 192.168.1.1/24")
     assert not interface.tags
@@ -357,6 +367,10 @@ def test_tags(platform_a: Platform) -> None:
     assert "a" in ip_address.tags
     assert "b" not in interface.tags
     assert "b" not in ip_address.tags
+    interface.tags_add("c")
+    assert "c" in ip_address.tags
+    interface.tags_remove("c")
+    assert "c" not in ip_address.tags
 
 
 def test_append_tags(platform_a: Platform) -> None:
@@ -384,9 +398,11 @@ def test_remove_tags(platform_a: Platform) -> None:
 
 
 def test_negate(platform_a: Platform) -> None:
-    interface = get_hconfig(platform_a).add_child("interface Vlan2")
+    config = get_hconfig(platform_a)
+    interface = config.add_child("interface Vlan2")
     interface.negate()
     assert interface.text == "no interface Vlan2"
+    assert config.children.mapping == {"no interface Vlan2": interface}
 
 
 def test_config_to_get_to(platform_a: Platform) -> None:
@@ -416,18 +432,13 @@ def test_config_to_get_to2(platform_a: Platform) -> None:
     assert "add me" in delta.children
 
 
-def test_add_shallow_copy_of(platform_a: Platform, platform_b: Platform) -> None:
+def test_add_shallow_copy_of(platform_a: Platform) -> None:
     base_config = get_hconfig(platform_a)
 
     interface_a = get_hconfig(platform_a).add_child("interface Vlan2")
     interface_a.tags_add(frozenset(("ta", "tb")))
     interface_a.comments.add("ca")
     interface_a.order_weight = 200
-
-    interface_b = get_hconfig(platform_b).add_child("interface Vlan2")
-    interface_b.tags_add(frozenset(("tc",)))
-    interface_b.comments.add("cc")
-    interface_b.order_weight = 201
 
     copied_interface = base_config.add_shallow_copy_of(interface_a, merged=True)
     assert copied_interface.tags == frozenset(("ta", "tb"))
@@ -438,24 +449,6 @@ def test_add_shallow_copy_of(platform_a: Platform, platform_b: Platform) -> None
             id=id(interface_a.root),
             comments=frozenset(interface_a.comments),
             tags=interface_a.tags,
-        ),
-    ]
-
-    copied_interface = base_config.add_shallow_copy_of(interface_b, merged=True)
-
-    assert copied_interface.tags == frozenset(("ta", "tb", "tc"))
-    assert copied_interface.comments == frozenset(("ca", "cc"))
-    assert copied_interface.order_weight == 201
-    assert copied_interface.instances == [
-        Instance(
-            id=id(interface_a.root),
-            comments=frozenset(interface_a.comments),
-            tags=interface_a.tags,
-        ),
-        Instance(
-            id=id(interface_b.root),
-            comments=frozenset(interface_b.comments),
-            tags=interface_b.tags,
         ),
     ]
 
@@ -618,3 +611,84 @@ def test_future_config_no_command_in_source() -> None:
     calculated_running_config = future_config.future(rollback_config)
     assert not calculated_running_config.children
     assert not tuple(calculated_running_config.unified_diff(running_config))
+
+
+def test_sectional_overwrite() -> None:
+    platform = Platform.CISCO_XR
+    # There is a sectional_overwrite rules in the CISCO_XR driver for "template".
+    running_config = get_hconfig_fast_load(platform, "template test\n  a\n  b")
+    generated_config = get_hconfig_fast_load(platform, "template test\n  a")
+    expected_remediation_config = get_hconfig_fast_load(
+        platform, "no template test\ntemplate test\n  a"
+    )
+    workflow_remediation = WorkflowRemediation(running_config, generated_config)
+    remediation_config = workflow_remediation.remediation_config
+    assert remediation_config == expected_remediation_config
+
+
+def test_sectional_overwrite_no_negate() -> None:
+    platform = Platform.CISCO_XR
+    running_config = get_hconfig_fast_load(platform, "as-path-set test\n  a\n  b")
+    generated_config = get_hconfig_fast_load(platform, "as-path-set test\n  a")
+    expected_remediation_config = get_hconfig_fast_load(
+        platform, "as-path-set test\n  a"
+    )
+    workflow_remediation = WorkflowRemediation(running_config, generated_config)
+    remediation_config = workflow_remediation.remediation_config
+    assert remediation_config == expected_remediation_config
+
+
+def test_sectional_overwrite_no_negate2() -> None:
+    platform = Platform.CISCO_XR
+    running_config = get_hconfig_fast_load(
+        platform,
+        "route-policy test\n  duplicate\n  not_duplicate1\n  duplicate\n  not_duplicate2",
+    )
+    generated_config = get_hconfig_fast_load(
+        platform, "route-policy test\n  duplicate\n  not_duplicate1"
+    )
+    expected_remediation_config = get_hconfig_fast_load(
+        platform, "route-policy test\n  duplicate\n  not_duplicate1"
+    )
+    workflow_remediation = WorkflowRemediation(running_config, generated_config)
+    remediation_config = workflow_remediation.remediation_config
+    assert remediation_config == expected_remediation_config
+
+
+def test_overwrite_with_negate() -> None:
+    platform = Platform.CISCO_XR
+    running_config = get_hconfig_fast_load(
+        platform, "route-policy test\n  duplicate\n  not_duplicate\n  duplicate"
+    )
+    generated_config = get_hconfig_fast_load(
+        platform, "route-policy test\n  duplicate\n  not_duplicate"
+    )
+    expected_config = get_hconfig_fast_load(
+        platform,
+        "no route-policy test\nroute-policy test\n  duplicate\n  not_duplicate",
+    )
+    delta_config = get_hconfig(platform)
+    running_config.children["route-policy test"].overwrite_with(
+        generated_config.children["route-policy test"], delta_config
+    )
+    assert delta_config == expected_config
+
+
+def test_overwrite_with_no_negate() -> None:
+    platform = Platform.CISCO_XR
+    running_config = get_hconfig_fast_load(
+        platform,
+        "route-policy test\n  duplicate\n  not-duplicate\n  duplicate\n  duplicate",
+    )
+    generated_config = get_hconfig_fast_load(
+        platform, "route-policy test\n  duplicate\n  not-duplicate\n  duplicate"
+    )
+    expected_config = get_hconfig_fast_load(
+        platform,
+        "route-policy test\n  duplicate\n  not-duplicate\n  duplicate",
+    )
+    delta_config = get_hconfig(platform)
+    running_config.children["route-policy test"].overwrite_with(
+        generated_config.children["route-policy test"], delta_config, negate=False
+    )
+    assert delta_config == expected_config


### PR DESCRIPTION
Changes
- Abstract the two children list and dict collections into a single class.
- Relax pydantic pinning a little.
- In `_difference()`, consider `sectional_overwrite` first and do not add` subtree` just to delete it.
- Add `return_if_present` and `check_if_present` args to `add_child()`.
- Simplify call to `config_to_get_to()`.
- Rework `__eq__()` methods of `HConfig` related objects.
- Use TypeVar to remove the need to do 3 `isinstance()` checks.
- Remove need to do a second `children.get()` in `add_children_deep()`.
- Simplify `overwrite_with()` logic.
- Various test improvements.