### PR TITLE
Skip probe allocation for matched leaves in _remediation_right() (#191)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Remediation right pass no longer allocates a probe `HConfigChild` for matched
+  leaf lines, where the delta subtree is provably empty. Speeds up remediation
+  of mostly-identical configs by ~30% and resolves the long-standing TODO in
+  `_remediation_right()` (#191).
 - `HConfigBase.__len__()` now counts descendants with a generator instead of
   materializing a tuple of every node, avoiding a large temporary allocation on
   big configuration trees (#188).

--- a/hier_config/base.py
+++ b/hier_config/base.py
@@ -479,8 +479,10 @@ class HConfigBase(ABC):  # noqa: PLR0904
                 if self_child.use_sectional_overwrite_without_negation():
                     self_child.overwrite_with(target_child, delta, negate=False)
                     continue
-                # This creates a new HConfigChild object just in case there are some delta children.
-                # This is not very efficient, think of a way to not do this.
+                # Matched leaves can never produce delta lines - neither pass
+                # has children to visit - so skip the subtree allocation (#191).
+                if not (self_child.children or target_child.children):
+                    continue
                 subtree = delta.instantiate_child(target_child.text)
                 self_child._remediation(target_child, subtree)  # noqa: SLF001
                 if subtree.children:


### PR DESCRIPTION
## Summary

Closes #191. Of the issue's three approaches, this applies "defer child creation" precisely where emptiness is provable: when a target child matches a running child and **neither side has children**, the left pass (negate missing) and right pass (add new) both have nothing to visit, so the probe subtree is guaranteed empty. An O(1) guard skips the `instantiate_child()` allocation and the recursive call for that case.

Matched leaves dominate real-world remediation (most of a config is unchanged lines), so the win is measurable. The other proposed approaches were evaluated and rejected: a sentinel/proxy object would have to intercept every mutation path of the recursion, and add-then-remove (what `_difference()` does) is strictly more work than the current conditional append.

## Benchmarks (best of 3, ~10k-line configs)

| Benchmark | Before | After |
|---|---|---|
| Remediation, 10% diff | 0.0273s | 0.0183s (~33% faster) |
| Remediation, 100% diff | 0.0539s | 0.0460s (~15% faster) |
| Remediation, completely different | 0.0324s | 0.0328s (unchanged — no matched leaves) |

## Test plan

- [x] Behavior is unchanged by construction (the skipped recursion provably contributes nothing); full suite passes with ≥95% coverage.
- [x] `poetry run ./scripts/build.py lint-and-test` — all linters pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)