### PR TITLE
Implement dot1q_mode_from_vlans() in HConfigViewBase (#228)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `HConfigBase.__len__()` now counts descendants with a generator instead of
   materializing a tuple of every node, avoiding a large temporary allocation on
   big configuration trees (#188).
+- `dot1q_mode_from_vlans()` is now a concrete static method on `HConfigViewBase`
+  implementing the same semantics as `ConfigViewInterfaceBase.dot1q_mode`
+  (`tagged_all` → `TAGGED_ALL`, tagged VLANs → `TAGGED`, untagged only →
+  `ACCESS`); the per-platform `NotImplementedError` stubs were removed (#228).
 - Changed `style` parameter on `indented_text()` and `RemediationReporter.to_text()` from `str` to `Literal["without_comments", "merged", "with_comments"]` via new `TextStyle` type alias (#189).
 - Renamed `load_hconfig_v2_options` to `load_driver_rules` (#221).
 - Renamed `load_hconfig_v2_tags` to `load_tag_rules` (#221).

--- a/hier_config/platforms/arista_eos/view.py
+++ b/hier_config/platforms/arista_eos/view.py
@@ -3,7 +3,6 @@ from ipaddress import IPv4Address, IPv4Interface
 
 from hier_config.child import HConfigChild
 from hier_config.platforms.models import (
-    InterfaceDot1qMode,
     InterfaceDuplex,
     NACHostMode,
     StackMember,
@@ -147,15 +146,6 @@ class ConfigViewInterfaceAristaEOS(ConfigViewInterfaceBase):  # noqa: PLR0904
 
 class HConfigViewAristaEOS(HConfigViewBase):
     """Full-tree config view for Arista EOS."""
-
-    def dot1q_mode_from_vlans(
-        self,
-        untagged_vlan: int | None = None,
-        tagged_vlans: tuple[int, ...] = (),
-        *,
-        tagged_all: bool = False,
-    ) -> InterfaceDot1qMode | None:
-        raise NotImplementedError
 
     @property
     def hostname(self) -> str | None:

--- a/hier_config/platforms/cisco_ios/view.py
+++ b/hier_config/platforms/cisco_ios/view.py
@@ -5,7 +5,6 @@ from re import sub
 from hier_config.child import HConfigChild
 from hier_config.platforms.functions import expand_range
 from hier_config.platforms.models import (
-    InterfaceDot1qMode,
     InterfaceDuplex,
     NACHostMode,
     StackMember,
@@ -233,15 +232,6 @@ class ConfigViewInterfaceCiscoIOS(ConfigViewInterfaceBase):  # noqa: PLR0904
 
 class HConfigViewCiscoIOS(HConfigViewBase):
     """Full-tree config view for Cisco IOS / IOS-XE."""
-
-    def dot1q_mode_from_vlans(
-        self,
-        untagged_vlan: int | None = None,
-        tagged_vlans: tuple[int, ...] = (),
-        *,
-        tagged_all: bool = False,
-    ) -> InterfaceDot1qMode | None:
-        raise NotImplementedError
 
     @property
     def hostname(self) -> str | None:

--- a/hier_config/platforms/cisco_nxos/view.py
+++ b/hier_config/platforms/cisco_nxos/view.py
@@ -4,7 +4,6 @@ from re import sub
 
 from hier_config.child import HConfigChild
 from hier_config.platforms.models import (
-    InterfaceDot1qMode,
     InterfaceDuplex,
     NACHostMode,
     StackMember,
@@ -164,15 +163,6 @@ class ConfigViewInterfaceCiscoNXOS(ConfigViewInterfaceBase):  # noqa: PLR0904
 
 class HConfigViewCiscoNXOS(HConfigViewBase):
     """Full-tree config view for Cisco NX-OS."""
-
-    def dot1q_mode_from_vlans(
-        self,
-        untagged_vlan: int | None = None,
-        tagged_vlans: tuple[int, ...] = (),
-        *,
-        tagged_all: bool = False,
-    ) -> InterfaceDot1qMode | None:
-        raise NotImplementedError
 
     @property
     def hostname(self) -> str | None:

--- a/hier_config/platforms/cisco_xr/view.py
+++ b/hier_config/platforms/cisco_xr/view.py
@@ -4,7 +4,6 @@ from re import sub
 
 from hier_config.child import HConfigChild
 from hier_config.platforms.models import (
-    InterfaceDot1qMode,
     InterfaceDuplex,
     NACHostMode,
     StackMember,
@@ -166,15 +165,6 @@ class ConfigViewInterfaceCiscoIOSXR(ConfigViewInterfaceBase):  # noqa: PLR0904
 
 class HConfigViewCiscoIOSXR(HConfigViewBase):
     """Full-tree config view for Cisco IOS XR."""
-
-    def dot1q_mode_from_vlans(
-        self,
-        untagged_vlan: int | None = None,
-        tagged_vlans: tuple[int, ...] = (),
-        *,
-        tagged_all: bool = False,
-    ) -> InterfaceDot1qMode | None:
-        raise NotImplementedError
 
     @property
     def hostname(self) -> str | None:

--- a/hier_config/platforms/hp_procurve/view.py
+++ b/hier_config/platforms/hp_procurve/view.py
@@ -6,7 +6,6 @@ from hier_config.child import HConfigChild
 from hier_config.platforms.functions import expand_range
 from hier_config.platforms.hp_procurve.functions import hp_procurve_expand_range
 from hier_config.platforms.models import (
-    InterfaceDot1qMode,
     InterfaceDuplex,
     NACHostMode,
     StackMember,
@@ -236,15 +235,6 @@ def _duplex_from_speed_duplex(speed_duplex: str) -> InterfaceDuplex:
 
 class HConfigViewHPProcurve(HConfigViewBase):
     """Full-tree config view for HP ProCurve / Aruba AOSS."""
-
-    def dot1q_mode_from_vlans(
-        self,
-        untagged_vlan: int | None = None,
-        tagged_vlans: tuple[int, ...] = (),
-        *,
-        tagged_all: bool = False,
-    ) -> InterfaceDot1qMode | None:
-        raise NotImplementedError
 
     @property
     def hostname(self) -> str | None:

--- a/hier_config/platforms/view_base.py
+++ b/hier_config/platforms/view_base.py
@@ -195,8 +195,7 @@ class HConfigViewBase(ABC):
     """Abstract base providing a structured view over a full HConfig tree.
 
     Platform-specific subclasses (e.g. ``HConfigViewCiscoIOS``) implement
-    ``interface_views`` to yield :class:`ConfigViewInterfaceBase` objects and
-    ``dot1q_mode_from_vlans`` to interpret 802.1Q mode from VLAN data.
+    ``interface_views`` to yield :class:`ConfigViewInterfaceBase` objects.
     """
 
     def __init__(self, config: HConfig) -> None:
@@ -208,15 +207,21 @@ class HConfigViewBase(ABC):
             if interface_view.is_bundle:
                 yield interface_view
 
-    @abstractmethod
+    @staticmethod
     def dot1q_mode_from_vlans(
-        self,
         untagged_vlan: int | None = None,
         tagged_vlans: tuple[int, ...] = (),
         *,
         tagged_all: bool = False,
     ) -> InterfaceDot1qMode | None:
-        pass
+        """Derive the 802.1Q mode implied by the given VLAN membership data."""
+        if tagged_all:
+            return InterfaceDot1qMode.TAGGED_ALL
+        if tagged_vlans:
+            return InterfaceDot1qMode.TAGGED
+        if untagged_vlan is not None:
+            return InterfaceDot1qMode.ACCESS
+        return None
 
     @property
     @abstractmethod

--- a/tests/unit/platforms/views/test_arista_eos.py
+++ b/tests/unit/platforms/views/test_arista_eos.py
@@ -5,15 +5,6 @@ import pytest
 from hier_config import Platform, get_hconfig, get_hconfig_view
 
 
-def test_dot1q_mode_from_vlans_not_implemented() -> None:
-    """Test dot1q_mode_from_vlans raises NotImplementedError (covers line 154)."""
-    config = get_hconfig(Platform.ARISTA_EOS)
-    view = get_hconfig_view(config)
-
-    with pytest.raises(NotImplementedError):
-        view.dot1q_mode_from_vlans(untagged_vlan=10)
-
-
 def test_hostname() -> None:
     """Test hostname returns hostname (covers lines 158-160)."""
     config = get_hconfig(Platform.ARISTA_EOS)

--- a/tests/unit/platforms/views/test_cisco_ios.py
+++ b/tests/unit/platforms/views/test_cisco_ios.py
@@ -477,15 +477,6 @@ def test_vrf_empty() -> None:
     assert not interface_view.vrf
 
 
-def test_dot1q_mode_from_vlans_not_implemented() -> None:
-    """Test dot1q_mode_from_vlans raises NotImplementedError (covers line 264)."""
-    config = get_hconfig(Platform.CISCO_IOS)
-    view = get_hconfig_view(config)
-
-    with pytest.raises(NotImplementedError):
-        view.dot1q_mode_from_vlans(untagged_vlan=10)
-
-
 def test_hostname() -> None:
     """Test hostname returns hostname (covers lines 270-272)."""
     config = get_hconfig(Platform.CISCO_IOS)

--- a/tests/unit/platforms/views/test_cisco_nxos.py
+++ b/tests/unit/platforms/views/test_cisco_nxos.py
@@ -500,15 +500,6 @@ def test_bundle_prefix() -> None:
     assert interface_view.is_bundle
 
 
-def test_dot1q_mode_from_vlans_not_implemented() -> None:
-    """Test dot1q_mode_from_vlans raises NotImplementedError (covers line 171)."""
-    config = get_hconfig(Platform.CISCO_NXOS)
-    view = get_hconfig_view(config)
-
-    with pytest.raises(NotImplementedError):
-        view.dot1q_mode_from_vlans(untagged_vlan=10)
-
-
 def test_hostname() -> None:
     """Test hostname returns hostname (covers lines 175-177)."""
     config = get_hconfig(Platform.CISCO_NXOS)

--- a/tests/unit/platforms/views/test_cisco_xr.py
+++ b/tests/unit/platforms/views/test_cisco_xr.py
@@ -489,15 +489,6 @@ def test_vrf_not_implemented() -> None:
         _ = interface_view.vrf
 
 
-def test_dot1q_mode_from_vlans_not_implemented() -> None:
-    """Test dot1q_mode_from_vlans raises NotImplementedError (covers line 173)."""
-    config = get_hconfig(Platform.CISCO_XR)
-    view = get_hconfig_view(config)
-
-    with pytest.raises(NotImplementedError):
-        view.dot1q_mode_from_vlans(untagged_vlan=10)
-
-
 def test_hostname() -> None:
     """Test hostname returns hostname (covers lines 177-179)."""
     config = get_hconfig(Platform.CISCO_XR)

--- a/tests/unit/platforms/views/test_hp_procurve.py
+++ b/tests/unit/platforms/views/test_hp_procurve.py
@@ -643,15 +643,6 @@ def test_bundle_prefix() -> None:
     assert interface_view.is_bundle
 
 
-def test_dot1q_mode_from_vlans_not_implemented() -> None:
-    """Test dot1q_mode_from_vlans raises NotImplementedError (covers line 243)."""
-    config = get_hconfig(Platform.HP_PROCURVE)
-    view = get_hconfig_view(config)
-
-    with pytest.raises(NotImplementedError):
-        view.dot1q_mode_from_vlans(untagged_vlan=10)
-
-
 def test_hostname() -> None:
     """Test hostname returns hostname (covers lines 247-249)."""
     config = get_hconfig(Platform.HP_PROCURVE)

--- a/tests/unit/platforms/views/test_view.py
+++ b/tests/unit/platforms/views/test_view.py
@@ -171,3 +171,51 @@ def test_interface_view_abstract_properties_coverage() -> None:
     assert hasattr(HConfigViewBase, "location")
     assert hasattr(HConfigViewBase, "stack_members")
     assert hasattr(HConfigViewBase, "vlans")
+
+
+def test_dot1q_mode_from_vlans_tagged_all() -> None:
+    """tagged_all wins over any other VLAN data (#228)."""
+    view = get_hconfig_view(get_hconfig(Platform.CISCO_IOS))
+    assert (
+        view.dot1q_mode_from_vlans(
+            untagged_vlan=10, tagged_vlans=(20,), tagged_all=True
+        )
+        == InterfaceDot1qMode.TAGGED_ALL
+    )
+
+
+def test_dot1q_mode_from_vlans_tagged() -> None:
+    """Explicit tagged VLANs mean TAGGED mode (#228)."""
+    view = get_hconfig_view(get_hconfig(Platform.CISCO_IOS))
+    assert (
+        view.dot1q_mode_from_vlans(tagged_vlans=(20, 30)) == InterfaceDot1qMode.TAGGED
+    )
+    assert (
+        view.dot1q_mode_from_vlans(untagged_vlan=10, tagged_vlans=(20, 30))
+        == InterfaceDot1qMode.TAGGED
+    )
+
+
+def test_dot1q_mode_from_vlans_access() -> None:
+    """An untagged VLAN alone means ACCESS mode (#228)."""
+    view = get_hconfig_view(get_hconfig(Platform.CISCO_IOS))
+    assert view.dot1q_mode_from_vlans(untagged_vlan=10) == InterfaceDot1qMode.ACCESS
+
+
+def test_dot1q_mode_from_vlans_none() -> None:
+    """No VLAN data means no 802.1Q mode (#228)."""
+    view = get_hconfig_view(get_hconfig(Platform.CISCO_IOS))
+    assert view.dot1q_mode_from_vlans() is None
+
+
+def test_dot1q_mode_from_vlans_available_on_all_views() -> None:
+    """Every platform view shares the base implementation (#228)."""
+    for platform in (
+        Platform.ARISTA_EOS,
+        Platform.CISCO_IOS,
+        Platform.CISCO_NXOS,
+        Platform.CISCO_XR,
+        Platform.HP_PROCURVE,
+    ):
+        view = get_hconfig_view(get_hconfig(platform))
+        assert view.dot1q_mode_from_vlans(untagged_vlan=1) == InterfaceDot1qMode.ACCESS


### PR DESCRIPTION
## Summary

Closes #228. Of the issue's two options (implement on IOS/ProCurve as reference, or drop from the base), this takes a third path that's simpler than both: the mode derivation is pure data interpretation with no platform-specific behavior — it's the same logic `ConfigViewInterfaceBase.dot1q_mode` already ships (`tagged_all` → `TAGGED_ALL`, tagged VLANs → `TAGGED`, untagged only → `ACCESS`, else `None`). So it's now implemented **once** as a concrete static method on `HConfigViewBase`, working uniformly on every platform view, and the five `NotImplementedError` stubs plus their raise-only tests are deleted.

## Test plan

- [x] New unit tests cover all four branches and verify the method works on all five platform views.
- [x] `poetry run ./scripts/build.py lint-and-test` — all linters pass, tests pass with ≥95% coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)