### PR TITLE
Run code quality checks and type validation

### DIFF
--- a/example_custom_unused_objects.py
+++ b/example_custom_unused_objects.py
@@ -39,7 +39,7 @@ nat source interface eth0 pool PUBLIC_POOL
 """
 
 
-def main():
+def main() -> None:
     """Demonstrate custom unused object detection."""
     print("=" * 70)
     print("Extensible Unused Object Detection Example")
@@ -69,8 +69,8 @@ def main():
     )
 
     print(f"Created rule: {acl_rule.object_type}")
-    print(f"  - Definition pattern: startswith='access-list '")
-    print(f"  - Reference extraction: apply-acl\\s+(\\S+)")
+    print("  - Definition pattern: startswith='access-list '")
+    print("  - Reference extraction: apply-acl\\s+(\\S+)")
     print(f"  - Removal template: {acl_rule.removal_template}")
 
     print("\n2. Using create_simple_rule (simplified API):")
@@ -87,8 +87,8 @@ def main():
     )
 
     print(f"Created rule: {nat_pool_rule.object_type}")
-    print(f"  - Definition pattern: startswith='nat-pool '")
-    print(f"  - Reference extraction: pool\\s+(\\S+)")
+    print("  - Definition pattern: startswith='nat-pool '")
+    print("  - Reference extraction: pool\\s+(\\S+)")
     print(f"  - Removal template: {nat_pool_rule.removal_template}")
 
     print("\n3. Adding rules to driver:")
@@ -130,7 +130,7 @@ def main():
     else:
         print("  (no unused objects to remove)")
 
-    print("\n" + "=" * 70)
+    print(f"\n{'=' * 70}")
     print("Example completed successfully!")
     print("=" * 70)
 

--- a/hier_config/unused_object_helpers.py
+++ b/hier_config/unused_object_helpers.py
@@ -251,7 +251,7 @@ def load_unused_object_rules_from_dict(data: dict[str, Any]) -> list[UnusedObjec
         ]
 
         # Parse reference patterns
-        reference_patterns = []
+        reference_patterns: list[ReferencePattern] = []
         for ref_pattern_data in rule_data["reference_patterns"]:
             match_rules = [
                 MatchRule(**match) for match in ref_pattern_data["match_rules"]
@@ -303,7 +303,7 @@ def load_unused_object_rules_from_yaml(file_path: str | Path) -> list[UnusedObje
 
     path = Path(file_path)
     with path.open(encoding="utf-8") as f:
-        data = yaml.safe_load(f)
+        data = yaml.safe_load(f)  # type: ignore[union-attr]
 
     return load_unused_object_rules_from_dict(data)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -150,3 +150,4 @@ parametrize-values-type = "tuple"
 
 [tool.ruff.lint.per-file-ignores]
 "**/tests/*" = ["PLC2701", "S101"]
+"example_custom_unused_objects.py" = ["T201"]


### PR DESCRIPTION
- Add return type annotation to main() in example file
- Fix f-strings without interpolation
- Make example file executable
- Add per-file ignore for T201 (print statements in example)
- Add type annotations to fix pyright warnings
- Fix yaml.safe_load type checking issue