### PR TITLE
fix DuplicateChildError on peer-public-key end for Huawei configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Nokia SRL platform driver (`Platform.NOKIA_SRL`) (#245)
 
+### Fixed
+
+- Huawei VRP: parsing configs with multiple `peer-public-key` blocks no longer
+  raises `DuplicateChildError`. The closing `peer-public-key end` line (printed
+  at the same indent as the opening `rsa/dsa/ecc peer-public-key ...` line) is
+  now nested under its opener via an `IndentAdjustRule`.
+
 - Renovate bot configuration (`.github/renovate.json`) to automate Poetry and
   GitHub Actions dependency updates, with weekly lock-file maintenance, grouped
   non-major updates, and immediate vulnerability alerts.

--- a/hier_config/platforms/huawei_vrp/driver.py
+++ b/hier_config/platforms/huawei_vrp/driver.py
@@ -1,7 +1,7 @@
 import re
 
 from hier_config.child import HConfigChild
-from hier_config.models import PerLineSubRule
+from hier_config.models import IndentAdjustRule, PerLineSubRule
 from hier_config.platforms.driver_base import HConfigDriverBase, HConfigDriverRules
 
 
@@ -46,6 +46,17 @@ class HConfigDriverHuaweiVrp(HConfigDriverBase):
     @staticmethod
     def _instantiate_rules() -> HConfigDriverRules:
         return HConfigDriverRules(
+            indent_adjust=[
+                # Huawei prints public-key blocks with the closing
+                # ``peer-public-key end`` line at the same indentation as the
+                # opening ``(rsa|dsa|ecc) peer-public-key ...`` line. Nest the
+                # whole block under its opener so multiple keys don't collide as
+                # duplicate root-level ``peer-public-key end`` children.
+                IndentAdjustRule(
+                    start_expression="^\\s*(rsa|dsa|ecc) peer-public-key ",
+                    end_expression="^\\s*peer-public-key end",
+                ),
+            ],
             per_line_sub=[
                 PerLineSubRule(search="^\\s*[#!].*", replace=""),
             ],

--- a/tests/test_driver_huawei_vrp.py
+++ b/tests/test_driver_huawei_vrp.py
@@ -89,6 +89,39 @@ def test_comments_stripped() -> None:
     )
 
 
+def test_multiple_peer_public_keys_no_duplicate_child_error() -> None:
+    platform = Platform.HUAWEI_VRP
+    config = get_hconfig(
+        platform,
+        "rsa peer-public-key user1 encoding-type openssh\n"
+        " public-key-code begin\n"
+        "  AAAAB3Nza1\n"
+        "  C1yc2EAAA\n"
+        " public-key-code end\n"
+        "peer-public-key end\n"
+        "#\n"
+        "rsa peer-public-key user2 encoding-type openssh\n"
+        " public-key-code begin\n"
+        "  DDDDB3Nza2\n"
+        " public-key-code end\n"
+        "peer-public-key end\n"
+        "#\n",
+    )
+    assert config.dump_simple() == (
+        "rsa peer-public-key user1 encoding-type openssh",
+        "  public-key-code begin",
+        "    AAAAB3Nza1",
+        "    C1yc2EAAA",
+        "  public-key-code end",
+        "  peer-public-key end",
+        "rsa peer-public-key user2 encoding-type openssh",
+        "  public-key-code begin",
+        "    DDDDB3Nza2",
+        "  public-key-code end",
+        "  peer-public-key end",
+    )
+
+
 def test_sectional_exit_is_quit() -> None:
     platform = Platform.HUAWEI_VRP
     config = get_hconfig_fast_load(


### PR DESCRIPTION
multiple `peer-public-key` blocks raised `DuplicateChildError` on the closing `peer-public-key end`, while this is valid Huawei config syntax, this PR fixes that