### PR TITLE
Fix XR indent_adjust misfiring on 'template data timeout' and 'template options timeout' (follow-up to #205)

### DIFF
--- a/hier_config/platforms/cisco_xr/driver.py
+++ b/hier_config/platforms/cisco_xr/driver.py
@@ -151,7 +151,10 @@ class HConfigDriverCiscoIOSXR(HConfigDriverBase):  # pylint: disable=too-many-in
             ],
             indent_adjust=[
                 IndentAdjustRule(
-                    start_expression="^\\s*template(?!\\s+timeout)",
+                    # Exclude the flow exporter-map leaf forms `template timeout`,
+                    # `template data timeout`, and `template options timeout` so they
+                    # are not mistaken for a `template ... end-template` block.
+                    start_expression="^\\s*template(?!\\s+(?:data\\s+|options\\s+)?timeout)",
                     end_expression="^\\s*end-template",
                 ),
             ],

--- a/tests/test_driver_cisco_xr.py
+++ b/tests/test_driver_cisco_xr.py
@@ -219,6 +219,77 @@ def test_flow_exporter_template_indent_adjust() -> None:
     )
 
 
+def test_flow_exporter_template_data_options_timeout_indent_adjust() -> None:
+    """Test 'template data timeout' / 'template options timeout' inside flow exporter-map.
+
+    Follow-up to issue #205: the negative lookahead added there covered only the bare
+    'template timeout' form. The 'template data timeout' and 'template options timeout'
+    leaf forms still triggered the indent_adjust rule, and with no 'end-template' ever
+    arriving, every subsequent line in the config was nested under them.
+    """
+    platform = Platform.CISCO_XR
+    running_config = get_hconfig_fast_load(
+        platform,
+        (
+            "flow exporter-map EXPORTER1",
+            " version v9",
+            "  options interface-table timeout 300",
+            "  options sampler-table timeout 300",
+            "  template data timeout 15",
+            "  template options timeout 15",
+            " !",
+            " transport udp 9999",
+            "!",
+            "interface Loopback0",
+            " ipv4 address 10.0.0.1 255.255.255.255",
+            "!",
+            "router bgp 65000",
+            " neighbor 10.0.0.2",
+            "  remote-as 65001",
+        ),
+    )
+    # Everything after the flow exporter-map must remain at the top level; with the
+    # unguarded rule it is all swallowed under 'template data timeout 15'.
+    assert running_config.get_child(equals="interface Loopback0") is not None
+    assert running_config.get_child(equals="router bgp 65000") is not None
+    exporter = running_config.get_child(equals="flow exporter-map EXPORTER1")
+    assert exporter is not None
+    version = exporter.get_child(equals="version v9")
+    assert version is not None
+    assert version.get_child(equals="template data timeout 15") is not None
+    assert version.get_child(equals="template options timeout 15") is not None
+
+    generated_config = get_hconfig_fast_load(
+        platform,
+        (
+            "flow exporter-map EXPORTER1",
+            " version v9",
+            "  options interface-table timeout 300",
+            "  options sampler-table timeout 300",
+            "  template data timeout 15",
+            "  template options timeout 15",
+            " !",
+            " transport udp 9999",
+            "!",
+            "interface Loopback0",
+            " ipv4 address 10.0.0.1 255.255.255.255",
+            "!",
+            "router bgp 65000",
+            " neighbor 10.0.0.3",
+            "  remote-as 65001",
+        ),
+    )
+    remediation_config = running_config.config_to_get_to(generated_config)
+    assert remediation_config.dump_simple(sectional_exiting=True) == (
+        "router bgp 65000",
+        "  no neighbor 10.0.0.2",
+        "  neighbor 10.0.0.3",
+        "    remote-as 65001",
+        "    exit",
+        "  root",
+    )
+
+
 def test_template_block_indent_adjust() -> None:
     """Test that template blocks still parse correctly with the indent_adjust rule."""
     platform = Platform.CISCO_XR


### PR DESCRIPTION
## Problem

#208 (fixing #205) added a negative lookahead so the XR `indent_adjust` rule no longer misfires on the bare `template timeout <s>` leaf inside `flow exporter-map ... version v9`. However, IOS-XR also renders two sibling leaf forms in the same block:

```
flow exporter-map EXPORTER1
 version v9
  options interface-table timeout 300
  options sampler-table timeout 300
  template data timeout 15
  template options timeout 15
 !
 transport udp 2055
!
interface Loopback0
 ipv4 address 10.0.0.1 255.255.255.255
```

`template data timeout 15` and `template options timeout 15` do not match `(?!\s+timeout)`, so the rule still fires, and since no `end-template` ever arrives, **every subsequent line of the config is nested under the timeout leaf**. On a real production IOS-XR config (Cisco 8000, ~1900 lines) the tree collapses from 249 top-level children to 110, and everything after the flow exporter-map (interfaces, router bgp, router isis, ...) silently stops matching for negations, merges, `config_to_get_to`, and `future()`. Any XR config that exports NetFlow/IPFIX with explicit template timeouts hits this.

## Fix

Extend the lookahead to cover all three leaf forms from the `flow exporter-map` version block grammar (`template timeout`, `template data timeout`, `template options timeout`):

```
^\s*template(?!\s+(?:data\s+|options\s+)?timeout)
```

Real `template <name> ... end-template` blocks still match the rule; the existing `test_template_block_indent_adjust` covers that and still passes.

## Testing

* Added `test_flow_exporter_template_data_options_timeout_indent_adjust`, modeled on the #208 test: asserts the sections following the exporter-map stay at the top level, the timeout leaves parse as children of `version v9`, and a remediation across the config is unaffected. The parse assertions fail on master and pass with this change.
* Full suite: 619 passed. `ruff check`, `ruff format --check`, and `mypy` clean on the touched files.
* Verified against a real ~1900-line IOS-XR 25.2.2 config: tree parses to the correct 249 top-level children and section negation (`no interface ...`) behaves correctly again.