### PR TITLE
Update sorted function to sort based on `child.text` value

### DIFF
--- a/hier_config/base.py
+++ b/hier_config/base.py
@@ -109,7 +109,7 @@ class HConfigBase(ABC):  # noqa: PLR0904
 
     def all_children_sorted(self) -> Iterator[HConfigChild]:
         """Recursively find and yield all children sorted at each hierarchy."""
-        for child in sorted(self.children):
+        for child in sorted(self.children, key=lambda child: child.text):
             yield child
             yield from child.all_children_sorted()
 


### PR DESCRIPTION
Fixes issue #153 

Adding a lambda function key to return `child.text` so we can sort strings alphabetically.