### PR TITLE
Fix XR tests for exit_text_parent_level

### DIFF
--- a/hier_config/platforms/cisco_xr/driver.py
+++ b/hier_config/platforms/cisco_xr/driver.py
@@ -84,6 +84,7 @@ class HConfigDriverCiscoIOSXR(HConfigDriverBase):  # pylint: disable=too-many-in
                 SectionalExitingRule(
                     match_rules=(MatchRule(startswith="group"),),
                     exit_text="end-group",
+                    exit_text_parent_level=True,
                 ),
                 SectionalExitingRule(
                     match_rules=(MatchRule(startswith="interface"),),

--- a/tests/test_driver_cisco_xr.py
+++ b/tests/test_driver_cisco_xr.py
@@ -156,7 +156,7 @@ def test_nested_if_endif_route_policy() -> None:
         "    exit",
         "  endif",
         "  pass",
-        "  end-policy",
+        "end-policy",
     )
 
 
@@ -215,7 +215,7 @@ def test_flow_exporter_template_indent_adjust() -> None:
         "    exit",
         "  endif",
         "  drop",
-        "  end-policy",
+        "end-policy",
     )
 
 
@@ -288,7 +288,7 @@ def test_template_block_indent_adjust() -> None:
         "    transmit",
         "    receive",
         "    exit",
-        "  end-template",
+        "end-template",
     )
 
 


### PR DESCRIPTION
## Summary
- Fix 3 failing tests in `test_driver_cisco_xr.py` that expected indented exit text (`  end-policy`, `  end-template`) but now get unindented output after PR #142 set `exit_text_parent_level=True` on XR sectional exiting rules
- Add `exit_text_parent_level=True` to the `group`/`end-group` rule for consistency with all other XR `end-*` rules

## Test plan
- [x] All 19 XR driver tests pass
- [x] Full `lint-and-test` suite passes (553 tests, linting, type checking)

🤖 Generated with [Claude Code](https://claude.com/claude-code)