### PR TITLE
Add Literal type for cisco_style_text() style parameter (#189)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `TextStyle` type alias (`Literal["without_comments", "merged", "with_comments"]`) for
+  the `style` parameter on `HConfigChild.cisco_style_text()` and
+  `RemediationReporter.to_text()`, replacing the unconstrained `str` type (#189).
+
 - Performance benchmarks for parsing, remediation, and iteration (#202).
   Skipped by default; run with `poetry run pytest -m benchmark -v -s`.
 

--- a/hier_config/__init__.py
+++ b/hier_config/__init__.py
@@ -6,7 +6,7 @@ from .constructors import (
     get_hconfig_from_dump,
     get_hconfig_view,
 )
-from .models import ChangeDetail, MatchRule, Platform, ReportSummary, TagRule
+from .models import ChangeDetail, MatchRule, Platform, ReportSummary, TagRule, TextStyle
 from .reporting import RemediationReporter
 from .root import HConfig
 from .workflows import WorkflowRemediation
@@ -20,6 +20,7 @@ __all__ = (
     "RemediationReporter",
     "ReportSummary",
     "TagRule",
+    "TextStyle",
     "WorkflowRemediation",
     "get_hconfig",
     "get_hconfig_driver",

--- a/hier_config/child.py
+++ b/hier_config/child.py
@@ -6,7 +6,7 @@ from re import search, sub
 from typing import TYPE_CHECKING, Any
 
 from .base import HConfigBase
-from .models import Instance, MatchRule, SetLikeOfStr
+from .models import Instance, MatchRule, SetLikeOfStr, TextStyle
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Iterator
@@ -181,7 +181,7 @@ class HConfigChild(  # noqa: PLR0904  pylint: disable=too-many-instance-attribut
 
     def cisco_style_text(
         self,
-        style: str = "without_comments",
+        style: TextStyle = "without_comments",
         tag: str | None = None,
     ) -> str:
         """Return a Cisco style formated line i.e. indentation_level + text ! comments."""

--- a/hier_config/models.py
+++ b/hier_config/models.py
@@ -1,7 +1,10 @@
 from enum import Enum, auto
+from typing import Literal
 
 from pydantic import BaseModel as PydanticBaseModel
 from pydantic import ConfigDict, NonNegativeInt, PositiveInt
+
+TextStyle = Literal["without_comments", "merged", "with_comments"]
 
 
 class BaseModel(PydanticBaseModel):

--- a/hier_config/reporting.py
+++ b/hier_config/reporting.py
@@ -14,7 +14,7 @@ from pathlib import Path
 from typing import Any
 
 from hier_config.child import HConfigChild
-from hier_config.models import ChangeDetail, ReportSummary, TagRule
+from hier_config.models import ChangeDetail, ReportSummary, TagRule, TextStyle
 from hier_config.root import HConfig
 
 
@@ -637,7 +637,7 @@ class RemediationReporter:  # noqa: PLR0904
         self,
         file_path: str | Path,
         *,
-        style: str = "merged",
+        style: TextStyle = "merged",
         include_tags: Iterable[str] = (),
         exclude_tags: Iterable[str] = (),
     ) -> None:

--- a/tests/test_hier_config.py
+++ b/tests/test_hier_config.py
@@ -2187,3 +2187,16 @@ def test_children_extend() -> None:
     assert len(interface1.children) == 2
     assert "description test" in interface1.children
     assert "ip address 192.0.2.1 255.255.255.0" in interface1.children
+
+
+def test_cisco_style_text_literal_styles(platform_a: Platform) -> None:
+    """Verify cisco_style_text works with each valid TextStyle literal value (#189)."""
+    config = get_hconfig(platform_a)
+    child = config.add_child("interface Vlan2")
+    child.add_child("ip address 10.0.0.1 255.255.255.0")
+
+    # Each valid style should produce a non-empty string without raising
+    for style in ("without_comments", "merged", "with_comments"):
+        result = child.cisco_style_text(style=style)
+        assert isinstance(result, str)
+        assert "interface Vlan2" in result


### PR DESCRIPTION
## Summary

- Introduces `TextStyle = Literal["without_comments", "merged", "with_comments"]` type alias in `models.py`
- Constrains `style` parameter on `cisco_style_text()` and `to_text()` to `TextStyle`
- Exports `TextStyle` from `hier_config.__init__`
- Adds test for all three valid style values

## Test plan

- [x] All tests pass
- [x] Full lint suite clean (`poetry run ./scripts/build.py lint-and-test`)

Closes #189

🤖 Generated with [Claude Code](https://claude.com/claude-code)