### PR TITLE
Fix linting and type checking errors

### DIFF
--- a/hier_config/models.py
+++ b/hier_config/models.py
@@ -131,7 +131,7 @@ class ReferencePattern(BaseModel):
 
 
 class UnusedObjectRule(BaseModel):
-    """Defines how to identify and remove an unused object type.
+    r"""Defines how to identify and remove an unused object type.
 
     This rule is completely user-definable and can be applied to ANY configuration
     object type on ANY platform. Users can create custom rules for their specific

--- a/hier_config/platforms/driver_base.py
+++ b/hier_config/platforms/driver_base.py
@@ -1,11 +1,10 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from collections.abc import Callable, Iterable
+from typing import TYPE_CHECKING
 
 from pydantic import Field, PositiveInt
 
-from hier_config.child import HConfigChild
 from hier_config.models import (
     BaseModel,
     FullTextSubRule,
@@ -23,7 +22,12 @@ from hier_config.models import (
     UnusedObjectAnalysis,
     UnusedObjectRule,
 )
-from hier_config.root import HConfig
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterable
+
+    from hier_config.child import HConfigChild
+    from hier_config.root import HConfig
 
 
 def _full_text_sub_rules_default() -> list[FullTextSubRule]:
@@ -177,7 +181,7 @@ class HConfigDriverBase(ABC):
     def config_preprocessor(config_text: str) -> str:
         return config_text
 
-    def get_unused_object_rules(self) -> list["UnusedObjectRule"]:
+    def get_unused_object_rules(self) -> list[UnusedObjectRule]:
         """Returns the unused object rules for this driver.
 
         Returns:
@@ -187,7 +191,7 @@ class HConfigDriverBase(ABC):
         return self.rules.unused_object_rules
 
     def add_unused_object_rules(
-        self, rules: list["UnusedObjectRule"] | "UnusedObjectRule"
+        self, rules: list[UnusedObjectRule] | UnusedObjectRule
     ) -> None:
         r"""Add custom unused object rules to this driver instance.
 
@@ -201,7 +205,12 @@ class HConfigDriverBase(ABC):
 
         Example:
             >>> from hier_config import get_hconfig
-            >>> from hier_config.models import Platform, UnusedObjectRule, MatchRule, ReferencePattern
+            >>> from hier_config.models import (
+            ...     Platform,
+            ...     UnusedObjectRule,
+            ...     MatchRule,
+            ...     ReferencePattern,
+            ... )
             >>> config = get_hconfig(Platform.CISCO_IOS, "interface GigabitEthernet0/1")
             >>> custom_rule = UnusedObjectRule(
             ...     object_type="my-custom-object",
@@ -221,7 +230,7 @@ class HConfigDriverBase(ABC):
         rules_to_add = [rules] if isinstance(rules, UnusedObjectRule) else rules
         self.rules.unused_object_rules.extend(rules_to_add)
 
-    def find_unused_objects(self, config: "HConfig") -> UnusedObjectAnalysis:  # noqa: PLR6301
+    def find_unused_objects(self, config: HConfig) -> UnusedObjectAnalysis:  # noqa: PLR6301
         """Convenience method to find unused objects in a configuration.
 
         Args:


### PR DESCRIPTION
Resolves all ruff, mypy, pyright, and pylint issues:

- Add raw string prefix (r""") to docstrings containing regex examples to fix invalid escape sequence warnings in models.py and unused_object_helpers.py

- Move type-checking-only imports to TYPE_CHECKING block in driver_base.py to reduce runtime overhead

- Remove unnecessary quotes from type annotations (UnusedObjectRule, HConfig) per PEP 585

- Add explicit encoding="utf-8" to file open() calls for cross-platform consistency

- Fix YAML_AVAILABLE constant redefinition by using conditional assignment pattern

- Add noqa comment for create_simple_rule function which intentionally accepts multiple parameters as a convenience function

- Auto-format files with ruff to ensure consistent code style

All ruff checks now pass with zero errors.