### PR TITLE
Release 3.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,16 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+---
+
+## [3.6.1] - 2026-07-04
+
 ### Added
 
 - Nokia SRL platform driver (`Platform.NOKIA_SRL`) (#245)
 
-### Fixed
-
-- Huawei VRP: parsing configs with multiple `peer-public-key` blocks no longer
-  raises `DuplicateChildError`. The closing `peer-public-key end` line (printed
-  at the same indent as the opening `rsa/dsa/ecc peer-public-key ...` line) is
-  now nested under its opener via an `IndentAdjustRule`.
+### Changed
 
 - Renovate bot configuration (`.github/renovate.json`) to automate Poetry and
   GitHub Actions dependency updates, with weekly lock-file maintenance, grouped
@@ -26,7 +25,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Collapsed VLAN lines can produce a destructive `no vlan x,y` remediation in Cisco IOS (#264)
+- Huawei VRP: parsing configs with multiple `peer-public-key` blocks no longer
+  raises `DuplicateChildError`. The closing `peer-public-key end` line (printed
+  at the same indent as the opening `rsa/dsa/ecc peer-public-key ...` line) is
+  now nested under its opener via an `IndentAdjustRule` (#266).
+
+- Collapsed VLAN lines can produce a destructive `no vlan x,y` remediation in Cisco IOS (#264, #265).
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hier-config"
-version = "3.6.0"
+version = "3.6.1"
 description = "A network configuration query and comparison library, used to build remediation configurations."
 packages = [
     { include="hier_config", from="."},


### PR DESCRIPTION
## Release 3.6.1

Prepares the 3.6.1 release: bumps `pyproject.toml` to `3.6.1` and finalizes the CHANGELOG.

### Added
- Nokia SRL platform driver (`Platform.NOKIA_SRL`) (#245)

### Changed
- Renovate bot configuration to automate Poetry and GitHub Actions dependency updates

### Fixed
- Huawei VRP: multiple `peer-public-key` blocks no longer raise `DuplicateChildError` (#266)
- Collapsed VLAN lines could produce a destructive `no vlan x,y` remediation on Cisco IOS (#264, #265)

Plus dependency/CI chores (poetry-core v2, pytest security update, actions/checkout & setup-python bumps).

### Validation
`poetry run ./scripts/build.py lint-and-test` passes clean (ruff, mypy, pyright, pylint, pytest ≥95% coverage, yamllint, flynt).

> Note: the Nokia SRL driver is a new feature; under strict semver this could warrant a 3.7.0 minor bump. Releasing as 3.6.1 per maintainer request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)