### PR TITLE
Update the XR driver per github issues #205 and #206

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.4.2] - 2026-03-17
+
+### Fixed
+
+- IOS-XR: `DuplicateChildError` on nested `if/endif` blocks inside `route-policy`
+  sections. Added a `parent_allows_duplicate_child` rule at depth 2
+  (`route-policy` -> `if`) so duplicate `endif` children are permitted (issue #206).
+- IOS-XR: `indent_adjust` rule for `template` incorrectly triggered on
+  `template timeout` leaf parameters inside `flow exporter-map` blocks, corrupting
+  indentation for all subsequent top-level sections. Narrowed the start expression
+  with a negative lookahead (`(?!\s+timeout)`) to exclude leaf uses (issue #205).
+
+---
+
 ## [3.4.1] - 2026-01-28
 
 ### Added

--- a/hier_config/platforms/cisco_xr/driver.py
+++ b/hier_config/platforms/cisco_xr/driver.py
@@ -115,13 +115,19 @@ class HConfigDriverCiscoIOSXR(HConfigDriverBase):  # pylint: disable=too-many-in
             ],
             indent_adjust=[
                 IndentAdjustRule(
-                    start_expression="^\\s*template",
+                    start_expression="^\\s*template(?!\\s+timeout)",
                     end_expression="^\\s*end-template",
                 ),
             ],
             parent_allows_duplicate_child=[
                 ParentAllowsDuplicateChildRule(
                     match_rules=(MatchRule(startswith="route-policy"),)
+                ),
+                ParentAllowsDuplicateChildRule(
+                    match_rules=(
+                        MatchRule(startswith="route-policy"),
+                        MatchRule(startswith="if "),
+                    )
                 ),
             ],
             per_line_sub=[

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hier-config"
-version = "3.4.1"
+version = "3.4.2"
 description = "A network configuration query and comparison library, used to build remediation configurations."
 packages = [
     { include="hier_config", from="."},

--- a/tests/test_driver_cisco_xr.py
+++ b/tests/test_driver_cisco_xr.py
@@ -46,6 +46,195 @@ def test_duplicate_child_route_policy() -> None:
     )
 
 
+def test_nested_if_endif_route_policy() -> None:
+    """Test nested if/endif blocks in route-policy don't raise DuplicateChildError."""
+    platform = Platform.CISCO_XR
+    running_config = get_hconfig_fast_load(
+        platform,
+        (
+            "route-policy EXAMPLE-POLICY",
+            "  if (community matches-any COMM-SET-A) then",
+            "    if (community matches-any COMM-SET-B) then",
+            "      done",
+            "    endif",
+            "    if (community matches-any COMM-SET-C) then",
+            "      done",
+            "    endif",
+            "    drop",
+            "  endif",
+            "  pass",
+            "end-policy",
+        ),
+    )
+    generated_config = get_hconfig_fast_load(
+        platform,
+        (
+            "route-policy EXAMPLE-POLICY",
+            "  if (community matches-any COMM-SET-A) then",
+            "    if (community matches-any COMM-SET-B) then",
+            "      done",
+            "    endif",
+            "    if (community matches-any COMM-SET-D) then",
+            "      set local-preference 200",
+            "    endif",
+            "    drop",
+            "  endif",
+            "  pass",
+            "end-policy",
+        ),
+    )
+    remediation_config = running_config.config_to_get_to(generated_config)
+    assert remediation_config.dump_simple(sectional_exiting=True) == (
+        "route-policy EXAMPLE-POLICY",
+        "  if (community matches-any COMM-SET-A) then",
+        "    if (community matches-any COMM-SET-B) then",
+        "      done",
+        "      exit",
+        "    endif",
+        "    if (community matches-any COMM-SET-D) then",
+        "      set local-preference 200",
+        "      exit",
+        "    endif",
+        "    drop",
+        "    exit",
+        "  endif",
+        "  pass",
+        "  end-policy",
+    )
+
+
+def test_flow_exporter_template_indent_adjust() -> None:
+    """Test that 'template timeout' inside flow exporter-map doesn't corrupt indentation."""
+    platform = Platform.CISCO_XR
+    running_config = get_hconfig_fast_load(
+        platform,
+        (
+            "flow exporter-map EXPORTER1",
+            " version v9",
+            "  template timeout 60",
+            " !",
+            " transport udp 9999",
+            "!",
+            "route-policy POLICY1",
+            "  if (destination in PREFIX-SET1) then",
+            "    drop",
+            "  endif",
+            "  if (destination in PREFIX-SET2) then",
+            "    done",
+            "  endif",
+            "  drop",
+            "end-policy",
+        ),
+    )
+    generated_config = get_hconfig_fast_load(
+        platform,
+        (
+            "flow exporter-map EXPORTER1",
+            " version v9",
+            "  template timeout 60",
+            " !",
+            " transport udp 9999",
+            "!",
+            "route-policy POLICY1",
+            "  if (destination in PREFIX-SET1) then",
+            "    drop",
+            "  endif",
+            "  if (destination in PREFIX-SET3) then",
+            "    pass",
+            "  endif",
+            "  drop",
+            "end-policy",
+        ),
+    )
+    remediation_config = running_config.config_to_get_to(generated_config)
+    assert remediation_config.dump_simple(sectional_exiting=True) == (
+        "route-policy POLICY1",
+        "  if (destination in PREFIX-SET1) then",
+        "    drop",
+        "    exit",
+        "  endif",
+        "  if (destination in PREFIX-SET3) then",
+        "    pass",
+        "    exit",
+        "  endif",
+        "  drop",
+        "  end-policy",
+    )
+
+
+def test_template_block_indent_adjust() -> None:
+    """Test that template blocks still parse correctly with the indent_adjust rule."""
+    platform = Platform.CISCO_XR
+    running_config = get_hconfig_fast_load(
+        platform,
+        (
+            "template ACCESS-PORT",
+            " description Access Port - Standard Config",
+            " load-interval 30",
+            " ipv4 mtu 1500",
+            " mtu 1518",
+            " dampening",
+            " carrier-delay up 5000 down 0",
+            " spanning-tree portfast",
+            "!",
+            "template UPLINK-PORT",
+            " description Uplink - Core Facing",
+            " load-interval 30",
+            " mtu 9000",
+            " ipv4 mtu 8972",
+            " dampening",
+            " carrier-delay up 5000 down 0",
+            " lldp",
+            "  transmit",
+            "  receive",
+            " !",
+            "!",
+        ),
+    )
+    generated_config = get_hconfig_fast_load(
+        platform,
+        (
+            "template ACCESS-PORT",
+            " description Access Port - Standard Config",
+            " load-interval 30",
+            " ipv4 mtu 1500",
+            " mtu 1518",
+            " dampening",
+            " carrier-delay up 5000 down 0",
+            " spanning-tree portfast",
+            "!",
+            "template UPLINK-PORT",
+            " description Uplink - Core Facing",
+            " load-interval 30",
+            " mtu 9216",
+            " ipv4 mtu 9000",
+            " dampening",
+            " carrier-delay up 5000 down 0",
+            " lldp",
+            "  transmit",
+            "  receive",
+            " !",
+            "!",
+        ),
+    )
+    remediation_config = running_config.config_to_get_to(generated_config)
+    assert remediation_config.dump_simple(sectional_exiting=True) == (
+        "no template UPLINK-PORT",
+        "template UPLINK-PORT",
+        "  description Uplink - Core Facing",
+        "  load-interval 30",
+        "  mtu 9216",
+        "  ipv4 mtu 9000",
+        "  dampening",
+        "  carrier-delay up 5000 down 0",
+        "  lldp",
+        "    transmit",
+        "    receive",
+        "    exit",
+        "  end-template",
+    )
+
+
 def test_ipv4_acl_sequence_number_idempotent() -> None:
     """Test IPv4 ACL sequence number idempotency (covers lines 25-31)."""
     platform = Platform.CISCO_XR


### PR DESCRIPTION
  Summary                                                                                                                              
                  
  - Fix DuplicateChildError when parsing IOS-XR route-policy blocks with nested if/endif at depth > 1 (fixes #206)                     
  - Fix indent_adjust rule incorrectly triggering on template timeout leaf parameters inside flow exporter-map blocks, which corrupted
  indentation for all subsequent top-level blocks (fixes #205)                                                                         
                  
  Changes                                                                                                                              
                  
  Driver (hier_config/platforms/cisco_xr/driver.py):                                                                                   
  - Added a parent_allows_duplicate_child rule matching route-policy → if at depth 2, allowing duplicate endif children under nested if
   blocks                                                                                                                              
  - Changed indent_adjust start expression from ^\s*template to ^\s*template(?!\s+timeout) — a negative lookahead that prevents
  template timeout leaf parameters from triggering the indent increment meant for template block openers                               
                                                                                                                                       
  Tests (tests/test_driver_cisco_xr.py):
  - test_nested_if_endif_route_policy — verifies parsing and remediation of route-policies with multiple nested if/endif blocks        
  - test_flow_exporter_template_indent_adjust — verifies template timeout inside flow exporter-map doesn't corrupt parsing of          
  subsequent route-policy blocks                                                                                             
  - test_template_block_indent_adjust — regression test confirming proper template block handling (e.g. template ACCESS-PORT, template 
  UPLINK-PORT) still works with the updated regex
                                                                                                                                       
  Test plan       
                                                                                                                                       
  - All 7 IOS-XR driver tests pass                                                                                                     
  - Verify no regressions in full test suite