### PR TITLE
Resolve config views from the driver's view_class attribute (#187)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Custom exception hierarchy: `HierConfigError` base, `DriverNotFoundError`,
   `InvalidConfigError`, `IncompatibleDriverError` (#219). `DuplicateChildError`
   reparented under `HierConfigError`.
+- `view_class` attribute on `HConfigDriverBase`: drivers now declare their own
+  config view, so custom drivers can register or override views (#187, #229).
 
 ### Changed
 
+- `get_hconfig_view()` resolves the view from the driver's `view_class`
+  attribute instead of a hardcoded `isinstance` chain; drivers without a view
+  raise `DriverNotFoundError` with a `No view registered for driver` message (#187).
 - Changed `style` parameter on `indented_text()` and `RemediationReporter.to_text()` from `str` to `Literal["without_comments", "merged", "with_comments"]` via new `TextStyle` type alias (#189).
 - Renamed `load_hconfig_v2_options` to `load_driver_rules` (#221).
 - Renamed `load_hconfig_v2_tags` to `load_tag_rules` (#221).

--- a/hier_config/constructors.py
+++ b/hier_config/constructors.py
@@ -10,18 +10,13 @@ from .child import HConfigChild
 from .exceptions import DriverNotFoundError, InvalidConfigError
 from .models import Dump, Platform
 from .platforms.arista_eos.driver import HConfigDriverAristaEOS
-from .platforms.arista_eos.view import HConfigViewAristaEOS
 from .platforms.cisco_ios.driver import HConfigDriverCiscoIOS
-from .platforms.cisco_ios.view import HConfigViewCiscoIOS
 from .platforms.cisco_nxos.driver import HConfigDriverCiscoNXOS
-from .platforms.cisco_nxos.view import HConfigViewCiscoNXOS
 from .platforms.cisco_xr.driver import HConfigDriverCiscoIOSXR
-from .platforms.cisco_xr.view import HConfigViewCiscoIOSXR
 from .platforms.fortinet_fortios.driver import HConfigDriverFortinetFortiOS
 from .platforms.generic.driver import HConfigDriverGeneric
 from .platforms.hp_comware5.driver import HConfigDriverHPComware5
 from .platforms.hp_procurve.driver import HConfigDriverHPProcurve
-from .platforms.hp_procurve.view import HConfigViewHPProcurve
 from .platforms.huawei_vrp.driver import HConfigDriverHuaweiVrp
 from .platforms.juniper_junos.driver import HConfigDriverJuniperJUNOS
 from .platforms.nokia_srl.driver import HConfigDriverNokiaSRL
@@ -58,23 +53,15 @@ def get_hconfig_driver(platform: Platform) -> HConfigDriverBase:
 
 
 def get_hconfig_view(config: HConfig) -> HConfigViewBase:
-    """Instantiates the appropriate HConfigView.
+    """Instantiates the HConfigView declared by the config's driver.
 
-    If you implement your own HConfigView, you will likely need to create a function like this one locally.
+    Drivers declare their view via the `view_class` attribute, so a custom
+    driver can register its own view by setting `view_class` on the subclass.
     """
-    driver = config.driver
-    if isinstance(driver, HConfigDriverAristaEOS):
-        return HConfigViewAristaEOS(config)
-    if isinstance(driver, HConfigDriverCiscoIOS):
-        return HConfigViewCiscoIOS(config)
-    if isinstance(driver, HConfigDriverCiscoNXOS):
-        return HConfigViewCiscoNXOS(config)
-    if isinstance(driver, HConfigDriverCiscoIOSXR):
-        return HConfigViewCiscoIOSXR(config)
-    if isinstance(driver, HConfigDriverHPProcurve):
-        return HConfigViewHPProcurve(config)
+    if view_class := config.driver.view_class:
+        return view_class(config)
 
-    message = f"Unsupported platform: {config.driver.__class__.__name__}"
+    message = f"No view registered for driver: {config.driver.__class__.__name__}"
     raise DriverNotFoundError(message)
 
 

--- a/hier_config/platforms/arista_eos/driver.py
+++ b/hier_config/platforms/arista_eos/driver.py
@@ -5,6 +5,7 @@ from hier_config.models import (
     PerLineSubRule,
     SectionalExitingRule,
 )
+from hier_config.platforms.arista_eos.view import HConfigViewAristaEOS
 from hier_config.platforms.driver_base import HConfigDriverBase, HConfigDriverRules
 
 
@@ -16,6 +17,8 @@ class HConfigDriverAristaEOS(HConfigDriverBase):
     and a comprehensive set of idempotency rules for interface, BGP, and OSPF
     commands.  Platform enum: ``Platform.ARISTA_EOS``.
     """
+
+    view_class = HConfigViewAristaEOS
 
     @staticmethod
     def _instantiate_rules() -> HConfigDriverRules:

--- a/hier_config/platforms/cisco_ios/driver.py
+++ b/hier_config/platforms/cisco_ios/driver.py
@@ -9,6 +9,7 @@ from hier_config.models import (
     PerLineSubRule,
     SectionalExitingRule,
 )
+from hier_config.platforms.cisco_ios.view import HConfigViewCiscoIOS
 from hier_config.platforms.driver_base import HConfigDriverBase, HConfigDriverRules
 from hier_config.root import HConfig
 
@@ -83,6 +84,8 @@ class HConfigDriverCiscoIOS(HConfigDriverBase):
     ``logging console`` negation-with replacement.  Platform enum:
     ``Platform.CISCO_IOS``.
     """
+
+    view_class = HConfigViewCiscoIOS
 
     @staticmethod
     def _instantiate_rules() -> HConfigDriverRules:

--- a/hier_config/platforms/cisco_nxos/driver.py
+++ b/hier_config/platforms/cisco_nxos/driver.py
@@ -6,6 +6,7 @@ from hier_config.models import (
     NegationDefaultWithRule,
     PerLineSubRule,
 )
+from hier_config.platforms.cisco_nxos.view import HConfigViewCiscoNXOS
 from hier_config.platforms.driver_base import HConfigDriverBase, HConfigDriverRules
 
 
@@ -17,6 +18,8 @@ class HConfigDriverCiscoNXOS(HConfigDriverBase):
     assignments, and ``secondary`` IP address avoidance in idempotency checks.
     Platform enum: ``Platform.CISCO_NXOS``.
     """
+
+    view_class = HConfigViewCiscoNXOS
 
     @staticmethod
     def _instantiate_rules() -> HConfigDriverRules:

--- a/hier_config/platforms/cisco_xr/driver.py
+++ b/hier_config/platforms/cisco_xr/driver.py
@@ -14,6 +14,7 @@ from hier_config.models import (
     SectionalOverwriteNoNegateRule,
     SectionalOverwriteRule,
 )
+from hier_config.platforms.cisco_xr.view import HConfigViewCiscoIOSXR
 from hier_config.platforms.driver_base import HConfigDriverBase, HConfigDriverRules
 
 if TYPE_CHECKING:
@@ -49,6 +50,8 @@ class HConfigDriverCiscoIOSXR(HConfigDriverBase):  # pylint: disable=too-many-in
     duplicate-child allowances inside ``route-policy`` blocks.
     Platform enum: ``Platform.CISCO_XR``.
     """
+
+    view_class = HConfigViewCiscoIOSXR
 
     def idempotent_for(
         self,

--- a/hier_config/platforms/driver_base.py
+++ b/hier_config/platforms/driver_base.py
@@ -1,6 +1,7 @@
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Iterable
 from re import Match, search
+from typing import TYPE_CHECKING, ClassVar
 
 from pydantic import Field, PositiveInt
 
@@ -24,6 +25,9 @@ from hier_config.models import (
     UnusedObjectRule,
 )
 from hier_config.root import HConfig
+
+if TYPE_CHECKING:
+    from hier_config.platforms.view_base import HConfigViewBase
 
 
 def _full_text_sub_rules_default() -> list[FullTextSubRule]:
@@ -148,6 +152,11 @@ class HConfigDriverBase(ABC):
     """Defines all hier_config options, rules, and rule checking methods.
     Override methods as needed.
     """
+
+    #: View class instantiated by ``get_hconfig_view()``. ``None`` means the
+    #: platform has no config view. Set this on a driver subclass to register
+    #: a view for a custom platform or to override a built-in view.
+    view_class: ClassVar[type["HConfigViewBase"] | None] = None
 
     def __init__(self) -> None:
         self.rules = self._instantiate_rules()

--- a/hier_config/platforms/hp_procurve/driver.py
+++ b/hier_config/platforms/hp_procurve/driver.py
@@ -11,6 +11,7 @@ from hier_config.models import (
 )
 from hier_config.platforms.driver_base import HConfigDriverBase, HConfigDriverRules
 from hier_config.platforms.hp_procurve.functions import hp_procurve_expand_range
+from hier_config.platforms.hp_procurve.view import HConfigViewHPProcurve
 from hier_config.root import HConfig
 
 
@@ -120,6 +121,8 @@ class HConfigDriverHPProcurve(HConfigDriverBase):
     port-access interface ranges, and split device-profile tagged-VLAN lists.
     Platform enum: ``Platform.HP_PROCURVE``.
     """
+
+    view_class = HConfigViewHPProcurve
 
     def idempotent_for(
         self,

--- a/tests/unit/test_constructors.py
+++ b/tests/unit/test_constructors.py
@@ -20,6 +20,12 @@ from hier_config.constructors import (
 )
 from hier_config.exceptions import DriverNotFoundError, InvalidConfigError
 from hier_config.models import Platform
+from hier_config.platforms.arista_eos.view import HConfigViewAristaEOS
+from hier_config.platforms.cisco_ios.driver import HConfigDriverCiscoIOS
+from hier_config.platforms.cisco_ios.view import HConfigViewCiscoIOS
+from hier_config.platforms.cisco_nxos.view import HConfigViewCiscoNXOS
+from hier_config.platforms.cisco_xr.view import HConfigViewCiscoIOSXR
+from hier_config.platforms.hp_procurve.view import HConfigViewHPProcurve
 from hier_config.root import HConfig
 
 
@@ -32,13 +38,57 @@ def test_get_hconfig_driver_unsupported_platform() -> None:
 
 
 def test_get_hconfig_view_unsupported_platform() -> None:
-    """Test DriverNotFoundError when platform is not supported (lines 72-73)."""
+    """Test DriverNotFoundError when the driver declares no view."""
     driver = get_hconfig_driver(Platform.FORTINET_FORTIOS)
     config = HConfig(driver=driver)
     with pytest.raises(
-        DriverNotFoundError, match="Unsupported platform: HConfigDriverFortinetFortiOS"
+        DriverNotFoundError,
+        match="No view registered for driver: HConfigDriverFortinetFortiOS",
     ):
         get_hconfig_view(config)
+
+
+def test_get_hconfig_view_dispatches_on_driver_view_class() -> None:
+    """Each built-in driver with a view resolves it via view_class (#187)."""
+    for platform, view_cls in (
+        (Platform.ARISTA_EOS, HConfigViewAristaEOS),
+        (Platform.CISCO_IOS, HConfigViewCiscoIOS),
+        (Platform.CISCO_NXOS, HConfigViewCiscoNXOS),
+        (Platform.CISCO_XR, HConfigViewCiscoIOSXR),
+        (Platform.HP_PROCURVE, HConfigViewHPProcurve),
+    ):
+        config = HConfig(driver=get_hconfig_driver(platform))
+        view = get_hconfig_view(config)
+        assert isinstance(view, view_cls)
+
+
+def test_get_hconfig_view_inherited_by_driver_subclass() -> None:
+    """A driver subclass inherits its parent's view_class (#187)."""
+
+    class ExtendedIOSDriver(HConfigDriverCiscoIOS):
+        """Driver subclass without its own view_class."""
+
+    config = HConfig(driver=ExtendedIOSDriver())
+    view = get_hconfig_view(config)
+
+    assert isinstance(view, HConfigViewCiscoIOS)
+
+
+def test_get_hconfig_view_custom_driver_view_class() -> None:
+    """A user-defined driver can supply its own view via view_class (#187, #229)."""
+
+    class CustomView(HConfigViewCiscoIOS):
+        """User-defined view."""
+
+    class CustomDriver(HConfigDriverCiscoIOS):
+        """User-defined driver registering its own view."""
+
+        view_class = CustomView
+
+    config = HConfig(driver=CustomDriver())
+    view = get_hconfig_view(config)
+
+    assert isinstance(view, CustomView)
 
 
 def test_get_hconfig_from_path() -> None:


### PR DESCRIPTION
## Summary

Closes #187 — with a re-evaluated approach. Rather than converting the `isinstance` chain in `get_hconfig_view()` to a dict (the issue's proposal), the view class now lives on the driver itself:

- `HConfigDriverBase.view_class: ClassVar[type[HConfigViewBase] | None] = None`
- The five platforms with views (`EOS`, `IOS`, `NXOS`, `XR`, `ProCurve`) declare theirs on the driver class.
- `get_hconfig_view()` is now three lines: instantiate `driver.view_class`, or raise `DriverNotFoundError` ("No view registered for driver: ...") when the platform has no view.

Why this beats dict-dispatch:
- A dict keyed by driver type breaks for driver subclasses; keeping isinstance semantics in a dict needs an ordered isinstance scan — barely better than the chain. `view_class` inherits naturally.
- It delivers the driver-side half of #229 (tie view registration to driver registration) now: a custom driver registers or overrides a view by setting one attribute. When the #226 registration system lands, registering a driver implicitly registers its view — nothing extra to design.
- No import cycles: platform view modules don't import their driver modules, and `driver_base` only imports `HConfigViewBase` under `TYPE_CHECKING`.

## Test plan

- [x] New unit tests: all five built-in views resolve via `view_class`; driver subclasses inherit the parent's view; a custom driver can register its own view; view-less drivers raise `DriverNotFoundError` with the new message.
- [x] `poetry run ./scripts/build.py lint-and-test` — all linters pass, tests pass with ≥95% coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)