### PR TITLE
chore(release): prepare 3.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.6.2] - 2026-07-13
+
+### Fixed
+
+- Cisco IOS-XR: the `indent_adjust` rule no longer misfires on the
+  `template data timeout` and `template options timeout` leaves inside a
+  `flow exporter-map` version block. Because no `end-template` follows these
+  leaves, the parser previously nested every subsequent configuration line
+  under them, silently collapsing the tree. Follow-up to #205 (#268).
+
+---
+
 ## [3.6.1] - 2026-07-04
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hier-config"
-version = "3.6.1"
+version = "3.6.2"
 description = "A network configuration query and comparison library, used to build remediation configurations."
 packages = [
     { include="hier_config", from="."},


### PR DESCRIPTION
## Release prep for 3.6.2

Patch release covering the single change merged since `3.6.1`.

### Changes
- Bump `pyproject.toml` version `3.6.1` → `3.6.2`
- Finalize `CHANGELOG.md`: add `[3.6.2] - 2026-07-13` heading with the #268 fix

### Included in this release
- **#268** — Cisco IOS-XR `indent_adjust` no longer misfires on `template data timeout` / `template options timeout` leaves inside a `flow exporter-map` version block (follow-up to #205). Previously every subsequent config line was silently nested under the timeout leaf.

### Release mechanism
After this PR merges, creating a **GitHub Release** (tag `v3.6.2`) triggers `deploy-pypi.yml`, which builds and publishes to PyPI.

Co-authored-by: Claude Opus 4.8 (1M context) <noreply@anthropic.com>