### PR TITLE
Bump version to 3.6.0 and update docs/changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+---
+
+## [3.6.0] - 2026-03-26
+
 ### Added
 
 - `TextStyle` type alias (`Literal["without_comments", "merged", "with_comments"]`) for
@@ -26,6 +30,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   separators (e.g., ` !`, `  !`). The `per_line_sub` regex was changed from `^!\s*$`
   to `^\s*!\s*$` so bare `!` lines at any indentation level are stripped, restoring
   v3.4.2 behavior (#231).
+
+- `__hash__` and `__eq__` inconsistency in `HConfigChild`: `__hash__` included
+  `new_in_config` and `order_weight` but `__eq__` excluded them, and `__eq__` checked
+  `tags` but `__hash__` did not, violating the Python invariant that `a == b` implies
+  `hash(a) == hash(b)`. Both methods now use the same fields: `text`, `tags`, and
+  `children` (#185).
 
 ---
 
@@ -226,7 +236,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-[Unreleased]: https://github.com/netdevops/hier_config/compare/v3.4.1...HEAD
+[Unreleased]: https://github.com/netdevops/hier_config/compare/v3.6.0...HEAD
+[3.6.0]: https://github.com/netdevops/hier_config/compare/v3.5.1...v3.6.0
+[3.5.1]: https://github.com/netdevops/hier_config/compare/v3.5.0...v3.5.1
+[3.5.0]: https://github.com/netdevops/hier_config/compare/v3.4.3...v3.5.0
+[3.4.3]: https://github.com/netdevops/hier_config/compare/v3.4.2...v3.4.3
+[3.4.2]: https://github.com/netdevops/hier_config/compare/v3.4.1...v3.4.2
 [3.4.1]: https://github.com/netdevops/hier_config/compare/v3.4.0...v3.4.1
 [3.4.0]: https://github.com/netdevops/hier_config/compare/v3.3.0...v3.4.0
 [3.3.0]: https://github.com/netdevops/hier_config/compare/v3.2.2...v3.3.0

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Hierarchical Configuration has been used extensively on:
 - [x] Fortinet FortiOS
 - [x] HP Procurve (Aruba AOSS)
 - [x] HP Comware5 / H3C
+- [x] Huawei VRP
 
 In addition to the Cisco-style syntax, hier_config offers experimental support for Juniper-style configurations using set and delete commands. This allows users to remediate Junos configurations in native syntax. However, please note that Juniper syntax support is still in an experimental phase and has not been tested extensively. Use with caution in production environments.
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -46,6 +46,8 @@ Auto-generated reference documentation for the `hier_config` public API.
 
 ::: hier_config.models.Platform
 
+::: hier_config.models.TextStyle
+
 ::: hier_config.models.MatchRule
 
 ::: hier_config.models.TagRule

--- a/docs/drivers.md
+++ b/docs/drivers.md
@@ -34,10 +34,11 @@ The following drivers are included in Hier Config:
 - **CISCO_IOS**
 - **CISCO_XR**
 - **CISCO_NXOS**
-- **GENERIC**
 - **FORTINET_FORTIOS**
+- **GENERIC**
 - **HP_COMWARE5**
 - **HP_PROCURVE**
+- **HUAWEI_VRP**
 - **JUNIPER_JUNOS**
 - **VYOS**
 
@@ -236,6 +237,38 @@ from hier_config import WorkflowRemediation, get_hconfig, Platform
 
 running = get_hconfig(Platform.HP_COMWARE5, running_text)
 intended = get_hconfig(Platform.HP_COMWARE5, intended_text)
+workflow = WorkflowRemediation(running, intended)
+
+for line in workflow.remediation_config.all_children_sorted():
+    print(line.cisco_style_text())
+```
+
+---
+
+### Huawei VRP Driver
+
+Huawei VRP (Versatile Routing Platform) uses `undo` as the negation prefix rather than `no`. The `HUAWEI_VRP` driver customises negation handling for several command families:
+
+- **[Negation prefix](glossary.md#negation-prefix)**: `undo ` (replaces `no `).
+- **Smart negation**: `description` and `alias` commands are negated without their argument; `remark` commands strip the remark text; `snmp-agent community` commands truncate to the community name.
+- **Sectional exiting**: section exit text `exit` is translated to `quit` as VRP requires.
+- **Per-line substitutions**: strips `#` and `!` comment lines during parsing.
+
+Platform enum: `Platform.HUAWEI_VRP`
+
+```python
+from hier_config import Platform, get_hconfig_driver
+
+driver = get_hconfig_driver(Platform.HUAWEI_VRP)
+```
+
+**Remediation example:**
+
+```python
+from hier_config import WorkflowRemediation, get_hconfig, Platform
+
+running = get_hconfig(Platform.HUAWEI_VRP, running_text)
+intended = get_hconfig(Platform.HUAWEI_VRP, intended_text)
 workflow = WorkflowRemediation(running, intended)
 
 for line in workflow.remediation_config.all_children_sorted():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hier-config"
-version = "3.5.1"
+version = "3.6.0"
 description = "A network configuration query and comparison library, used to build remediation configurations."
 packages = [
     { include="hier_config", from="."},


### PR DESCRIPTION
## Summary

- Promotes all `[Unreleased]` items to `## [3.6.0] - 2026-03-26` in `CHANGELOG.md`
- Adds missing `__hash__`/`__eq__` fix entry (#185) to `CHANGELOG.md`
- Fixes stale footer comparison links — adds `3.4.2`, `3.4.3`, `3.5.0`, `3.5.1`, and `3.6.0` entries
- Adds `HUAWEI_VRP` to `docs/drivers.md` built-in driver list and a new driver section
- Adds Huawei VRP to the `README.md` platform compatibility list
- Adds `TextStyle` to `docs/api-reference.md` Models section
- Bumps `pyproject.toml` version to `3.6.0`

## Test plan

- [ ] Verify `CHANGELOG.md` footer links resolve correctly on GitHub
- [ ] Verify `docs/drivers.md` renders the Huawei VRP section correctly
- [ ] Verify `pyproject.toml` version matches the new CHANGELOG entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)