### PR TITLE
add ability to set sectional exit text at the parent level

### DIFF
--- a/hier_config/child.py
+++ b/hier_config/child.py
@@ -114,7 +114,8 @@ class HConfigChild(  # noqa: PLR0904  pylint: disable=too-many-instance-attribut
             yield from child.lines(sectional_exiting=sectional_exiting)
 
         if sectional_exiting and (exit_text := self.sectional_exit):
-            yield " " * self.driver.rules.indentation * self.depth() + exit_text
+            depth = self.depth() - 1 if self.sectional_exit_text_parent_level else self.depth()
+            yield " " * self.driver.rules.indentation * depth + exit_text
 
     @property
     def sectional_exit(self) -> Optional[str]:
@@ -128,6 +129,14 @@ class HConfigChild(  # noqa: PLR0904  pylint: disable=too-many-instance-attribut
             return None
 
         return "exit"
+
+    @property
+    def sectional_exit_text_parent_level(self) -> Optional[bool]:
+        for rule in self.driver.rules.sectional_exiting:
+            if self.is_lineage_match(rule.match_rules):
+                return rule.exit_text_parent_level
+    
+        return None
 
     def delete_sectional_exit(self) -> None:
         try:

--- a/hier_config/models.py
+++ b/hier_config/models.py
@@ -35,6 +35,7 @@ class TagRule(BaseModel):
 class SectionalExitingRule(BaseModel):
     match_rules: tuple[MatchRule, ...]
     exit_text: str
+    exit_text_parent_level: bool = False
 
 
 class SectionalOverwriteRule(BaseModel):

--- a/hier_config/platforms/cisco_xr/driver.py
+++ b/hier_config/platforms/cisco_xr/driver.py
@@ -40,30 +40,37 @@ class HConfigDriverCiscoIOSXR(HConfigDriverBase):  # pylint: disable=too-many-in
                 SectionalExitingRule(
                     match_rules=(MatchRule(startswith="route-policy"),),
                     exit_text="end-policy",
+                    exit_text_parent_level=True,
                 ),
                 SectionalExitingRule(
                     match_rules=(MatchRule(startswith="prefix-set"),),
                     exit_text="end-set",
+                    exit_text_parent_level=True,
                 ),
                 SectionalExitingRule(
                     match_rules=(MatchRule(startswith="policy-map"),),
                     exit_text="end-policy-map",
+                    exit_text_parent_level=True,
                 ),
                 SectionalExitingRule(
                     match_rules=(MatchRule(startswith="class-map"),),
                     exit_text="end-class-map",
+                    exit_text_parent_level=True,
                 ),
                 SectionalExitingRule(
                     match_rules=(MatchRule(startswith="community-set"),),
                     exit_text="end-set",
+                    exit_text_parent_level=True,
                 ),
                 SectionalExitingRule(
                     match_rules=(MatchRule(startswith="extcommunity-set"),),
                     exit_text="end-set",
+                    exit_text_parent_level=True,
                 ),
                 SectionalExitingRule(
                     match_rules=(MatchRule(startswith="template"),),
                     exit_text="end-template",
+                    exit_text_parent_level=True,
                 ),
                 SectionalExitingRule(
                     match_rules=(MatchRule(startswith="interface"),),


### PR DESCRIPTION
```python
In [1]: from hier_config import WorkflowRemediation, get_hconfig, Platform

   ...: """
   ...: generated_config_text = """
   ...: prefix-set ALL
   ...:   0.0.0.0/0 eq 32
   ...: end-set
   ...: !
   ...: prefix-set PEERINGS
   ...:   1.1.1.1/32,
   ...:   172.16.0.0/12,
   ...:   192.168.3.0/26
   ...: end-set
   ...: """

In [3]: running_config = get_hconfig(Platform.CISCO_XR, running_config_text)
   ...: generated_config = get_hconfig(Platform.CISCO_XR, generated_config_text)
   ...: workflow = WorkflowRemediation(running_config, generated_config)

In [4]: print(workflow.remediation_config)
prefix-set PEERINGS
  1.1.1.1/32,
  172.16.0.0/12,
  192.168.3.0/26
end-set

In [5]: pfx = running_config.get_child(equals="prefix-set ALL")

In [6]: pfx.sectional_exit_text_parent_level
Out[6]: True
```