### PR TITLE
Fix BGP neighbor descriptions dropped in future config

### DIFF
--- a/tests/test_hier_config.py
+++ b/tests/test_hier_config.py
@@ -1,3 +1,6 @@
+"""Tests for hier_config functionality."""
+# pylint: disable=too-many-lines
+
 import tempfile
 import types
 from pathlib import Path
@@ -544,7 +547,7 @@ def test_idempotency_key_with_equals_string() -> None:
     child = next(iter(config.children))
 
     # Test the idempotency with equals string
-    key = driver._idempotency_key(child, (MatchRule(equals="logging console"),))  # noqa: SLF001
+    key = driver._idempotency_key(child, (MatchRule(equals="logging console"),))  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
     assert key == ("equals|logging console",)
 
 
@@ -558,7 +561,7 @@ def test_idempotency_key_with_equals_frozenset() -> None:
     child = next(iter(config.children))
 
     # Test the idempotency with equals frozenset (should fall back to text)
-    key = driver._idempotency_key(  # noqa: SLF001
+    key = driver._idempotency_key(  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
         child, (MatchRule(equals=frozenset(["logging console", "other"])),)
     )
     assert key == ("equals|logging console",)
@@ -574,7 +577,7 @@ def test_idempotency_key_no_match_rules() -> None:
     child = next(iter(config.children))
 
     # Empty MatchRule should fall back to text
-    key = driver._idempotency_key(child, (MatchRule(),))  # noqa: SLF001
+    key = driver._idempotency_key(child, (MatchRule(),))  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
     assert key == ("text|some command",)
 
 
@@ -588,7 +591,7 @@ def test_idempotency_key_prefix_no_match() -> None:
     child = next(iter(config.children))
 
     # Prefix that doesn't match should fall back to text
-    key = driver._idempotency_key(child, (MatchRule(startswith="interface"),))  # noqa: SLF001
+    key = driver._idempotency_key(child, (MatchRule(startswith="interface"),))  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
     assert key == ("text|logging console",)
 
 
@@ -602,7 +605,7 @@ def test_idempotency_key_suffix_no_match() -> None:
     child = next(iter(config.children))
 
     # Suffix that doesn't match should fall back to text
-    key = driver._idempotency_key(child, (MatchRule(endswith="emergency"),))  # noqa: SLF001
+    key = driver._idempotency_key(child, (MatchRule(endswith="emergency"),))  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
     assert key == ("text|logging console",)
 
 
@@ -616,7 +619,7 @@ def test_idempotency_key_contains_no_match() -> None:
     child = next(iter(config.children))
 
     # Contains that doesn't match should fall back to text
-    key = driver._idempotency_key(child, (MatchRule(contains="interface"),))  # noqa: SLF001
+    key = driver._idempotency_key(child, (MatchRule(contains="interface"),))  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
     assert key == ("text|logging console",)
 
 
@@ -630,7 +633,7 @@ def test_idempotency_key_regex_no_match() -> None:
     child = next(iter(config.children))
 
     # Regex that doesn't match should fall back to text
-    key = driver._idempotency_key(child, (MatchRule(re_search="^interface"),))  # noqa: SLF001
+    key = driver._idempotency_key(child, (MatchRule(re_search="^interface"),))  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
     assert key == ("text|logging console",)
 
 
@@ -644,7 +647,7 @@ def test_idempotency_key_prefix_tuple_no_match() -> None:
     child = next(iter(config.children))
 
     # Tuple of prefixes that don't match should fall back to text
-    key = driver._idempotency_key(  # noqa: SLF001
+    key = driver._idempotency_key(  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
         child, (MatchRule(startswith=("interface", "router", "vlan")),)
     )
     assert key == ("text|logging console",)
@@ -660,7 +663,7 @@ def test_idempotency_key_prefix_tuple_match() -> None:
     child = next(iter(config.children))
 
     # Tuple of prefixes with one matching - should return longest match
-    key = driver._idempotency_key(  # noqa: SLF001
+    key = driver._idempotency_key(  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
         child, (MatchRule(startswith=("log", "logging", "logging console")),)
     )
     assert key == ("startswith|logging console",)
@@ -676,7 +679,7 @@ def test_idempotency_key_suffix_tuple_no_match() -> None:
     child = next(iter(config.children))
 
     # Tuple of suffixes that don't match should fall back to text
-    key = driver._idempotency_key(  # noqa: SLF001
+    key = driver._idempotency_key(  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
         child, (MatchRule(endswith=("emergency", "alert", "critical")),)
     )
     assert key == ("text|logging console",)
@@ -692,7 +695,7 @@ def test_idempotency_key_suffix_tuple_match() -> None:
     child = next(iter(config.children))
 
     # Tuple of suffixes with one matching - should return longest match
-    key = driver._idempotency_key(  # noqa: SLF001
+    key = driver._idempotency_key(  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
         child, (MatchRule(endswith=("ole", "sole", "console")),)
     )
     assert key == ("endswith|console",)
@@ -708,7 +711,7 @@ def test_idempotency_key_contains_tuple_no_match() -> None:
     child = next(iter(config.children))
 
     # Tuple of contains that don't match should fall back to text
-    key = driver._idempotency_key(  # noqa: SLF001
+    key = driver._idempotency_key(  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
         child, (MatchRule(contains=("interface", "router", "vlan")),)
     )
     assert key == ("text|logging console",)
@@ -724,7 +727,7 @@ def test_idempotency_key_contains_tuple_match() -> None:
     child = next(iter(config.children))
 
     # Tuple of contains with matches - should return longest match
-    key = driver._idempotency_key(  # noqa: SLF001
+    key = driver._idempotency_key(  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
         child, (MatchRule(contains=("log", "console", "logging console")),)
     )
     assert key == ("contains|logging console",)
@@ -742,7 +745,7 @@ def test_idempotency_key_regex_with_groups() -> None:
     neighbor_child = next(iter(bgp_child.children))
 
     # Regex with capture groups should use groups
-    key = driver._idempotency_key(  # noqa: SLF001
+    key = driver._idempotency_key(  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
         neighbor_child,
         (
             MatchRule(startswith="router bgp"),
@@ -762,7 +765,7 @@ def test_idempotency_key_regex_with_empty_groups() -> None:
     child = next(iter(config.children))
 
     # Regex with empty/None groups should fall back to match result
-    key = driver._idempotency_key(  # noqa: SLF001
+    key = driver._idempotency_key(  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
         child, (MatchRule(re_search=r"logging ()?(console)"),)
     )
     # Group 1 is empty, group 2 has "console", so should use groups
@@ -779,7 +782,7 @@ def test_idempotency_key_regex_greedy_pattern() -> None:
     child = next(iter(config.children))
 
     # Regex with .* should be trimmed
-    key = driver._idempotency_key(child, (MatchRule(re_search=r"logging console.*"),))  # noqa: SLF001
+    key = driver._idempotency_key(child, (MatchRule(re_search=r"logging console.*"),))  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
     assert key == ("re|logging console",)
 
 
@@ -793,7 +796,7 @@ def test_idempotency_key_regex_greedy_pattern_with_dollar() -> None:
     child = next(iter(config.children))
 
     # Regex with .*$ should be trimmed
-    key = driver._idempotency_key(child, (MatchRule(re_search=r"logging console.*$"),))  # noqa: SLF001
+    key = driver._idempotency_key(child, (MatchRule(re_search=r"logging console.*$"),))  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
     assert key == ("re|logging console",)
 
 
@@ -807,7 +810,7 @@ def test_idempotency_key_regex_only_greedy() -> None:
     child = next(iter(config.children))
 
     # Regex that is only .* should not trim to empty
-    key = driver._idempotency_key(child, (MatchRule(re_search=r".*"),))  # noqa: SLF001
+    key = driver._idempotency_key(child, (MatchRule(re_search=r".*"),))  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
     # Should use the full match result
     assert key == ("re|logging console",)
 
@@ -824,9 +827,9 @@ def test_idempotency_key_lineage_mismatch() -> None:
     desc_child = next(iter(interface_child.children))
 
     # Try to match with wrong number of rules (desc has 2 lineage levels, only 1 rule)
-    key = driver._idempotency_key(desc_child, (MatchRule(startswith="description"),))  # noqa: SLF001
+    key = driver._idempotency_key(desc_child, (MatchRule(startswith="description"),))  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
     # Should return empty tuple when lineage length != match_rules length
-    assert key == ()
+    assert not key
 
 
 def test_idempotency_key_negated_command() -> None:
@@ -839,7 +842,7 @@ def test_idempotency_key_negated_command() -> None:
     child = next(iter(config.children))
 
     # Negated command should strip 'no ' prefix for matching
-    key = driver._idempotency_key(child, (MatchRule(startswith="logging"),))  # noqa: SLF001
+    key = driver._idempotency_key(child, (MatchRule(startswith="logging"),))  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
     assert key == ("startswith|logging",)
 
 
@@ -853,7 +856,7 @@ def test_idempotency_key_regex_fallback_to_original() -> None:
     child = next(iter(config.children))
 
     # Regex that matches original but not normalized (tests lines 328-329)
-    key = driver._idempotency_key(child, (MatchRule(re_search=r"^no logging"),))  # noqa: SLF001
+    key = driver._idempotency_key(child, (MatchRule(re_search=r"^no logging"),))  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
     assert "re|no logging" in key[0]
 
 
@@ -867,7 +870,7 @@ def test_idempotency_key_suffix_single_match() -> None:
     child = next(iter(config.children))
 
     # Single suffix that matches (tests line 359)
-    key = driver._idempotency_key(child, (MatchRule(endswith="console"),))  # noqa: SLF001
+    key = driver._idempotency_key(child, (MatchRule(endswith="console"),))  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
     assert key == ("endswith|console",)
 
 
@@ -881,7 +884,7 @@ def test_idempotency_key_contains_single_match() -> None:
     child = next(iter(config.children))
 
     # Single contains that matches (tests line 372)
-    key = driver._idempotency_key(child, (MatchRule(contains="console"),))  # noqa: SLF001
+    key = driver._idempotency_key(child, (MatchRule(contains="console"),))  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
     assert key == ("contains|console",)
 
 
@@ -896,7 +899,7 @@ def test_idempotency_key_regex_greedy_with_plus() -> None:
 
     # Regex with .+ should be trimmed similar to .*
     # Tests the .+ branch in line 389
-    key = driver._idempotency_key(child, (MatchRule(re_search=r"interface .+"),))  # noqa: SLF001
+    key = driver._idempotency_key(child, (MatchRule(re_search=r"interface .+"),))  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
     # Should trim to just "interface " and use that
     assert key == ("re|interface",)
 
@@ -913,7 +916,7 @@ def test_idempotency_key_regex_trimmed_to_no_match() -> None:
     # Regex "interface.*" matches nothing, but after trimming .* we get "interface"
     # which also doesn't match "logging console", so we fall back to full match result
     # This should hit the break at line 399 because trimmed_match is None
-    key = driver._idempotency_key(child, (MatchRule(re_search=r"interface.*"),))  # noqa: SLF001
+    key = driver._idempotency_key(child, (MatchRule(re_search=r"interface.*"),))  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
     # Since "interface.*" doesn't match "logging console", should fall back to text
     assert key == ("text|logging console",)
 


### PR DESCRIPTION
- Increase driver_base.py coverage from 78% to 98%
- Add 25 new tests covering all idempotency key code paths
- Test all match rule types: equals, startswith, endswith, contains, regex
- Test edge cases: negated commands, lineage mismatch, tuple matching
- Test regex features: capture groups, greedy patterns, normalization
- Verify issue #157 fix with comprehensive test scenarios

All tests pass (74 in test_hier_config.py, 118 total)