### PR TITLE
v4: close out all remaining v4 issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Interface view capability mixins (#227): `ConfigViewInterfaceBase` now
+  carries only the core interface properties (`name`, `description`,
+  `enabled`, `ipv4_interfaces`, `is_loopback`, `is_svi`, `number`,
+  `port_number`, `vrf`, plus concrete helpers `ipv4_interface`,
+  `is_subinterface`, `parent_name`, `subinterface_number`). Optional
+  capabilities moved to new ABC mixins in
+  `hier_config.platforms.view_base` — `InterfaceBundleViewMixin`,
+  `InterfaceVlanViewMixin` (owns the concrete `dot1q_mode`),
+  `InterfaceNACViewMixin`, and `InterfacePhysicalViewMixin` (owns a concrete
+  `module_number`) — all exported from the package root. Platform views
+  inherit only the mixins they support, and users check capability with
+  `isinstance(view, InterfaceVlanViewMixin)` instead of catching
+  `NotImplementedError`. `HConfigViewBase.bundle_interface_views` and
+  `module_numbers` are now capability-aware.
+- Completed the Arista EOS, Cisco NX-OS, and Cisco IOS XR config views (#230):
+  all three now implement the full core interface property set plus the VLAN
+  and bundle mixins (EOS/NX-OS switchport, trunk, and channel-group parsing;
+  XR `encapsulation dot1q`, `ipv4 address x.x.x.x/nn | x.x.x.x y.y.y.y`, and
+  `Bundle-Ether`/`bundle id <N>` parsing), along with the root view
+  properties `interface_names_mentioned`, `ipv4_default_gw`, `location`,
+  `stack_members`, and `vlans`.
+- Cisco IOS `bundle_member_interfaces` and HP ProCurve `bundle_id` are now
+  implemented (previously `NotImplementedError` stubs) (#230).
+
 - Driver registration system (#226): `register_driver()`, `unregister_driver()`,
   and `get_registered_platforms()`. Custom platforms are registered by string
   name (case-insensitive) and work anywhere a `Platform` is accepted; built-in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,21 +11,49 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Driver registration system (#226): `register_driver()`, `unregister_driver()`,
+  and `get_registered_platforms()`. Custom platforms are registered by string
+  name (case-insensitive) and work anywhere a `Platform` is accepted; built-in
+  drivers can be overridden and later restored. `HConfigDriverBase` and
+  `HConfigDriverRules` are now exported as public API.
+- View registration follows driver registration (#187, #229): drivers declare
+  their view via the `view_class` attribute, `get_hconfig_view()` resolves it
+  from the driver, and registered custom drivers get views without extra
+  wiring.
+- `HConfig.from_text()`, `HConfig.from_lines()`, and `HConfig.from_dump()`
+  classmethod constructors (#218).
+- `remediation_transform_callbacks` on `HConfigDriverRules` (#180): drivers can
+  transform the remediation config after diff computation, before it is
+  returned by `WorkflowRemediation.remediation_config`.
+- `RemediationPlugin` ABC (`hier_config.plugins`) and a `plugins` parameter on
+  `WorkflowRemediation` (#181): users can package custom remediation
+  transforms outside hier_config and apply them per workflow.
+- Root-level duplicate children (#215): a `ParentAllowsDuplicateChildRule`
+  with empty `match_rules` now applies to the root `HConfig`.
+- Structured config format detection (#232): `HConfig.from_text()` rejects XML
+  and JSON input with a clear `InvalidConfigError`; set-style configs remain
+  natively supported via the JunOS, VyOS, and Nokia SRL driver preprocessors.
+  Full XML/JSON ingestion is additive, post-4.0 roadmap work.
 - Custom exception hierarchy: `HierConfigError` base, `DriverNotFoundError`,
   `InvalidConfigError`, `IncompatibleDriverError` (#219). `DuplicateChildError`
   reparented under `HierConfigError`.
-- `view_class` attribute on `HConfigDriverBase`: drivers now declare their own
-  config view, so custom drivers can register or override views (#187, #229).
 
 ### Changed
 
+- Negation rules are unified into a single `NegationRule` model with a
+  `NegationStrategy` enum — `REPLACE` (was `negate_with`), `DEFAULT` (was
+  `negation_default_when`), and `REGEX_SUB` (was `negation_sub`) — in one
+  ordered `negation` list on `HConfigDriverRules`; first matching rule wins
+  (#220). `load_driver_rules()` still accepts the v2 dict keys.
+- Tree algorithms (difference, remediation, future, with_tags) extracted from
+  `HConfigBase` into `hier_config.tree_algorithms` as standalone functions;
+  `HConfigBase` retains thin delegating methods (#217).
+- `_load_from_string_lines()` refactored into a stateful `_ConfigTextLoader`
+  parser class with focused banner/normalize/hierarchy methods (#186).
 - Remediation right pass no longer allocates a probe `HConfigChild` for matched
   leaf lines, where the delta subtree is provably empty. Speeds up remediation
   of mostly-identical configs by ~30% and resolves the long-standing TODO in
   `_remediation_right()` (#191).
-- `get_hconfig_view()` resolves the view from the driver's `view_class`
-  attribute instead of a hardcoded `isinstance` chain; drivers without a view
-  raise `DriverNotFoundError` with a `No view registered for driver` message (#187).
 - `HConfigBase.__len__()` now counts descendants with a generator instead of
   materializing a tuple of every node, avoiding a large temporary allocation on
   big configuration trees (#188).
@@ -44,6 +72,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+- `get_hconfig()`, `get_hconfig_fast_load()`, `get_hconfig_from_dump()`, and
+  `get_hconfig_fast_generic_load()` — replaced by the `HConfig.from_*`
+  classmethods (#218). `get_hconfig_driver()` and `get_hconfig_view()` remain.
+- `NegationDefaultWithRule`, `NegationDefaultWhenRule`, and `NegationSubRule`
+  models and their `HConfigDriverRules` fields (#220).
+- `HConfigChild.use_default_for_negation()` — subsumed by the unified
+  negation rule evaluation (#220).
 - Removed `HCONFIG_PLATFORM_V2_TO_V3_MAPPING` constant (#221).
 - Removed `hconfig_v2_os_v3_platform_mapper()` function (#221).
 - Removed `hconfig_v3_platform_v2_os_mapper()` function (#221).
@@ -55,6 +90,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `IndexError` on degenerate single-word commands, and documented that dropping
   parameters when negating (`set description "Port 1"` → `unset description`) is
   intentional FortiOS semantics (#225).
+
+### v4 design decisions
+
+- `HConfig.remediation()` stays public (#223): it was deliberately renamed
+  from `config_to_get_to()` in #216 as the tree-level primitive;
+  `WorkflowRemediation` remains the recommended workflow API and already
+  validates driver compatibility (`IncompatibleDriverError`).
+- Drivers remain declaratively-configured with sanctioned imperative
+  extension points (#222): #220 removed the negation-related override needs;
+  `idempotent_for()`, `negate_with()`, and `config_preprocessor()` stay
+  overridable for logic that rules cannot express.
+- Config trees stay mutable (#224): full immutability would break the
+  callback/plugin mutation model for marginal benefit. The remediation
+  algorithms are guaranteed (and now tested) not to mutate their input
+  configs.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   transforms outside hier_config and apply them per workflow.
 - Root-level duplicate children (#215): a `ParentAllowsDuplicateChildRule`
   with empty `match_rules` now applies to the root `HConfig`.
+- `NegationRule` validates its per-strategy fields at construction time:
+  `REPLACE` requires `use` and `REGEX_SUB` requires `search` (#220).
 - Structured config format detection (#232): `HConfig.from_text()` rejects XML
   and JSON input with a clear `InvalidConfigError`; set-style configs remain
   natively supported via the JunOS, VyOS, and Nokia SRL driver preprocessors.
@@ -110,6 +112,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `port_number` no longer raises `ValueError` on slash-less interface names
+  such as `Port-channel10`, `port-channel10`, `Bundle-Ether10`, and `Trk1`;
+  it now derives from the letter-stripped `number` property on all platform
+  views (IOS, EOS, NX-OS, XR, ProCurve).
 - Fortinet FortiOS: hardened `swap_negation()` and `idempotent_for()` against
   `IndexError` on degenerate single-word commands, and documented that dropping
   parameters when negating (`set description "Port 1"` → `unset description`) is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Shared interface-view logic hoisted out of the five platform view files into
+  concrete defaults on `ConfigViewInterfaceBase`, the capability mixins
+  (parameterized by `_bundle_membership_prefix` / `_encapsulation_prefix`
+  hooks), `HConfigViewBase`, and a new `parse_ipv4_interface()` helper in
+  `hier_config.platforms.functions` — removing ~390 duplicated lines (#227).
+- `WorkflowRemediation(plugins=...)` accepts any `Callable[[HConfig], None]`;
+  `RemediationPlugin` instances are now callable (#181).
+- The structured-format guard (#232) also covers the raw-`str` form of
+  `HConfig.from_lines()`, inspects only a bounded prefix of the input, and
+  `from_lines()`/`from_dump()` no longer route empty-tree construction through
+  the full text-parsing pipeline.
+- `HConfig` calls the `tree_algorithms` functions directly; the pass-through
+  delegation shims on `HConfigBase` were removed (#217).
 - Negation rules are unified into a single `NegationRule` model with a
   `NegationStrategy` enum — `REPLACE` (was `negate_with`), `DEFAULT` (was
   `negation_default_when`), and `REGEX_SUB` (was `negation_sub`) — in one

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,14 +76,15 @@ Each platform driver subclasses `HConfigDriverBase` (driver_base.py) and overrid
 - **MatchRule** supports: `equals`, `startswith`, `endswith`, `contains`, `re_search`. Multiple fields = AND logic.
 - `is_lineage_match()` on `HConfigChild` compares the full ancestry path against a tuple of MatchRules.
 
-Key rule types: `SectionalExitingRule`, `IdempotentCommandsRule`, `PerLineSubRule`, `NegationDefaultWithRule`, `OrderingRule`, `ParentAllowsDuplicateChildRule`, `IndentAdjustRule`.
+Key rule types: `SectionalExitingRule`, `IdempotentCommandsRule`, `PerLineSubRule`, `NegationRule` (strategy enum: REPLACE/DEFAULT/REGEX_SUB), `OrderingRule`, `ParentAllowsDuplicateChildRule`, `IndentAdjustRule`.
 
-Platform drivers: `CISCO_IOS`, `CISCO_XR`, `CISCO_NXOS`, `ARISTA_EOS`, `FORTINET_FORTIOS`, `HP_PROCURVE`, `HP_COMWARE5`, `JUNIPER_JUNOS`, `VYOS`, `GENERIC`.
+Platform drivers: `CISCO_IOS`, `CISCO_XR`, `CISCO_NXOS`, `ARISTA_EOS`, `FORTINET_FORTIOS`, `HP_PROCURVE`, `HP_COMWARE5`, `HUAWEI_VRP`, `JUNIPER_JUNOS`, `NOKIA_SRL`, `VYOS`, `GENERIC`. Custom drivers register via `register_driver()` (registry.py).
 
 ### Workflow Layer
 
 - `WorkflowRemediation` (workflows.py) — primary API: `remediation_config` and `rollback_config` properties.
-- Constructor functions in `constructors.py`: `get_hconfig()`, `get_hconfig_fast_load()`, `get_hconfig_driver()`.
+- Constructors: `HConfig.from_text()`, `HConfig.from_lines()`, `HConfig.from_dump()` classmethods (implementations in `constructors.py`); `get_hconfig_driver()` (registry.py) and `get_hconfig_view()` remain standalone.
+- Tree algorithms (diff/remediation/future) live in `tree_algorithms.py`; `HConfigBase` delegates to them.
 
 ### Adding a New Driver Rule Type
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ pip install hier-config
 ### Step 1: Import Required Classes
 
 ```python
-from hier_config import WorkflowRemediation, get_hconfig, Platform
+from hier_config import WorkflowRemediation, HConfig, Platform
 from hier_config.utils import read_text_from_file
 ```
 
@@ -70,8 +70,8 @@ generated_config_text = read_text_from_file("./tests/fixtures/generated_config.c
 Specify the device platform (e.g., `Platform.CISCO_IOS`):
 
 ```python
-running_config = get_hconfig(Platform.CISCO_IOS, running_config_text)
-generated_config = get_hconfig(Platform.CISCO_IOS, generated_config_text)
+running_config = HConfig.from_text(Platform.CISCO_IOS, running_config_text)
+generated_config = HConfig.from_text(Platform.CISCO_IOS, generated_config_text)
 ```
 
 ### Step 4: Initialize WorkflowRemediation

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -4,11 +4,27 @@ Auto-generated reference documentation for the `hier_config` public API.
 
 ---
 
-## Constructor Functions
+## Constructors
 
-::: hier_config.get_hconfig
+::: hier_config.HConfig.from_text
+
+::: hier_config.HConfig.from_lines
+
+::: hier_config.HConfig.from_dump
 
 ::: hier_config.get_hconfig_driver
+
+::: hier_config.get_hconfig_view
+
+---
+
+## Driver Registry
+
+::: hier_config.register_driver
+
+::: hier_config.unregister_driver
+
+::: hier_config.get_registered_platforms
 
 ---
 
@@ -54,9 +70,9 @@ Auto-generated reference documentation for the `hier_config` public API.
 
 ::: hier_config.models.IdempotentCommandsRule
 
-::: hier_config.models.NegationDefaultWithRule
+::: hier_config.models.NegationRule
 
-::: hier_config.models.NegationDefaultWhenRule
+::: hier_config.models.NegationStrategy
 
 ::: hier_config.models.SectionalExitingRule
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -157,7 +157,8 @@ See [Future Config](future-config.md) for known limitations.
 The view layer (`hier_config/platforms/view_base.py` and platform-specific `view.py` files) provides structured, typed access to configuration elements without modifying the underlying tree.
 
 - `HConfigViewBase` — abstract base; subclasses implement `interface_views` and `dot1q_mode_from_vlans`.
-- `ConfigViewInterfaceBase` — abstract base for per-interface views; exposes properties like `ip_address`, `native_vlan`, `tagged_vlans`, `description`, `duplex`, `bundle_id`.
+- `ConfigViewInterfaceBase` — abstract base for per-interface views; exposes core properties like `name`, `description`, `enabled`, `ipv4_interfaces`, and `vrf`.
+- Optional capability mixins — `InterfaceBundleViewMixin` (`bundle_id`, `bundle_member_interfaces`, ...), `InterfaceVlanViewMixin` (`native_vlan`, `tagged_vlans`, `dot1q_mode`, ...), `InterfaceNACViewMixin` (`has_nac`, `nac_host_mode`, ...), and `InterfacePhysicalViewMixin` (`duplex`, `speed`, `poe`, `module_number`). Platform views inherit only the mixins they support; check capability with `isinstance(view, InterfaceVlanViewMixin)`.
 
 Instantiate a view with:
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -31,9 +31,9 @@ The tree layer lives in `hier_config/base.py`, `hier_config/root.py`, `hier_conf
 Create an `HConfig` object via the constructor function:
 
 ```python
-from hier_config import get_hconfig, Platform
+from hier_config import HConfig, Platform
 
-hconfig = get_hconfig(Platform.CISCO_IOS, config_text)
+hconfig = HConfig.from_text(Platform.CISCO_IOS, config_text)
 ```
 
 ### `HConfigChild` (tree node)
@@ -84,8 +84,7 @@ A frozen Pydantic model holding lists of typed rule objects:
 
 | Field | Rule type | Effect |
 |-------|-----------|--------|
-| `negate_with` | `NegationDefaultWithRule` | Replace negation with a fixed command |
-| `negation_default_when` | `NegationDefaultWhenRule` | Use `default` form instead of `no` |
+| `negation` | `NegationRule` | Unified negation: REPLACE a fixed command, use the DEFAULT form, or REGEX_SUB the negated text (#220) |
 | `sectional_exiting` | `SectionalExitingRule` | Emit an exit token at end of section (optionally at parent indent level) |
 | `sectional_overwrite` | `SectionalOverwriteRule` | Negate + re-create whole section |
 | `sectional_overwrite_no_negate` | `SectionalOverwriteNoNegateRule` | Re-create without prior negation |

--- a/docs/config-view.md
+++ b/docs/config-view.md
@@ -114,7 +114,7 @@ The framework uses a combination of abstract base classes (e.g., `ConfigViewInte
 Assume we have a Cisco IOS configuration file as a string.
 
 ```python
-from hier_config import Platform, get_hconfig
+from hier_config import Platform, HConfig
 
 
 raw_config = """
@@ -129,7 +129,7 @@ vlan 10
  name DATA
 """
 
-hconfig = get_hconfig(Platform.CISCO_IOS, raw_config)
+hconfig = HConfig.from_text(Platform.CISCO_IOS, raw_config)
 ```
 
 ### Step 2: Create Config View
@@ -169,7 +169,7 @@ for vlan in config_view.vlans:
 Assume we have a Cisco IOS configuration file as a string.
 
 ```python
-from hier_config import Platform, get_hconfig
+from hier_config import Platform, HConfig
 
 
 raw_config = """
@@ -186,7 +186,7 @@ interface GigabitEthernet0/2
 !
 """
 
-hconfig = get_hconfig(Platform.CISCO_IOS, raw_config)
+hconfig = HConfig.from_text(Platform.CISCO_IOS, raw_config)
 ```
 
 ### Step 2: Create Config View and Access Interface Views

--- a/docs/config-view.md
+++ b/docs/config-view.md
@@ -4,6 +4,24 @@ A Config View is an abstraction layer for network device configurations. It prov
 
 The framework uses a combination of abstract base classes (e.g., `ConfigViewInterfaceBase`, `HConfigViewBase`) and platform-specific implementations (e.g., `ConfigViewInterfaceCiscoIOS`, `HConfigViewCiscoIOS`) to provide a unified interface for interacting with configurations while accounting for the unique syntax and semantics of each vendor or platform.
 
+`ConfigViewInterfaceBase` carries only the core interface properties that every platform supports. Optional capabilities are modeled as mixins that platform views inherit when they genuinely support them:
+
+- `InterfaceBundleViewMixin` — bundle / port-channel properties (`bundle_id`, `bundle_name`, `bundle_member_interfaces`, `is_bundle`).
+- `InterfaceVlanViewMixin` — 802.1Q VLAN properties (`native_vlan`, `tagged_vlans`, `tagged_all`, `dot1q_mode`).
+- `InterfaceNACViewMixin` — NAC properties (`has_nac`, `nac_host_mode`, `nac_mab_first`, ...).
+- `InterfacePhysicalViewMixin` — physical-layer properties (`duplex`, `speed`, `poe`, `module_number`).
+
+Check whether a platform supports a capability with `isinstance()`:
+
+```python
+from hier_config import InterfaceVlanViewMixin
+
+if isinstance(interface_view, InterfaceVlanViewMixin):
+    print(interface_view.native_vlan)
+```
+
+Current platform capabilities: Cisco IOS and HP ProCurve inherit all four mixins; Arista EOS, Cisco NX-OS, and Cisco IOS XR inherit the bundle and VLAN mixins.
+
 ## Why Use Config Views?
 
 1. **Vendor Abstraction:** Network devices from different vendors (Cisco, Arista, Juniper, etc.) have varied configuration formats. Config Views standardize access, making it easier to work across platforms.

--- a/docs/custom-workflows.md
+++ b/docs/custom-workflows.md
@@ -11,7 +11,7 @@ Certain scenarios demand remediation strategies that go beyond the standard [neg
 Start by importing the necessary modules and loading the running and intended configurations for comparison.
 
 ```python
-from hier_config import WorkflowRemediation, get_hconfig, Platform
+from hier_config import WorkflowRemediation, HConfig, Platform
 from hier_config.utils import read_text_from_file
 ```
 
@@ -33,8 +33,8 @@ Initialize the WorkflowRemediation object for a Cisco IOS platform:
 
 ```python
 wfr = WorkflowRemediation(
-        running_config=get_hconfig(Platform.CISCO_IOS, running_config),
-        generated_config=get_hconfig(Platform.CISCO_IOS, generated_config)
+        running_config=HConfig.from_text(Platform.CISCO_IOS, running_config),
+        generated_config=HConfig.from_text(Platform.CISCO_IOS, generated_config)
 )
 ```
 This object manages the remediation workflow between the running and generated configurations.

--- a/docs/drivers.md
+++ b/docs/drivers.md
@@ -57,7 +57,7 @@ driver = get_hconfig_driver(Platform.CISCO_IOS)
 Cisco IOS is hier_config's primary reference platform and the most thoroughly tested driver. The `CISCO_IOS` driver ships with a comprehensive set of rules covering common IOS configuration patterns:
 
 - **[Idempotent commands](glossary.md#idempotent-command)**: `hostname`, `ip address`, `ip access-group`, `description`, `banner`, and many others are treated as last-write-wins — applying the same command twice leaves only the final value in place.
-- **Negation**: standard `no ` [negation prefix](glossary.md#negation-prefix). Several commands (such as `logging console`) use [`NegationDefaultWithRule`](glossary.md#negation-negate-with) overrides to emit a specific reset form.
+- **Negation**: standard `no ` [negation prefix](glossary.md#negation-prefix). Several commands (such as `logging console`) use REPLACE-strategy [`NegationRule`](glossary.md#negation-negate-with) overrides to emit a specific reset form.
 - **[Sectional exiting](glossary.md#sectional-exiting)**: BGP `peer-policy` and `peer-session` blocks require `exit-peer-policy` and `exit-peer-session` closure tokens.
 - **Per-line substitutions**: strips `Building configuration…` banners and timestamp headers.
 - **VLAN id list splitting**: IOS can render unnamed VLANs collapsed onto a single comma/range line (e.g. `vlan 69,381`, `vlan 10-12`), depending on how the VLANs were created — named VLANs always get their own block, and the grouping shifts as VLANs are named or unnamed. When such a collapsed line is present, a post-load callback splits it into one `vlan <id>` block each so the VLANs diff block-to-block against an intended config that lists them separately — avoiding a destructive `no vlan 69,381`.
@@ -114,7 +114,7 @@ driver = get_hconfig_driver(Platform.CISCO_XR)
 Cisco NX-OS is similar to IOS in CLI structure but has NX-OS-specific idempotency requirements:
 
 - **TCAM region idempotency**: `hardware access-list tcam region` commands are treated as last-write-wins.
-- Some BGP commands use different negation forms; the driver includes `NegationDefaultWithRule` entries for affected commands.
+- Some BGP commands use different negation forms; the driver includes REPLACE-strategy `NegationRule` entries for affected commands.
 - [Negation prefix](glossary.md#negation-prefix): `no ` (default).
 
 Platform enum: `Platform.CISCO_NXOS`
@@ -166,10 +166,10 @@ driver = get_hconfig_driver(Platform.NOKIA_SRL)
 **Remediation example:**
 
 ```python
-from hier_config import WorkflowRemediation, get_hconfig, Platform
+from hier_config import WorkflowRemediation, HConfig, Platform
 
-running = get_hconfig(Platform.NOKIA_SRL, running_text)
-intended = get_hconfig(Platform.NOKIA_SRL, intended_text)
+running = HConfig.from_text(Platform.NOKIA_SRL, running_text)
+intended = HConfig.from_text(Platform.NOKIA_SRL, intended_text)
 workflow = WorkflowRemediation(running, intended)
 
 for line in workflow.remediation_config.all_children_sorted():
@@ -238,10 +238,10 @@ driver = get_hconfig_driver(Platform.HP_PROCURVE)
 **Remediation example:**
 
 ```python
-from hier_config import WorkflowRemediation, get_hconfig, Platform
+from hier_config import WorkflowRemediation, HConfig, Platform
 
-running = get_hconfig(Platform.HP_PROCURVE, running_text)
-intended = get_hconfig(Platform.HP_PROCURVE, intended_text)
+running = HConfig.from_text(Platform.HP_PROCURVE, running_text)
+intended = HConfig.from_text(Platform.HP_PROCURVE, intended_text)
 workflow = WorkflowRemediation(running, intended)
 
 for line in workflow.remediation_config.all_children_sorted():
@@ -267,10 +267,10 @@ driver = get_hconfig_driver(Platform.HP_COMWARE5)
 **Remediation example:**
 
 ```python
-from hier_config import WorkflowRemediation, get_hconfig, Platform
+from hier_config import WorkflowRemediation, HConfig, Platform
 
-running = get_hconfig(Platform.HP_COMWARE5, running_text)
-intended = get_hconfig(Platform.HP_COMWARE5, intended_text)
+running = HConfig.from_text(Platform.HP_COMWARE5, running_text)
+intended = HConfig.from_text(Platform.HP_COMWARE5, intended_text)
 workflow = WorkflowRemediation(running, intended)
 
 for line in workflow.remediation_config.all_children_sorted():
@@ -299,10 +299,10 @@ driver = get_hconfig_driver(Platform.HUAWEI_VRP)
 **Remediation example:**
 
 ```python
-from hier_config import WorkflowRemediation, get_hconfig, Platform
+from hier_config import WorkflowRemediation, HConfig, Platform
 
-running = get_hconfig(Platform.HUAWEI_VRP, running_text)
-intended = get_hconfig(Platform.HUAWEI_VRP, intended_text)
+running = HConfig.from_text(Platform.HUAWEI_VRP, running_text)
+intended = HConfig.from_text(Platform.HUAWEI_VRP, intended_text)
 workflow = WorkflowRemediation(running, intended)
 
 for line in workflow.remediation_config.all_children_sorted():
@@ -346,13 +346,11 @@ In Hier Config, the rules within a driver are organized into sections, each targ
 
 **Purpose**: Define how to negate commands or reset them to a default state.
 
-- **Models**:
-  - **`NegationDefaultWithRule`**:
+- **Model**: **`NegationRule`** — a single unified model with a `NegationStrategy` enum. Rules are evaluated in list order; the first matching rule wins.
     - `match_rules`: A tuple of `MatchRule` objects defining the conditions under which the rule applies.
-    - `use`: The text to use as the negation command.
-
-  - **`NegationDefaultWhenRule`**:
-    - `match_rules`: A tuple of `MatchRule` objects for matching conditions where negation is default.
+    - `strategy`: `NegationStrategy.REPLACE` (replace the command with the fixed string in `use`), `NegationStrategy.DEFAULT` (rewrite the command to its `default` form), or `NegationStrategy.REGEX_SUB` (apply `re.sub(search, replace, ...)` to the already-negated text).
+    - `use`: The replacement negation command (REPLACE strategy).
+    - `search` / `replace`: The regex substitution (REGEX_SUB strategy).
 
 ---
 
@@ -512,7 +510,8 @@ In this approach, you create a new class that subclasses the base Cisco IOS driv
 ```python
 from hier_config.models import (
     MatchRule,
-    NegationDefaultWithRule,
+    NegationRule,
+    NegationStrategy,
     SectionalExitingRule,
     OrderingRule,
     PerLineSubRule,
@@ -528,10 +527,11 @@ class ExtendedHConfigDriverCiscoIOS(HConfigDriverCiscoIOS):
         base_rules = HConfigDriverCiscoIOS._instantiate_rules()
 
         # Extend negation rules
-        base_rules.negate_with.append(
-            NegationDefaultWithRule(
+        base_rules.negation.append(
+            NegationRule(
+                strategy=NegationStrategy.REPLACE,
                 match_rules=(MatchRule(startswith="ip route "),),
-                use="no ip route"
+                use="no ip route",
             )
         )
 
@@ -600,7 +600,8 @@ If you already have the driver instantiated, you can modify its rules dynamicall
 from hier_config import get_hconfig_driver, Platform
 from hier_config.models import (
     MatchRule,
-    NegationDefaultWithRule,
+    NegationRule,
+    NegationStrategy,
     SectionalExitingRule,
     OrderingRule,
     PerLineSubRule,
@@ -611,10 +612,11 @@ from hier_config.models import (
 driver = get_hconfig_driver(Platform.CISCO_IOS)
 
 # Dynamically extend negation rules
-driver.rules.negate_with.append(
-    NegationDefaultWithRule(
+driver.rules.negation.append(
+    NegationRule(
+        strategy=NegationStrategy.REPLACE,
         match_rules=(MatchRule(startswith="ip route "),),
-        use="no ip route"
+        use="no ip route",
     )
 )
 
@@ -677,7 +679,7 @@ You can add unused object rules dynamically or via `load_driver_rules`:
 #### Dynamic Extension
 
 ```python
-from hier_config import get_hconfig, get_hconfig_driver, Platform
+from hier_config import HConfig, get_hconfig_driver, Platform
 from hier_config.models import MatchRule, ReferenceLocation, UnusedObjectRule
 
 driver = get_hconfig_driver(Platform.CISCO_XR)
@@ -696,7 +698,7 @@ driver.rules.unused_objects.append(
     )
 )
 
-config = get_hconfig(driver, running_config_text)
+config = HConfig.from_text(driver, running_config_text)
 for unused in config.unused_objects():
     print(f"Unused: {unused.text}")
 ```
@@ -704,7 +706,7 @@ for unused in config.unused_objects():
 #### Via `load_driver_rules`
 
 ```python
-from hier_config import get_hconfig, Platform
+from hier_config import HConfig, Platform
 from hier_config.utils import load_driver_rules
 
 options = {
@@ -722,7 +724,7 @@ options = {
     ],
 }
 driver = load_driver_rules(options, Platform.CISCO_XR)
-config = get_hconfig(driver, running_config_text)
+config = HConfig.from_text(driver, running_config_text)
 
 for unused in config.unused_objects():
     print(f"Unused: {unused.text}")
@@ -736,23 +738,64 @@ Each `UnusedObjectRule` requires:
 
 ### Example 4: Adding Negation Substitution
 
-Some platforms require negation commands to be truncated or transformed. Use `NegationSubRule` for regex-based negation transformations:
+Some platforms require negation commands to be truncated or transformed. Use a REGEX_SUB-strategy `NegationRule` for regex-based negation transformations:
 
 ```python
 from hier_config import get_hconfig_driver, Platform
-from hier_config.models import MatchRule, NegationSubRule
+from hier_config.models import MatchRule, NegationRule, NegationStrategy
 
 driver = get_hconfig_driver(Platform.CISCO_NXOS)
 
 # Truncate SNMP user negation after the username
-driver.rules.negation_sub.append(
-    NegationSubRule(
+driver.rules.negation.append(
+    NegationRule(
+        strategy=NegationStrategy.REGEX_SUB,
         match_rules=(MatchRule(startswith="snmp-server user "),),
         search=r"(no snmp-server user \S+).*",
         replace=r"\1",
     )
 )
 ```
+
+## Registering a Custom Driver
+
+Custom drivers (and overrides of built-in drivers) plug into the standard API
+via the driver registry:
+
+```python
+from hier_config import (
+    HConfig,
+    HConfigDriverBase,
+    HConfigDriverRules,
+    Platform,
+    register_driver,
+    unregister_driver,
+)
+
+
+class MyNOSDriver(HConfigDriverBase):
+    """Driver for a custom network operating system."""
+
+    @staticmethod
+    def _instantiate_rules() -> HConfigDriverRules:
+        return HConfigDriverRules()
+
+
+# Register a new platform by name (case-insensitive)
+register_driver("MY_NOS", MyNOSDriver)
+config = HConfig.from_text("MY_NOS", config_text)
+
+# Override a built-in driver
+register_driver(Platform.CISCO_IOS, MyCustomIOSDriver)
+
+# Restore the built-in default
+unregister_driver(Platform.CISCO_IOS)
+```
+
+If the driver class sets a `view_class`, `get_hconfig_view()` resolves the
+view automatically for the registered platform.
+
+---
 
 ## Creating a Custom Driver
 
@@ -782,7 +825,8 @@ Begin by subclassing `HConfigDriverBase` to define a new driver.
 from hier_config.platforms.driver_base import HConfigDriverBase, HConfigDriverRules
 from hier_config.models import (
     MatchRule,
-    NegationDefaultWithRule,
+    NegationRule,
+    NegationStrategy,
     SectionalExitingRule,
     OrderingRule,
     PerLineSubRule,
@@ -797,8 +841,9 @@ class CustomHConfigDriver(HConfigDriverBase):
     def _instantiate_rules() -> HConfigDriverRules:
         """Define the rules for this custom driver."""
         return HConfigDriverRules(
-            negate_with=[
-                NegationDefaultWithRule(
+            negation=[
+                NegationRule(
+                    strategy=NegationStrategy.REPLACE,
                     match_rules=(MatchRule(startswith="ip route "),),
                     use="no ip route"
                 )
@@ -884,7 +929,7 @@ class CustomPlatform(str, Enum):
 
 ```python
 from .custom_platform import CustomPlatform
-from hier_config import get_hconfig
+from hier_config import HConfig
 from hier_config.utils import read_text_from_file
 
 # Load running and intended configurations from files
@@ -892,8 +937,8 @@ running_config_text = read_text_from_file("./tests/fixtures/running_config.conf"
 generated_config_text = read_text_from_file("./tests/fixtures/remediation_config.conf")
 
 # Create HConfig objects for running and intended configurations
-running_config = get_hconfig(CustomPlatform.CUSTOM_DRIVER, running_config_text)
-generated_config = get_hconfig(CustomPlatform.CUSTOM_DRIVER, generated_config_text)
+running_config = HConfig.from_text(CustomPlatform.CUSTOM_DRIVER, running_config_text)
+generated_config = HConfig.from_text(CustomPlatform.CUSTOM_DRIVER, generated_config_text)
 ```
 
 ##### 4. Instantiate a `WorkflowRemediation`
@@ -947,8 +992,9 @@ def swap_negation(self, child: HConfigChild) -> HConfigChild:
 Define commands that require specific negation handling:
 
 ```python
-negate_with=[
-    NegationDefaultWithRule(
+negation=[
+    NegationRule(
+        strategy=NegationStrategy.REPLACE,
         match_rules=(MatchRule(startswith="ip route "),),
         use="no ip route"
     )

--- a/docs/future-config.md
+++ b/docs/future-config.md
@@ -44,7 +44,7 @@ The `future()` algorithm is a best-effort simulation.  The following cases are n
 
 3. **Negate-with rules.**
    When a command has a custom [negation string](glossary.md#negation-negate-with) defined by the driver (e.g.
-   `NegationDefaultWithRule`), the `future()` algorithm may not apply that string when
+   a REPLACE-strategy `NegationRule`), the `future()` algorithm may not apply that string when
    processing removal of that command.
 
 4. **Idempotent command avoid list.**
@@ -80,15 +80,15 @@ configuration because their identities differ within the `neighbor` hierarchy.
 > such as IP address or description text.
 
 ```bash
->>> from hier_config import get_hconfig, Platform
+>>> from hier_config import HConfig, Platform
 >>> from hier_config.utils import read_text_from_file
 >>>
 
 >>> running_config_text = read_text_from_file("./tests/fixtures/running_config.conf")
 >>> generated_config_text = read_text_from_file("./tests/fixtures/remediation_config_without_tags.conf")
 >>>
->>> running_config = get_hconfig(Platform.CISCO_IOS, running_config_text)
->>> remediation_config = get_hconfig(Platform.CISCO_IOS, remediation_config_text)
+>>> running_config = HConfig.from_text(Platform.CISCO_IOS, running_config_text)
+>>> remediation_config = HConfig.from_text(Platform.CISCO_IOS, remediation_config_text)
 >>>
 >>> print("Running Config")
 Running Config
@@ -181,14 +181,14 @@ This is useful when comparing configurations from two network devices (such as r
 > **Note:** The unified diff algorithm shares the same limitations as `future()` regarding duplicate child entries (e.g., multiple `endif` statements in an IOS XR route-policy) and command ordering in sections where sequence matters (such as ACLs). For accurate ACL ordering, use sequence numbers.
 
 ```python
->>> from hier_config import get_hconfig, Platform
+>>> from hier_config import HConfig, Platform
 >>> from pprint import pprint
 >>>
 >>> running_config_text = read_text_from_file("./tests/fixtures/running_config.conf")
 >>> generated_config_text = read_text_from_file("./tests/fixtures/generated_config.conf")
 >>>
->>> running_config = get_hconfig(Platform.CISCO_IOS, running_config_text)
->>> generated_config = get_hconfig(Platform.CISCO_IOS, generated_config_text)
+>>> running_config = HConfig.from_text(Platform.CISCO_IOS, running_config_text)
+>>> generated_config = HConfig.from_text(Platform.CISCO_IOS, generated_config_text)
 >>>
 >>> pprint(list(running_config.unified_diff(generated_config)))
 ['vlan 3',

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -4,10 +4,10 @@ Hier Config is a Python library that assists with remediating network configurat
 
 ## Step 1: Import Required Classes
 
-To use `WorkflowRemediation`, you’ll import it along with `get_hconfig` (for generating configuration objects) and `Platform` (for specifying the operating system driver).
+To use `WorkflowRemediation`, you’ll import it along with `HConfig` (for generating configuration objects) and `Platform` (for specifying the operating system driver).
 
 ```python
->>> from hier_config import WorkflowRemediation, get_hconfig, Platform
+>>> from hier_config import WorkflowRemediation, HConfig, Platform
 >>> from hier_config.utils import read_text_from_file
 >>>
 ```
@@ -16,7 +16,7 @@ With these imports, you can create HConfig objects and compare them.
 
 ## Step 2: Creating HConfig Objects for Configurations
 
-Use `get_hconfig` to create HConfig objects for both the running and intended configurations. Specify the platform with `Platform.CISCO_IOS`, `Platform.CISCO_NXOS`, etc., based on the device type.
+Use `HConfig.from_text` to create HConfig objects for both the running and intended configurations. Specify the platform with `Platform.CISCO_IOS`, `Platform.CISCO_NXOS`, etc., based on the device type.
 
 ```python
 # Define running and intended configurations as strings
@@ -25,8 +25,8 @@ Use `get_hconfig` to create HConfig objects for both the running and intended co
 >>>
 
 # Create HConfig objects for running and intended configurations
->>> running_config = get_hconfig(Platform.CISCO_IOS, running_config_text)
->>> generated_config = get_hconfig(Platform.CISCO_IOS, generated_config_text)
+>>> running_config = HConfig.from_text(Platform.CISCO_IOS, running_config_text)
+>>> generated_config = HConfig.from_text(Platform.CISCO_IOS, generated_config_text)
 >>>
 ```
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -14,7 +14,7 @@ The string that precedes a *positive* (enabling) command in platforms that use e
 
 ## Driver / HConfigDriverBase
 
-A Python class that encodes all operating-system-specific behaviour for one network platform.  Every driver subclasses `HConfigDriverBase` and provides an `HConfigDriverRules` instance via `_instantiate_rules()`.  Drivers are selected by passing a `Platform` enum value to `get_hconfig()` or `get_hconfig_driver()`.
+A Python class that encodes all operating-system-specific behaviour for one network platform.  Every driver subclasses `HConfigDriverBase` and provides an `HConfigDriverRules` instance via `_instantiate_rules()`.  Drivers are selected by passing a `Platform` enum value to `HConfig.from_text()` or `get_hconfig_driver()`.
 
 **Example:** `HConfigDriverCiscoIOS`, `HConfigDriverJuniperJUNOS`.
 
@@ -80,13 +80,13 @@ The string prepended to a command to negate (remove) it.  `HConfigDriverBase.neg
 
 ## Negation — default when
 
-A `NegationDefaultWhenRule` that causes hier_config to use the `default <command>` form of negation instead of `no <command>`.  Some IOS and EOS commands behave differently when defaulted vs negated (e.g. `logging event link-status`).
+A DEFAULT-strategy `NegationRule` that causes hier_config to use the `default <command>` form of negation instead of `no <command>`.  Some IOS and EOS commands behave differently when defaulted vs negated (e.g. `logging event link-status`).
 
 ---
 
 ## Negation — negate with
 
-A `NegationDefaultWithRule` that replaces the standard negation with a fixed command string.  Used when a command cannot be simply prepended with `"no "` — for example, `logging console debugging` is the correct way to reset the console logging level rather than `no logging console`.
+A REPLACE-strategy `NegationRule` that replaces the standard negation with a fixed command string.  Used when a command cannot be simply prepended with `"no "` — for example, `logging console debugging` is the correct way to reset the console logging level rather than `no logging console`.
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -38,10 +38,10 @@
 ## Quick Example
 
 ```python
-from hier_config import WorkflowRemediation, get_hconfig, Platform
+from hier_config import WorkflowRemediation, HConfig, Platform
 
-running = get_hconfig(Platform.CISCO_IOS, running_config_text)
-intended = get_hconfig(Platform.CISCO_IOS, intended_config_text)
+running = HConfig.from_text(Platform.CISCO_IOS, running_config_text)
+intended = HConfig.from_text(Platform.CISCO_IOS, intended_config_text)
 workflow = WorkflowRemediation(running, intended)
 
 for line in workflow.remediation_config.all_children_sorted():

--- a/docs/junos-style-syntax-remediation.md
+++ b/docs/junos-style-syntax-remediation.md
@@ -25,14 +25,14 @@ set interfaces irb unit 3 family inet description "switch_mgmt_10.0.4.0/24"
 
 
 $ python3
->>> from hier_config import WorkflowRemediation, get_hconfig, Platform
+>>> from hier_config import WorkflowRemediation, HConfig, Platform
 >>> from hier_config.utils import read_text_from_file
 >>>
 >>> running_config_text = read_text_from_file("./tests/fixtures/running_config_flat_junos.conf")
 >>> generated_config_text = read_text_from_file("./tests/fixtures/generated_config_flat_junos.conf")
 # Create HConfig objects for the running and generated configurations using JunOS syntax
->>> running_config = get_hconfig(Platform.JUNIPER_JUNOS, running_config_text)
->>> generated_config = get_hconfig(Platform.JUNIPER_JUNOS, generated_config_text)
+>>> running_config = HConfig.from_text(Platform.JUNIPER_JUNOS, running_config_text)
+>>> generated_config = HConfig.from_text(Platform.JUNIPER_JUNOS, generated_config_text)
 >>>
 # Initialize WorkflowRemediation with the running and generated configurations
 >>> workflow = WorkflowRemediation(running_config, generated_config)
@@ -118,14 +118,14 @@ interfaces {
 }
 
 $ python3
->>> from hier_config import WorkflowRemediation, get_hconfig, Platform
+>>> from hier_config import WorkflowRemediation, HConfig, Platform
 >>> from hier_config.utils import read_text_from_file
 >>>
 >>> running_config_text = read_text_from_file("./tests/fixtures/running_config_junos.conf")
 >>> generated_config_text = read_text_from_file("./tests/fixtures/generated_config_junos.conf")
 # Create HConfig objects for the running and generated configurations using JunOS syntax
->>> running_config = get_hconfig(Platform.JUNIPER_JUNOS, running_config_text)
->>> generated_config = get_hconfig(Platform.JUNIPER_JUNOS, generated_config_text)
+>>> running_config = HConfig.from_text(Platform.JUNIPER_JUNOS, running_config_text)
+>>> generated_config = HConfig.from_text(Platform.JUNIPER_JUNOS, generated_config_text)
 >>>
 # Initialize WorkflowRemediation with the running and generated configurations
 >>> workflow = WorkflowRemediation(running_config, generated_config)

--- a/docs/remediation-reporting.md
+++ b/docs/remediation-reporting.md
@@ -21,15 +21,15 @@ The `RemediationReporter` class allows you to:
 from hier_config import (
     RemediationReporter,
     WorkflowRemediation,
-    get_hconfig,
+    HConfig,
     Platform,
 )
 
 # Generate remediations for each device
 devices_remediations = []
 for device in devices:
-    running = get_hconfig(Platform.CISCO_IOS, device.running_config)
-    generated = get_hconfig(Platform.CISCO_IOS, device.generated_config)
+    running = HConfig.from_text(Platform.CISCO_IOS, device.running_config)
+    generated = HConfig.from_text(Platform.CISCO_IOS, device.generated_config)
     wfr = WorkflowRemediation(running, generated)
     devices_remediations.append(wfr.remediation_config)
 
@@ -93,7 +93,7 @@ reporter.add_remediations(more_remediations)
 
 ```python
 # If you already have a merged configuration
-merged = get_hconfig(Platform.CISCO_IOS)
+merged = HConfig.from_text(Platform.CISCO_IOS)
 merged.merge([device1, device2, device3])
 
 reporter = RemediationReporter.from_merged_config(merged)

--- a/docs/tags.md
+++ b/docs/tags.md
@@ -109,7 +109,7 @@ With the tags loaded, you can create a targeted remediation based on those tags 
 #!/usr/bin/env python3
 
 # Import necessary libraries
-from hier_config import WorkflowRemediation, get_hconfig, Platform
+from hier_config import WorkflowRemediation, HConfig, Platform
 from hier_config.utils import read_text_from_file, load_hier_config_tags
 
 # Load the running and generated configurations from files
@@ -121,8 +121,8 @@ tags = load_hier_config_tags("./tests/fixtures/tag_rules_ios.yml")
 
 # Initialize a WorkflowRemediation object with the running and intended configurations
 wfr = WorkflowRemediation(
-    running_config=get_hconfig(Platform.CISCO_IOS, running_config),
-    generated_config=get_hconfig(Platform.CISCO_IOS, generated_config)
+    running_config=HConfig.from_text(Platform.CISCO_IOS, running_config),
+    generated_config=HConfig.from_text(Platform.CISCO_IOS, generated_config)
 )
 
 # Apply the tag rules to filter remediation steps by tags

--- a/docs/unified-diff.md
+++ b/docs/unified-diff.md
@@ -7,14 +7,14 @@ This feature is particularly useful when comparing configurations from two netwo
 Currently, the algorithm does not account for duplicate child entries (e.g., multiple `endif` statements in an IOS-XR route-policy) or enforce command order in sections where it may be critical, such as Access Control Lists (ACLs). For accurate ordering in ACLs, sequence numbers should be used if command order is important.
 
 ```bash
->>> from hier_config import get_hconfig, Platform
+>>> from hier_config import HConfig, Platform
 >>> from pprint import pprint
 >>>
 >>> running_config_text = read_text_from_file("./tests/fixtures/running_config.conf")
 >>> generated_config_text = read_text_from_file("./tests/fixtures/generated_config.conf")
 >>>
->>> running_config = get_hconfig(Platform.CISCO_IOS, running_config_text)
->>> generated_config = get_hconfig(Platform.CISCO_IOS, generated_config_text)
+>>> running_config = HConfig.from_text(Platform.CISCO_IOS, running_config_text)
+>>> generated_config = HConfig.from_text(Platform.CISCO_IOS, generated_config_text)
 >>>
 >>> pprint(list(running_config.unified_diff(generated_config)))
 ['vlan 3',

--- a/hier_config/__init__.py
+++ b/hier_config/__init__.py
@@ -1,11 +1,5 @@
 from .child import HConfigChild
-from .constructors import (
-    get_hconfig,
-    get_hconfig_driver,
-    get_hconfig_fast_load,
-    get_hconfig_from_dump,
-    get_hconfig_view,
-)
+from .constructors import get_hconfig_view
 from .exceptions import (
     DriverNotFoundError,
     DuplicateChildError,
@@ -14,6 +8,13 @@ from .exceptions import (
     InvalidConfigError,
 )
 from .models import ChangeDetail, MatchRule, Platform, ReportSummary, TagRule, TextStyle
+from .platforms.driver_base import HConfigDriverBase, HConfigDriverRules
+from .registry import (
+    get_hconfig_driver,
+    get_registered_platforms,
+    register_driver,
+    unregister_driver,
+)
 from .reporting import RemediationReporter
 from .root import HConfig
 from .workflows import WorkflowRemediation
@@ -24,6 +25,8 @@ __all__ = (
     "DuplicateChildError",
     "HConfig",
     "HConfigChild",
+    "HConfigDriverBase",
+    "HConfigDriverRules",
     "HierConfigError",
     "IncompatibleDriverError",
     "InvalidConfigError",
@@ -34,9 +37,9 @@ __all__ = (
     "TagRule",
     "TextStyle",
     "WorkflowRemediation",
-    "get_hconfig",
     "get_hconfig_driver",
-    "get_hconfig_fast_load",
-    "get_hconfig_from_dump",
     "get_hconfig_view",
+    "get_registered_platforms",
+    "register_driver",
+    "unregister_driver",
 )

--- a/hier_config/__init__.py
+++ b/hier_config/__init__.py
@@ -9,6 +9,14 @@ from .exceptions import (
 )
 from .models import ChangeDetail, MatchRule, Platform, ReportSummary, TagRule, TextStyle
 from .platforms.driver_base import HConfigDriverBase, HConfigDriverRules
+from .platforms.view_base import (
+    ConfigViewInterfaceBase,
+    HConfigViewBase,
+    InterfaceBundleViewMixin,
+    InterfaceNACViewMixin,
+    InterfacePhysicalViewMixin,
+    InterfaceVlanViewMixin,
+)
 from .plugins import RemediationPlugin
 from .registry import (
     get_hconfig_driver,
@@ -22,14 +30,20 @@ from .workflows import WorkflowRemediation
 
 __all__ = (
     "ChangeDetail",
+    "ConfigViewInterfaceBase",
     "DriverNotFoundError",
     "DuplicateChildError",
     "HConfig",
     "HConfigChild",
     "HConfigDriverBase",
     "HConfigDriverRules",
+    "HConfigViewBase",
     "HierConfigError",
     "IncompatibleDriverError",
+    "InterfaceBundleViewMixin",
+    "InterfaceNACViewMixin",
+    "InterfacePhysicalViewMixin",
+    "InterfaceVlanViewMixin",
     "InvalidConfigError",
     "MatchRule",
     "Platform",

--- a/hier_config/__init__.py
+++ b/hier_config/__init__.py
@@ -9,6 +9,7 @@ from .exceptions import (
 )
 from .models import ChangeDetail, MatchRule, Platform, ReportSummary, TagRule, TextStyle
 from .platforms.driver_base import HConfigDriverBase, HConfigDriverRules
+from .plugins import RemediationPlugin
 from .registry import (
     get_hconfig_driver,
     get_registered_platforms,
@@ -32,6 +33,7 @@ __all__ = (
     "InvalidConfigError",
     "MatchRule",
     "Platform",
+    "RemediationPlugin",
     "RemediationReporter",
     "ReportSummary",
     "TagRule",

--- a/hier_config/base.py
+++ b/hier_config/base.py
@@ -3,16 +3,10 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from itertools import chain
 from logging import getLogger
-from typing import TYPE_CHECKING, TypeVar
+from typing import TYPE_CHECKING
 
 from .children import HConfigChildren
 from .exceptions import DuplicateChildError
-from .tree_algorithms import (
-    compute_difference,
-    compute_future,
-    compute_remediation,
-    compute_with_tags,
-)
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Iterator
@@ -22,18 +16,17 @@ if TYPE_CHECKING:
     from .platforms.driver_base import HConfigDriverBase
     from .root import HConfig
 
-    _HConfigRootOrChildT = TypeVar("_HConfigRootOrChildT", bound=HConfig | HConfigChild)
 
 logger = getLogger(__name__)
 
 
-class HConfigBase(ABC):  # noqa: PLR0904
+class HConfigBase(ABC):  # ruff:ignore[too-many-public-methods]
     """Abstract base class for the hierarchical configuration tree.
 
     Both `HConfig` (the root) and `HConfigChild` (individual nodes) inherit from
     this class.  It provides the shared tree-manipulation API: adding, searching,
-    and diffing children, as well as the `_future` / `_remediation` algorithms
-    that power `WorkflowRemediation`.
+    and diffing children. The diff/remediation/future algorithms live in
+    `hier_config.tree_algorithms` and are invoked from `HConfig`.
     """
 
     __slots__ = ("children",)
@@ -104,7 +97,7 @@ class HConfigBase(ABC):  # noqa: PLR0904
         self.children.append(new_child)
         return new_child
 
-    def path(self) -> Iterator[str]:  # noqa: PLR6301
+    def path(self) -> Iterator[str]:  # ruff:ignore[no-self-use]
         yield from ()
 
     def add_deep_copy_of(
@@ -280,14 +273,6 @@ class HConfigBase(ABC):  # noqa: PLR0904
                     for c in target_child.all_children_sorted()
                 )
 
-    def _future(
-        self,
-        config: HConfig | HConfigChild,
-        future_config: HConfig | HConfigChild,
-    ) -> None:
-        """Delegates to :func:`hier_config.tree_algorithms.compute_future`."""
-        compute_future(self, config, future_config)
-
     @abstractmethod
     def instantiate_child(self, text: str) -> HConfigChild:
         pass
@@ -295,27 +280,3 @@ class HConfigBase(ABC):  # noqa: PLR0904
     @abstractmethod
     def _is_duplicate_child_allowed(self) -> bool:
         pass
-
-    def _with_tags(
-        self,
-        tags: frozenset[str],
-        new_instance: _HConfigRootOrChildT,
-    ) -> _HConfigRootOrChildT:
-        """Delegates to :func:`hier_config.tree_algorithms.compute_with_tags`."""
-        return compute_with_tags(self, tags, new_instance)
-
-    def _remediation(
-        self,
-        target: _HConfigRootOrChildT,
-        delta: _HConfigRootOrChildT,
-    ) -> _HConfigRootOrChildT:
-        """Delegates to :func:`hier_config.tree_algorithms.compute_remediation`."""
-        return compute_remediation(self, target, delta)
-
-    def _difference(
-        self,
-        target: _HConfigRootOrChildT,
-        delta: _HConfigRootOrChildT,
-    ) -> _HConfigRootOrChildT:
-        """Delegates to :func:`hier_config.tree_algorithms.compute_difference`."""
-        return compute_difference(self, target, delta)

--- a/hier_config/base.py
+++ b/hier_config/base.py
@@ -7,6 +7,12 @@ from typing import TYPE_CHECKING, TypeVar
 
 from .children import HConfigChildren
 from .exceptions import DuplicateChildError
+from .tree_algorithms import (
+    compute_difference,
+    compute_future,
+    compute_remediation,
+    compute_with_tags,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Iterator
@@ -274,83 +280,13 @@ class HConfigBase(ABC):  # noqa: PLR0904
                     for c in target_child.all_children_sorted()
                 )
 
-    def _future_pre(self, config: HConfig | HConfigChild) -> tuple[set[str], set[str]]:
-        negated_or_recursed: set[str] = set()
-        config_children_ignore: set[str] = set()
-        for self_child in self.children:
-            # Is the command effectively negating a command in self.children?
-            if (negation_text := self.root.driver.negate_with(self_child)) and (
-                config_child := config.get_child(equals=negation_text)
-            ):
-                negated_or_recursed.add(self_child.text)
-                config_children_ignore.add(config_child.text)
-        return negated_or_recursed, config_children_ignore
-
-    def _future(  # noqa: C901
+    def _future(
         self,
         config: HConfig | HConfigChild,
         future_config: HConfig | HConfigChild,
     ) -> None:
-        """Recursively compute the future configuration subtree.
-
-        Called by :meth:`HConfig.future` to walk the config tree and merge
-        ``config`` on top of ``self``, applying driver-specific rules for
-        sectional overwrite, idempotency, and negation.  The result is written
-        into ``future_config``.
-
-        Known gaps (not yet accounted for):
-
-        - Negating a numbered ACL when removing a single entry
-        - Idempotent command avoid list
-        - And likely other edge cases
-        """
-        negated_or_recursed, config_children_ignore = self._future_pre(config)
-
-        for config_child in config.children:
-            if config_child.text in config_children_ignore:
-                continue
-            # sectional_overwrite
-            # sectional_overwrite_no_negate
-            if (
-                config_child.use_sectional_overwrite()
-                or config_child.use_sectional_overwrite_without_negation()
-            ):
-                future_config.add_deep_copy_of(config_child)
-            # Idempotent commands
-            elif self_child := self.root.driver.idempotent_for(
-                config_child,
-                self.children,
-            ):
-                future_config.add_deep_copy_of(config_child)
-                negated_or_recursed.add(self_child.text)
-            # config_child is already in self
-            elif self_child := self.get_child(equals=config_child.text):
-                future_child = future_config.add_shallow_copy_of(self_child)
-                self_child._future(config_child, future_child)  # noqa: SLF001
-                negated_or_recursed.add(config_child.text)
-            # config_child is being negated
-            elif config_child.text.startswith(self.driver.negation_prefix):
-                unnegated_command = config_child.text_without_negation
-                if self.get_child(equals=unnegated_command):
-                    negated_or_recursed.add(unnegated_command)
-                # Account for "no ..." commands in the running config
-                else:
-                    future_config.add_shallow_copy_of(config_child)
-            # The negated form of config_child is in self.children
-            elif self_child := self.get_child(
-                equals=f"{self.driver.negation_prefix}{config_child.text}",
-            ):
-                negated_or_recursed.add(self_child.text)
-            # config_child is not in self and doesn't match a special case
-            else:
-                future_config.add_deep_copy_of(config_child)
-
-        for self_child in self.children:
-            # self_child matched an above special case and should be ignored
-            if self_child.text in negated_or_recursed:
-                continue
-            # self_child was not modified above and should be present in the future config
-            future_config.add_deep_copy_of(self_child)
+        """Delegates to :func:`hier_config.tree_algorithms.compute_future`."""
+        compute_future(self, config, future_config)
 
     @abstractmethod
     def instantiate_child(self, text: str) -> HConfigChild:
@@ -365,137 +301,21 @@ class HConfigBase(ABC):  # noqa: PLR0904
         tags: frozenset[str],
         new_instance: _HConfigRootOrChildT,
     ) -> _HConfigRootOrChildT:
-        """Adds children recursively that have a subset of tags."""
-        for child in self.children:
-            if tags.issubset(child.tags):
-                new_child = new_instance.add_shallow_copy_of(child)
-                child._with_tags(tags, new_instance=new_child)  # noqa: SLF001
-
-        return new_instance
+        """Delegates to :func:`hier_config.tree_algorithms.compute_with_tags`."""
+        return compute_with_tags(self, tags, new_instance)
 
     def _remediation(
         self,
         target: _HConfigRootOrChildT,
         delta: _HConfigRootOrChildT,
     ) -> _HConfigRootOrChildT:
-        """Figures out what commands need to be executed to transition from self to target.
-        self is the source data structure(i.e. the running_config),
-        target is the destination(i.e. generated_config).
-
-        """
-        self._remediation_left(target, delta)
-        self._remediation_right(target, delta)
-
-        return delta
-
-    @staticmethod
-    def _strip_acl_sequence_number(hier_child: HConfigChild) -> str:
-        words = hier_child.text.split()
-        if words[0].isdecimal():
-            words.pop(0)
-        return " ".join(words)
+        """Delegates to :func:`hier_config.tree_algorithms.compute_remediation`."""
+        return compute_remediation(self, target, delta)
 
     def _difference(
         self,
         target: _HConfigRootOrChildT,
         delta: _HConfigRootOrChildT,
-        target_acl_children: dict[str, HConfigChild] | None = None,
-        *,
-        in_acl: bool = False,
     ) -> _HConfigRootOrChildT:
-        acl_sw_matches = tuple(f"ip{x} access-list " for x in ("", "v4", "v6"))
-
-        for self_child in self.children:
-            # Not dealing with negations and defaults for now
-            if self_child.text.startswith((self.driver.negation_prefix, "default ")):
-                continue
-
-            if in_acl:
-                # Ignore ACL sequence numbers
-                if target_acl_children is None:
-                    message = "target_acl_children cannot be None"
-                    raise TypeError(message)
-                target_child = target_acl_children.get(
-                    self._strip_acl_sequence_number(self_child),
-                )
-            else:
-                target_child = target.get_child(equals=self_child.text)
-
-            if target_child is None:
-                delta.add_deep_copy_of(self_child)
-            else:
-                delta_child = delta.add_child(self_child.text)
-                if self_child.text.startswith(acl_sw_matches):
-                    self_child._difference(  # noqa: SLF001
-                        target_child,
-                        delta_child,
-                        target_acl_children={
-                            self._strip_acl_sequence_number(c): c
-                            for c in target_child.children
-                        },
-                        in_acl=True,
-                    )
-                else:
-                    self_child._difference(target_child, delta_child)  # noqa: SLF001
-                if not delta_child.children:
-                    delta_child.delete()
-
-        return delta
-
-    def _remediation_left(
-        self,
-        target: HConfig | HConfigChild,
-        delta: HConfig | HConfigChild,
-    ) -> None:
-        # find self.children that are not in target.children
-        # i.e. what needs to be negated or defaulted
-        # Also, find out if another command in self.children will overwrite
-        # i.e. be idempotent
-        for self_child in self.children:
-            if self_child.text in target.children:
-                continue
-            if self_child.is_idempotent_command(target.children):
-                continue
-
-            # in other but not self
-            # add this node but not any children
-            negated = delta.add_child(self_child.text).negate()
-            if self_child.children:
-                negated.comments.add(f"removes {len(self_child.children) + 1} lines")
-
-    def _remediation_right(
-        self,
-        target: HConfig | HConfigChild,
-        delta: HConfig | HConfigChild,
-    ) -> None:
-        # Find what would need to be added to source_config to get to self
-        for target_child in target.children:
-            # If the child exist, recurse into its children
-            if self_child := self.children.get(target_child.text):
-                # Do we need to rewrite the child and its children as well?
-                if self_child.use_sectional_overwrite():
-                    self_child.overwrite_with(target_child, delta)
-                    continue
-                if self_child.use_sectional_overwrite_without_negation():
-                    self_child.overwrite_with(target_child, delta, negate=False)
-                    continue
-                # Matched leaves can never produce delta lines - neither pass
-                # has children to visit - so skip the subtree allocation (#191).
-                if not (self_child.children or target_child.children):
-                    continue
-                subtree = delta.instantiate_child(target_child.text)
-                self_child._remediation(target_child, subtree)  # noqa: SLF001
-                if subtree.children:
-                    delta.children.append(subtree)
-            # The child is absent, add it.
-            else:
-                # If the target_child is already in the delta, that means it was negated in the target config
-                if target_child.text in delta.children:
-                    continue
-                new_item = delta.add_deep_copy_of(target_child)
-                # Mark the new item and all of its children as new_in_config.
-                new_item.new_in_config = True
-                for child in new_item.all_children():
-                    child.new_in_config = True
-                if new_item.children:
-                    new_item.comments.add("new section")
+        """Delegates to :func:`hier_config.tree_algorithms.compute_difference`."""
+        return compute_difference(self, target, delta)

--- a/hier_config/child.py
+++ b/hier_config/child.py
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
 logger = getLogger(__name__)
 
 
-class HConfigChild(  # noqa: PLR0904  pylint: disable=too-many-instance-attributes
+class HConfigChild(  # ruff:ignore[too-many-public-methods]  pylint: disable=too-many-instance-attributes
     HConfigBase,
 ):
     """A single node in the hierarchical configuration tree.
@@ -110,7 +110,7 @@ class HConfigChild(  # noqa: PLR0904  pylint: disable=too-many-instance-attribut
 
     @property
     def root(self) -> HConfig:
-        """Returns the HConfig object at the base of the tree."""
+        """The HConfig object at the base of the tree."""
         return self.parent.root
 
     def lines(self, *, sectional_exiting: bool = False) -> Iterable[str]:
@@ -147,7 +147,7 @@ class HConfigChild(  # noqa: PLR0904  pylint: disable=too-many-instance-attribut
 
     @property
     def depth(self) -> int:
-        """Returns the distance to the root HConfig object i.e. indent level."""
+        """The distance to the root HConfig object i.e. indent level."""
         return self.parent.depth + 1
 
     def move(self, new_parent: HConfig | HConfigChild) -> None:
@@ -271,12 +271,12 @@ class HConfigChild(  # noqa: PLR0904  pylint: disable=too-many-instance-attribut
 
     @property
     def is_leaf(self) -> bool:
-        """Returns True if there are no children and is not an instance of HConfig."""
+        """True if there are no children and is not an instance of HConfig."""
         return not self.is_branch
 
     @property
     def is_branch(self) -> bool:
-        """Returns True if there are children or is an instance of HConfig."""
+        """True if there are children or is an instance of HConfig."""
         return bool(self.children)
 
     @property
@@ -419,7 +419,7 @@ class HConfigChild(  # noqa: PLR0904  pylint: disable=too-many-instance-attribut
             for (child, rule) in zip(reversed(lineage), reversed(rules), strict=True)
         )
 
-    def is_match(  # noqa: PLR0911
+    def is_match(  # ruff:ignore[too-many-return-statements]
         self,
         *,
         equals: str | SetLikeOfStr | None = None,

--- a/hier_config/child.py
+++ b/hier_config/child.py
@@ -6,7 +6,7 @@ from re import search, sub
 from typing import TYPE_CHECKING, Any
 
 from .base import HConfigBase
-from .models import Instance, MatchRule, SetLikeOfStr, TextStyle
+from .models import Instance, MatchRule, NegationStrategy, SetLikeOfStr, TextStyle
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Iterator
@@ -238,16 +238,15 @@ class HConfigChild(  # noqa: PLR0904  pylint: disable=too-many-instance-attribut
     def negate(self) -> HConfigChild:
         """Negate self.text using driver-specific negation rules.
 
-        Negation is resolved in the following priority order:
+        Negation is resolved via the driver's unified ``negation`` rule list
+        (#220). ``driver.negate_with()`` is consulted first (REPLACE-strategy
+        rules plus any imperative driver override), then the remaining rules
+        are evaluated in list order — first match wins:
 
-        1. ``negate_with`` rule — replaces ``self.text`` with a custom
-           negation string defined in the driver (e.g. ``no ip route``).
-        2. ``negation_default_when`` rule — rewrites the command to its
-           ``default`` form (e.g. ``no shutdown`` → ``default shutdown``).
-        3. ``negation_sub`` rule — applies a regex substitution to the
-           negated text (e.g. truncating after a specific token).
-        4. ``swap_negation`` — toggles the negation prefix/declaration
-           prefix (e.g. ``shutdown`` ↔ ``no shutdown``).
+        - ``DEFAULT`` — rewrites the command to its ``default`` form.
+        - ``REGEX_SUB`` — applies a regex substitution to the negated text.
+
+        Falls back to ``swap_negation`` (e.g. ``shutdown`` ↔ ``no shutdown``).
 
         Returns self so that callers can chain further operations.
         """
@@ -255,11 +254,12 @@ class HConfigChild(  # noqa: PLR0904  pylint: disable=too-many-instance-attribut
             self.text = negate_with
             return self
 
-        if self.use_default_for_negation(self):
-            return self._default()
-
-        for rule in self.driver.rules.negation_sub:
+        for rule in self.driver.rules.negation:
+            if rule.strategy is NegationStrategy.REPLACE:
+                continue
             if self.is_lineage_match(rule.match_rules):
+                if rule.strategy is NegationStrategy.DEFAULT:
+                    return self._default()
                 self.text = sub(
                     rule.search,
                     rule.replace,
@@ -268,12 +268,6 @@ class HConfigChild(  # noqa: PLR0904  pylint: disable=too-many-instance-attribut
                 return self
 
         return self.driver.swap_negation(self)
-
-    def use_default_for_negation(self, config: HConfigChild) -> bool:
-        return any(
-            config.is_lineage_match(rule.match_rules)
-            for rule in self.driver.rules.negation_default_when
-        )
 
     @property
     def is_leaf(self) -> bool:

--- a/hier_config/constructors.py
+++ b/hier_config/constructors.py
@@ -1,5 +1,6 @@
 from contextlib import suppress
 from itertools import islice
+from json import JSONDecodeError, loads
 from logging import getLogger
 from pathlib import Path
 from re import search, sub
@@ -29,12 +30,33 @@ def get_hconfig_view(config: HConfig) -> HConfigViewBase:
     raise DriverNotFoundError(message)
 
 
+def _detect_structured_format(config_text: str) -> str | None:
+    """Detect structured config formats that the text parser cannot ingest (#232)."""
+    stripped = config_text.lstrip()
+    if stripped.startswith("<"):
+        return "XML"
+    if stripped.startswith(("{", "[")):
+        with suppress(JSONDecodeError):
+            loads(stripped)
+            return "JSON"
+    return None
+
+
 def hconfig_from_text(
     platform_or_driver: Platform | str | HConfigDriverBase,
     config_raw: Path | str = "",
 ) -> HConfig:
     if isinstance(config_raw, Path):
         config_raw = config_raw.read_text(encoding="utf8")
+
+    if detected := _detect_structured_format(config_raw):
+        message = (
+            f"The config appears to be {detected}, which hier_config does not"
+            " parse. Convert it to the platform's indented CLI text first"
+            " (set-style configs are supported natively by the Juniper JunOS,"
+            " VyOS, and Nokia SRL drivers)."
+        )
+        raise InvalidConfigError(message)
 
     config = HConfig(_get_driver(platform_or_driver))
     for rule in config.driver.rules.full_text_sub:
@@ -173,86 +195,105 @@ def _config_from_string_lines_end_of_banner_test(
     return any(c in config_line for c in banner_end_contains)
 
 
-def _load_from_string_lines(config: HConfig, config_text: str) -> None:  # noqa: C901
-    config_text = config.driver.config_preprocessor(config_text)
-    current_section: HConfig | HConfigChild = config
-    most_recent_item: HConfig | HConfigChild = current_section
-    indent_adjust = 0
-    end_indent_adjust: list[str] = []
-    temp_banner: list[str] = []
-    banner_end_lines = {"EOF", "%", "!"}
-    banner_end_contains: list[str] = []
-    in_banner = False
+class _ConfigTextLoader:
+    """Stateful parser turning raw config text into an HConfig tree (#186).
 
-    for line in config_text.splitlines():
-        # Process banners in configuration into one line
-        if in_banner:
-            if line != "!":
-                temp_banner.append(line)
+    Splits the three responsibilities of the former monolithic loader into
+    focused methods: banner detection/aggregation, line normalization, and
+    indentation-based hierarchy construction.
+    """
 
-            # Test if this line is the end of a banner
-            if _config_from_string_lines_end_of_banner_test(
-                line,
-                frozenset(banner_end_lines),
-                banner_end_contains,
-            ):
-                in_banner = False
-                most_recent_item = config.add_child(
-                    "\n".join(temp_banner),
-                )
-                most_recent_item.real_indent_level = 0
-                current_section = config
-                temp_banner = []
-            continue
+    def __init__(self, config: HConfig) -> None:
+        self.config = config
+        self.current_section: HConfig | HConfigChild = config
+        self.most_recent_item: HConfig | HConfigChild = config
+        self.indent_adjust = 0
+        self.end_indent_adjust: list[str] = []
+        self.temp_banner: list[str] = []
+        self.banner_end_lines = {"EOF", "%", "!"}
+        self.banner_end_contains: list[str] = []
+        self.in_banner = False
 
-        # Test if this line is the start of a banner and not an empty banner
+    def load(self, config_text: str) -> None:
+        config_text = self.config.driver.config_preprocessor(config_text)
+        for line in config_text.splitlines():
+            if self.in_banner:
+                self._process_banner_line(line)
+            elif self._detect_banner_start(line):
+                pass
+            else:
+                self._process_config_line(line)
+        if self.in_banner:
+            message = "we are still in a banner for some reason"
+            raise InvalidConfigError(message)
+
+    def _process_banner_line(self, line: str) -> None:
+        """Aggregate banner content until the end marker, then emit one child."""
+        if line != "!":
+            self.temp_banner.append(line)
+
+        if _config_from_string_lines_end_of_banner_test(
+            line,
+            frozenset(self.banner_end_lines),
+            self.banner_end_contains,
+        ):
+            self.in_banner = False
+            self.most_recent_item = self.config.add_child("\n".join(self.temp_banner))
+            self.most_recent_item.real_indent_level = 0
+            self.current_section = self.config
+            self.temp_banner = []
+
+    def _detect_banner_start(self, line: str) -> bool:
+        """Detect banner start markers and record the expected end markers."""
         # Empty banners matching the below expression have been seen on NX-OS
-        if line.startswith("banner ") and line != "banner motd ##":
-            in_banner = True
-            temp_banner.append(line)
-            banner_words = line.split()
-            with suppress(IndexError):
-                banner_end_contains.append(banner_words[2])
-                # Handle banner on ArubaOS-Switch
-                if banner_words[2].startswith('"'):
-                    banner_end_contains.append('"')
-                banner_end_lines.add(banner_words[2][:1])
-                banner_end_lines.add(banner_words[2][:2])
+        if not line.startswith("banner ") or line == "banner motd ##":
+            return False
+        self.in_banner = True
+        self.temp_banner.append(line)
+        banner_words = line.split()
+        with suppress(IndexError):
+            self.banner_end_contains.append(banner_words[2])
+            # Handle banner on ArubaOS-Switch
+            if banner_words[2].startswith('"'):
+                self.banner_end_contains.append('"')
+            self.banner_end_lines.add(banner_words[2][:1])
+            self.banner_end_lines.add(banner_words[2][:2])
+        return True
 
-            continue
-
+    def _normalize_line(self, line: str) -> str:
+        """Collapse repeated whitespace and apply per-line substitutions."""
         actual_indent = len(line) - len(line.lstrip())
-        line = " " * actual_indent + " ".join(line.split())  # noqa: PLW2901
-        for rule in config.driver.rules.per_line_sub:
-            line = sub(rule.search, rule.replace, line)  # noqa: PLW2901
-        line = line.rstrip()  # noqa: PLW2901
+        line = " " * actual_indent + " ".join(line.split())
+        for rule in self.config.driver.rules.per_line_sub:
+            line = sub(rule.search, rule.replace, line)
+        return line.rstrip()
 
-        # If line is now empty, move to the next
+    def _process_config_line(self, line: str) -> None:
+        """Attach a normalized config line to the correct place in the tree."""
+        line = self._normalize_line(line)
         if not line:
-            continue
+            return
 
         # Determine indentation level (after per_line_sub rules are applied)
-        this_indent = len(line) - len(line.lstrip()) + indent_adjust
+        this_indent = len(line) - len(line.lstrip()) + self.indent_adjust
+        line = line.lstrip()
 
-        line = line.lstrip()  # noqa: PLW2901
-
-        # Determine parent in hierarchy
-        most_recent_item, current_section = _analyze_indent(
-            most_recent_item,
-            current_section,
+        self.most_recent_item, self.current_section = _analyze_indent(
+            self.most_recent_item,
+            self.current_section,
             this_indent,
             line,
         )
-        indent_adjust, end_indent_adjust = _adjust_indent(
-            config.driver,
+        self.indent_adjust, self.end_indent_adjust = _adjust_indent(
+            self.config.driver,
             line,
-            indent_adjust,
-            end_indent_adjust,
+            self.indent_adjust,
+            self.end_indent_adjust,
         )
+        if self.end_indent_adjust and search(self.end_indent_adjust[0], line):
+            self.indent_adjust -= 1
+            self.end_indent_adjust.pop(0)
 
-        if end_indent_adjust and search(end_indent_adjust[0], line):
-            indent_adjust -= 1
-            end_indent_adjust.pop(0)
-    if in_banner:
-        message = "we are still in a banner for some reason"
-        raise InvalidConfigError(message)
+
+def _load_from_string_lines(config: HConfig, config_text: str) -> None:
+    _ConfigTextLoader(config).load(config_text)

--- a/hier_config/constructors.py
+++ b/hier_config/constructors.py
@@ -33,17 +33,28 @@ def get_hconfig_view(config: HConfig) -> HConfigViewBase:
 def _detect_structured_format(config_text: str) -> str | None:
     """Detect structured config formats that the text parser cannot ingest (#232).
 
-    Only guards the from_text() path; from_lines() assumes pre-processed CLI
-    lines and performs no detection.
+    Guards the raw-text entry points (from_text() and the str form of
+    from_lines()); pre-split lines are assumed to be CLI text.
     """
-    stripped = config_text.lstrip()
-    if stripped.startswith("<"):
+    prefix = config_text[:64].lstrip()
+    if prefix.startswith("<"):
         return "XML"
-    if stripped.startswith(("{", "[")):
+    if prefix.startswith(("{", "[")):
         with suppress(JSONDecodeError):
-            loads(stripped)
+            loads(config_text)
             return "JSON"
     return None
+
+
+def _reject_structured_format(config_text: str) -> None:
+    if detected := _detect_structured_format(config_text):
+        message = (
+            f"The config appears to be {detected}, which hier_config does not"
+            " parse. Convert it to the platform's indented CLI text first"
+            " (set-style configs are supported natively by the Juniper JunOS,"
+            " VyOS, and Nokia SRL drivers)."
+        )
+        raise InvalidConfigError(message)
 
 
 def hconfig_from_text(
@@ -53,14 +64,7 @@ def hconfig_from_text(
     if isinstance(config_raw, Path):
         config_raw = config_raw.read_text(encoding="utf8")
 
-    if detected := _detect_structured_format(config_raw):
-        message = (
-            f"The config appears to be {detected}, which hier_config does not"
-            " parse. Convert it to the platform's indented CLI text first"
-            " (set-style configs are supported natively by the Juniper JunOS,"
-            " VyOS, and Nokia SRL drivers)."
-        )
-        raise InvalidConfigError(message)
+    _reject_structured_format(config_raw)
 
     config = HConfig(_get_driver(platform_or_driver))
     for rule in config.driver.rules.full_text_sub:
@@ -81,7 +85,7 @@ def hconfig_from_dump(
     platform_or_driver: Platform | str | HConfigDriverBase, dump: Dump
 ) -> HConfig:
     """Load an HConfig dump."""
-    config = hconfig_from_text(_get_driver(platform_or_driver))
+    config = HConfig(_get_driver(platform_or_driver))
     last_item: HConfig | HConfigChild = config
     for item in dump.lines:
         # parent is the root
@@ -110,8 +114,9 @@ def hconfig_from_lines(
     lines: list[str] | tuple[str, ...] | str,
 ) -> HConfig:
     driver = _get_driver(platform_or_driver)
-    config = hconfig_from_text(driver)
+    config = HConfig(driver)
     if isinstance(lines, str):
+        _reject_structured_format(lines)
         lines = lines.splitlines()
 
     current_section: HConfig | HConfigChild = config
@@ -223,9 +228,7 @@ class _ConfigTextLoader:  # pylint: disable=too-many-instance-attributes,too-few
         for line in config_text.splitlines():
             if self.in_banner:
                 self._process_banner_line(line)
-            elif self._detect_banner_start(line):
-                pass
-            else:
+            elif not self._detect_banner_start(line):
                 self._process_config_line(line)
         if self.in_banner:
             message = "we are still in a banner for some reason"

--- a/hier_config/constructors.py
+++ b/hier_config/constructors.py
@@ -31,7 +31,11 @@ def get_hconfig_view(config: HConfig) -> HConfigViewBase:
 
 
 def _detect_structured_format(config_text: str) -> str | None:
-    """Detect structured config formats that the text parser cannot ingest (#232)."""
+    """Detect structured config formats that the text parser cannot ingest (#232).
+
+    Only guards the from_text() path; from_lines() assumes pre-processed CLI
+    lines and performs no detection.
+    """
     stripped = config_text.lstrip()
     if stripped.startswith("<"):
         return "XML"

--- a/hier_config/constructors.py
+++ b/hier_config/constructors.py
@@ -29,7 +29,7 @@ def get_hconfig_view(config: HConfig) -> HConfigViewBase:
     raise DriverNotFoundError(message)
 
 
-def _hconfig_from_text(
+def hconfig_from_text(
     platform_or_driver: Platform | str | HConfigDriverBase,
     config_raw: Path | str = "",
 ) -> HConfig:
@@ -51,11 +51,11 @@ def _hconfig_from_text(
     return config
 
 
-def _hconfig_from_dump(
+def hconfig_from_dump(
     platform_or_driver: Platform | str | HConfigDriverBase, dump: Dump
 ) -> HConfig:
     """Load an HConfig dump."""
-    config = _hconfig_from_text(_get_driver(platform_or_driver))
+    config = hconfig_from_text(_get_driver(platform_or_driver))
     last_item: HConfig | HConfigChild = config
     for item in dump.lines:
         # parent is the root
@@ -79,12 +79,12 @@ def _hconfig_from_dump(
     return config
 
 
-def _hconfig_from_lines(
+def hconfig_from_lines(
     platform_or_driver: Platform | str | HConfigDriverBase,
     lines: list[str] | tuple[str, ...] | str,
 ) -> HConfig:
     driver = _get_driver(platform_or_driver)
-    config = _hconfig_from_text(driver)
+    config = hconfig_from_text(driver)
     if isinstance(lines, str):
         lines = lines.splitlines()
 

--- a/hier_config/constructors.py
+++ b/hier_config/constructors.py
@@ -9,47 +9,11 @@ from hier_config.platforms.driver_base import HConfigDriverBase
 from .child import HConfigChild
 from .exceptions import DriverNotFoundError, InvalidConfigError
 from .models import Dump, Platform
-from .platforms.arista_eos.driver import HConfigDriverAristaEOS
-from .platforms.cisco_ios.driver import HConfigDriverCiscoIOS
-from .platforms.cisco_nxos.driver import HConfigDriverCiscoNXOS
-from .platforms.cisco_xr.driver import HConfigDriverCiscoIOSXR
-from .platforms.fortinet_fortios.driver import HConfigDriverFortinetFortiOS
-from .platforms.generic.driver import HConfigDriverGeneric
-from .platforms.hp_comware5.driver import HConfigDriverHPComware5
-from .platforms.hp_procurve.driver import HConfigDriverHPProcurve
-from .platforms.huawei_vrp.driver import HConfigDriverHuaweiVrp
-from .platforms.juniper_junos.driver import HConfigDriverJuniperJUNOS
-from .platforms.nokia_srl.driver import HConfigDriverNokiaSRL
 from .platforms.view_base import HConfigViewBase
-from .platforms.vyos.driver import HConfigDriverVYOS
+from .registry import get_hconfig_driver
 from .root import HConfig
 
 logger = getLogger(__name__)
-
-
-def get_hconfig_driver(platform: Platform) -> HConfigDriverBase:
-    """Create base options on an OS level."""
-    platform_drivers: dict[Platform, type[HConfigDriverBase]] = {
-        Platform.ARISTA_EOS: HConfigDriverAristaEOS,
-        Platform.CISCO_IOS: HConfigDriverCiscoIOS,
-        Platform.CISCO_NXOS: HConfigDriverCiscoNXOS,
-        Platform.CISCO_XR: HConfigDriverCiscoIOSXR,
-        Platform.FORTINET_FORTIOS: HConfigDriverFortinetFortiOS,
-        Platform.GENERIC: HConfigDriverGeneric,
-        Platform.HP_PROCURVE: HConfigDriverHPProcurve,
-        Platform.HP_COMWARE5: HConfigDriverHPComware5,
-        Platform.HUAWEI_VRP: HConfigDriverHuaweiVrp,
-        Platform.JUNIPER_JUNOS: HConfigDriverJuniperJUNOS,
-        Platform.NOKIA_SRL: HConfigDriverNokiaSRL,
-        Platform.VYOS: HConfigDriverVYOS,
-    }
-    driver_cls = platform_drivers.get(platform)
-
-    if driver_cls is None:
-        message = f"Unsupported platform: {platform}"
-        raise DriverNotFoundError(message)
-
-    return driver_cls()
 
 
 def get_hconfig_view(config: HConfig) -> HConfigViewBase:
@@ -65,8 +29,8 @@ def get_hconfig_view(config: HConfig) -> HConfigViewBase:
     raise DriverNotFoundError(message)
 
 
-def get_hconfig(
-    platform_or_driver: Platform | HConfigDriverBase,
+def _hconfig_from_text(
+    platform_or_driver: Platform | str | HConfigDriverBase,
     config_raw: Path | str = "",
 ) -> HConfig:
     if isinstance(config_raw, Path):
@@ -87,11 +51,11 @@ def get_hconfig(
     return config
 
 
-def get_hconfig_from_dump(
-    platform_or_driver: Platform | HConfigDriverBase, dump: Dump
+def _hconfig_from_dump(
+    platform_or_driver: Platform | str | HConfigDriverBase, dump: Dump
 ) -> HConfig:
     """Load an HConfig dump."""
-    config = get_hconfig(_get_driver(platform_or_driver))
+    config = _hconfig_from_text(_get_driver(platform_or_driver))
     last_item: HConfig | HConfigChild = config
     for item in dump.lines:
         # parent is the root
@@ -115,18 +79,12 @@ def get_hconfig_from_dump(
     return config
 
 
-def get_hconfig_fast_generic_load(
-    lines: list[str] | tuple[str, ...] | str,
-) -> HConfig:
-    return get_hconfig_fast_load(Platform.GENERIC, lines)
-
-
-def get_hconfig_fast_load(
-    platform_or_driver: Platform | HConfigDriverBase,
+def _hconfig_from_lines(
+    platform_or_driver: Platform | str | HConfigDriverBase,
     lines: list[str] | tuple[str, ...] | str,
 ) -> HConfig:
     driver = _get_driver(platform_or_driver)
-    config = get_hconfig(driver)
+    config = _hconfig_from_text(driver)
     if isinstance(lines, str):
         lines = lines.splitlines()
 
@@ -164,9 +122,9 @@ def get_hconfig_fast_load(
 
 
 def _get_driver(
-    platform_or_driver: Platform | HConfigDriverBase,
+    platform_or_driver: Platform | str | HConfigDriverBase,
 ) -> HConfigDriverBase:
-    if isinstance(platform_or_driver, Platform):
+    if isinstance(platform_or_driver, (Platform, str)):
         return get_hconfig_driver(platform_or_driver)
     return platform_or_driver
 

--- a/hier_config/constructors.py
+++ b/hier_config/constructors.py
@@ -195,7 +195,7 @@ def _config_from_string_lines_end_of_banner_test(
     return any(c in config_line for c in banner_end_contains)
 
 
-class _ConfigTextLoader:
+class _ConfigTextLoader:  # pylint: disable=too-many-instance-attributes,too-few-public-methods
     """Stateful parser turning raw config text into an HConfig tree (#186).
 
     Splits the three responsibilities of the former monolithic loader into

--- a/hier_config/models.py
+++ b/hier_config/models.py
@@ -126,34 +126,35 @@ class Instance(BaseModel):
     tags: frozenset[str]
 
 
-class NegationDefaultWhenRule(BaseModel):
-    """Rule specifying when negation should use the ``default`` form."""
+class NegationStrategy(str, Enum):
+    """How a matching command is negated (#220)."""
 
-    match_rules: tuple[MatchRule, ...]
-
-
-class NegationDefaultWithRule(BaseModel):
-    """Rule replacing negation with a fixed custom command string."""
-
-    match_rules: tuple[MatchRule, ...]
-    use: str
+    #: Replace the command with the fixed string in ``use``.
+    REPLACE = "replace"
+    #: Rewrite the command to its ``default`` form.
+    DEFAULT = "default"
+    #: Apply ``re.sub(search, replace, ...)`` to the already-negated text.
+    REGEX_SUB = "regex_sub"
 
 
-class NegationSubRule(BaseModel):
-    r"""Regex substitution applied to a command during negation.
+class NegationRule(BaseModel):
+    r"""Unified negation rule (#220).
 
-    When a negated command matches ``match_rules``, ``re.sub(search, replace, text)``
-    is applied to transform the negation line.  Useful when a platform requires
-    truncated or reformatted negation commands — e.g. NX-OS SNMP user removal
-    must drop everything after the username.
+    Replaces the former ``NegationDefaultWithRule`` (``strategy=REPLACE``),
+    ``NegationDefaultWhenRule`` (``strategy=DEFAULT``), and ``NegationSubRule``
+    (``strategy=REGEX_SUB``). Rules are evaluated in list order; the first
+    matching rule wins.
 
-    The regex is applied to the **already-negated** text (with ``no `` prepended).
-    ``replace`` supports back-references such as ``\1``.
+    For ``REGEX_SUB``, the regex is applied to the **already-negated** text
+    (with the negation prefix prepended) and ``replace`` supports
+    back-references such as ``\1``.
     """
 
     match_rules: tuple[MatchRule, ...]
-    search: str
-    replace: str
+    strategy: NegationStrategy
+    use: str = ""
+    search: str = ""
+    replace: str = ""
 
 
 class ReferenceLocation(BaseModel):

--- a/hier_config/models.py
+++ b/hier_config/models.py
@@ -2,7 +2,7 @@ from enum import Enum, auto
 from typing import Literal
 
 from pydantic import BaseModel as PydanticBaseModel
-from pydantic import ConfigDict, NonNegativeInt, PositiveInt
+from pydantic import ConfigDict, NonNegativeInt, PositiveInt, model_validator
 
 TextStyle = Literal["without_comments", "merged", "with_comments"]
 
@@ -142,8 +142,10 @@ class NegationRule(BaseModel):
 
     Replaces the former ``NegationDefaultWithRule`` (``strategy=REPLACE``),
     ``NegationDefaultWhenRule`` (``strategy=DEFAULT``), and ``NegationSubRule``
-    (``strategy=REGEX_SUB``). Rules are evaluated in list order; the first
-    matching rule wins.
+    (``strategy=REGEX_SUB``). REPLACE rules are consulted first (via
+    ``driver.negate_with()``, which imperative driver overrides also hook
+    into); the remaining rules are then evaluated in list order and the
+    first matching rule wins.
 
     For ``REGEX_SUB``, the regex is applied to the **already-negated** text
     (with the negation prefix prepended) and ``replace`` supports
@@ -155,6 +157,16 @@ class NegationRule(BaseModel):
     use: str = ""
     search: str = ""
     replace: str = ""
+
+    @model_validator(mode="after")
+    def _validate_strategy_fields(self) -> "NegationRule":
+        if self.strategy is NegationStrategy.REPLACE and not self.use:
+            message = "REPLACE strategy requires `use`"
+            raise ValueError(message)
+        if self.strategy is NegationStrategy.REGEX_SUB and not self.search:
+            message = "REGEX_SUB strategy requires `search`"
+            raise ValueError(message)
+        return self
 
 
 class ReferenceLocation(BaseModel):

--- a/hier_config/platforms/arista_eos/driver.py
+++ b/hier_config/platforms/arista_eos/driver.py
@@ -1,7 +1,8 @@
 from hier_config.models import (
     IdempotentCommandsRule,
     MatchRule,
-    NegationDefaultWhenRule,
+    NegationRule,
+    NegationStrategy,
     PerLineSubRule,
     SectionalExitingRule,
 )
@@ -231,8 +232,9 @@ class HConfigDriverAristaEOS(HConfigDriverBase):
                     ),
                 ),
             ],
-            negation_default_when=[
-                NegationDefaultWhenRule(
+            negation=[
+                NegationRule(
+                    strategy=NegationStrategy.DEFAULT,
                     match_rules=(
                         MatchRule(startswith="interface"),
                         MatchRule(equals="logging event link-status"),

--- a/hier_config/platforms/arista_eos/view.py
+++ b/hier_config/platforms/arista_eos/view.py
@@ -105,7 +105,7 @@ class ConfigViewInterfaceAristaEOS(
 
     @property
     def port_number(self) -> int:
-        return int(self.name.split("/")[-1].split(".")[0])
+        return int(self.number.split("/")[-1].split(".")[0])
 
     @property
     def tagged_all(self) -> bool:

--- a/hier_config/platforms/arista_eos/view.py
+++ b/hier_config/platforms/arista_eos/view.py
@@ -1,10 +1,8 @@
 from collections.abc import Iterable
 from ipaddress import IPv4Address, IPv4Interface
-from re import sub
 
 from hier_config.child import HConfigChild
-from hier_config.platforms.functions import expand_range
-from hier_config.platforms.models import StackMember, Vlan
+from hier_config.platforms.functions import parse_ipv4_interface
 from hier_config.platforms.view_base import (
     HConfigViewBase,
     InterfaceBundleViewMixin,
@@ -18,109 +16,14 @@ class ConfigViewInterfaceAristaEOS(
 ):
     """Interface config view for Arista EOS."""
 
-    @property
-    def bundle_id(self) -> str | None:
-        if channel_group := self.config.get_child(startswith="channel-group "):
-            return channel_group.text.split()[1]
-        return None
-
-    @property
-    def bundle_member_interfaces(self) -> Iterable[str]:
-        if not self.is_bundle:
-            return
-        for interface in self.config.parent.get_children(startswith="interface "):
-            if (
-                channel_group := interface.get_child(startswith="channel-group ")
-            ) and channel_group.text.split()[1] == self.number:
-                yield interface.text.split()[1]
-
-    @property
-    def description(self) -> str:
-        if child := self.config.get_child(startswith="description "):
-            return child.text.split(maxsplit=1)[1]
-        return ""
-
-    @property
-    def enabled(self) -> bool:
-        return not self.config.get_child(equals="shutdown")
+    _bundle_membership_prefix = "channel-group "
+    _encapsulation_prefix = "encapsulation dot1q vlan "
 
     @property
     def ipv4_interfaces(self) -> Iterable[IPv4Interface]:
         for ipv4_address_obj in self.config.get_children(startswith="ip address "):
-            words = ipv4_address_obj.text.split()
-            address = words[2] if "/" in words[2] else "/".join(words[2:4])
-            try:
-                yield IPv4Interface(address)
-            except ValueError:
-                continue
-
-    @property
-    def is_loopback(self) -> bool:
-        return self.name.lower().startswith("loopback")
-
-    @property
-    def is_svi(self) -> bool:
-        return self.name.lower().startswith("vlan")
-
-    @property
-    def name(self) -> str:
-        return self.config.text.split()[1]
-
-    @property
-    def native_vlan(self) -> int | None:
-        # It's configured as a sub-interface
-        if self.is_subinterface and (
-            vlan := self.config.get_child(startswith="encapsulation dot1q vlan ")
-        ):
-            return int(vlan.text.split()[3])
-
-        # It's not a switchport
-        if (
-            self.config.get_child(equals="no switchport")
-            or self.config.get_child(startswith="ip address ")
-            or self.is_loopback
-            or self.is_svi
-        ):
-            return None
-
-        # It's configured as a trunk
-        if self.config.get_child(equals="switchport mode trunk"):
-            if vlan := self.config.get_child(
-                startswith="switchport trunk native vlan ",
-            ):
-                return int(vlan.text.split()[4])
-
-            return None
-
-        # It's either dynamic or configured as an access port
-        if vlan := self.config.get_child(startswith="switchport access vlan "):
-            return int(vlan.text.split()[3])
-
-        # Default VLAN
-        return 1
-
-    @property
-    def number(self) -> str:
-        return sub(r"^[a-zA-Z-]+", "", self.name)
-
-    @property
-    def port_number(self) -> int:
-        return int(self.number.split("/")[-1].split(".")[0])
-
-    @property
-    def tagged_all(self) -> bool:
-        return bool(
-            self.config.get_child(equals="switchport mode trunk")
-            and not self.tagged_vlans,
-        )
-
-    @property
-    def tagged_vlans(self) -> tuple[int, ...]:
-        if child := self.config.get_child(
-            re_search="^switchport trunk allowed vlan [0-9,-]+$",
-        ):
-            return expand_range(child.text.split()[4])
-        return ()
+            if interface := parse_ipv4_interface(ipv4_address_obj.text.split()[2:]):
+                yield interface
 
     @property
     def vrf(self) -> str:
@@ -144,11 +47,6 @@ class HConfigViewAristaEOS(HConfigViewBase):
         return None
 
     @property
-    def interface_names_mentioned(self) -> frozenset[str]:
-        """Returns a set with all the interface names mentioned in the config."""
-        return frozenset(model.name for model in self.interface_views)
-
-    @property
     def interface_views(self) -> Iterable[ConfigViewInterfaceAristaEOS]:
         for interface in self.interfaces:
             yield ConfigViewInterfaceAristaEOS(interface)
@@ -162,42 +60,3 @@ class HConfigViewAristaEOS(HConfigViewBase):
         if gateway := self.config.get_child(startswith="ip route 0.0.0.0/0 "):
             return IPv4Address(gateway.text.split()[3])
         return None
-
-    @property
-    def location(self) -> str:
-        if location := self.config.get_child(startswith="snmp-server location "):
-            return location.text.split(maxsplit=2)[2].replace('"', "")
-        return ""
-
-    @property
-    def stack_members(self) -> Iterable[StackMember]:
-        """Arista EOS does not support stacking."""
-        return ()
-
-    @property
-    def vlans(self) -> Iterable[Vlan]:
-        yielded_vlans: set[int] = set()
-
-        # Yield explicitly defined VLANs
-        for child in self.config.get_children(re_search="^vlan [0-9,-]+$"):
-            vlan_name = None
-            if name := child.get_child(startswith="name "):
-                _, vlan_name = name.text.split(maxsplit=1)
-                vlan_name = vlan_name.replace('"', "")
-            for vlan_id in expand_range(child.text.split()[1]):
-                yielded_vlans.add(vlan_id)
-                yield Vlan(
-                    id=vlan_id,
-                    name=vlan_name or None,
-                )
-
-        # Yield any remaining unnamed VLANs mentioned on interfaces
-        for interface_view in self.interface_views:
-            if (
-                native_vlan := interface_view.native_vlan
-            ) and native_vlan not in yielded_vlans:
-                yielded_vlans.add(native_vlan)
-                yield Vlan(
-                    id=native_vlan,
-                    name=None,
-                )

--- a/hier_config/platforms/arista_eos/view.py
+++ b/hier_config/platforms/arista_eos/view.py
@@ -1,147 +1,137 @@
 from collections.abc import Iterable
 from ipaddress import IPv4Address, IPv4Interface
+from re import sub
 
 from hier_config.child import HConfigChild
-from hier_config.platforms.models import (
-    InterfaceDuplex,
-    NACHostMode,
-    StackMember,
-    Vlan,
-)
+from hier_config.platforms.functions import expand_range
+from hier_config.platforms.models import StackMember, Vlan
 from hier_config.platforms.view_base import (
-    ConfigViewInterfaceBase,
     HConfigViewBase,
+    InterfaceBundleViewMixin,
+    InterfaceVlanViewMixin,
 )
 
 
-class ConfigViewInterfaceAristaEOS(ConfigViewInterfaceBase):  # noqa: PLR0904
+class ConfigViewInterfaceAristaEOS(
+    InterfaceBundleViewMixin,
+    InterfaceVlanViewMixin,
+):
     """Interface config view for Arista EOS."""
 
     @property
     def bundle_id(self) -> str | None:
-        raise NotImplementedError
+        if channel_group := self.config.get_child(startswith="channel-group "):
+            return channel_group.text.split()[1]
+        return None
 
     @property
     def bundle_member_interfaces(self) -> Iterable[str]:
-        raise NotImplementedError
-
-    @property
-    def bundle_name(self) -> str | None:
-        raise NotImplementedError
+        if not self.is_bundle:
+            return
+        for interface in self.config.parent.get_children(startswith="interface "):
+            if (
+                channel_group := interface.get_child(startswith="channel-group ")
+            ) and channel_group.text.split()[1] == self.number:
+                yield interface.text.split()[1]
 
     @property
     def description(self) -> str:
-        raise NotImplementedError
-
-    @property
-    def duplex(self) -> InterfaceDuplex:
-        raise NotImplementedError
+        if child := self.config.get_child(startswith="description "):
+            return child.text.split(maxsplit=1)[1]
+        return ""
 
     @property
     def enabled(self) -> bool:
-        raise NotImplementedError
-
-    @property
-    def has_nac(self) -> bool:
-        """Determine if the interface has NAC configured."""
-        raise NotImplementedError
+        return not self.config.get_child(equals="shutdown")
 
     @property
     def ipv4_interfaces(self) -> Iterable[IPv4Interface]:
-        raise NotImplementedError
-
-    @property
-    def is_bundle(self) -> bool:
-        raise NotImplementedError
+        for ipv4_address_obj in self.config.get_children(startswith="ip address "):
+            words = ipv4_address_obj.text.split()
+            address = words[2] if "/" in words[2] else "/".join(words[2:4])
+            try:
+                yield IPv4Interface(address)
+            except ValueError:
+                continue
 
     @property
     def is_loopback(self) -> bool:
-        raise NotImplementedError
-
-    @property
-    def is_subinterface(self) -> bool:
-        return "." in self.name
+        return self.name.lower().startswith("loopback")
 
     @property
     def is_svi(self) -> bool:
-        raise NotImplementedError
-
-    @property
-    def module_number(self) -> int | None:
-        raise NotImplementedError
-
-    @property
-    def nac_control_direction_in(self) -> bool:
-        """Determine if the interface has NAC control direction in configured."""
-        raise NotImplementedError
-
-    @property
-    def nac_host_mode(self) -> NACHostMode | None:
-        """Determine the NAC host mode."""
-        raise NotImplementedError
-
-    @property
-    def nac_mab_first(self) -> bool:
-        """Determine if the interface has NAC configured for MAB first."""
-        raise NotImplementedError
-
-    @property
-    def nac_max_dot1x_clients(self) -> int:
-        """Determine the max dot1x clients."""
-        raise NotImplementedError
-
-    @property
-    def nac_max_mab_clients(self) -> int:
-        """Determine the max mab clients."""
-        raise NotImplementedError
+        return self.name.lower().startswith("vlan")
 
     @property
     def name(self) -> str:
-        raise NotImplementedError
+        return self.config.text.split()[1]
 
     @property
     def native_vlan(self) -> int | None:
-        raise NotImplementedError
+        # It's configured as a sub-interface
+        if self.is_subinterface and (
+            vlan := self.config.get_child(startswith="encapsulation dot1q vlan ")
+        ):
+            return int(vlan.text.split()[3])
+
+        # It's not a switchport
+        if (
+            self.config.get_child(equals="no switchport")
+            or self.config.get_child(startswith="ip address ")
+            or self.is_loopback
+            or self.is_svi
+        ):
+            return None
+
+        # It's configured as a trunk
+        if self.config.get_child(equals="switchport mode trunk"):
+            if vlan := self.config.get_child(
+                startswith="switchport trunk native vlan ",
+            ):
+                return int(vlan.text.split()[4])
+
+            return None
+
+        # It's either dynamic or configured as an access port
+        if vlan := self.config.get_child(startswith="switchport access vlan "):
+            return int(vlan.text.split()[3])
+
+        # Default VLAN
+        return 1
 
     @property
     def number(self) -> str:
-        raise NotImplementedError
-
-    @property
-    def parent_name(self) -> str | None:
-        raise NotImplementedError
-
-    @property
-    def poe(self) -> bool:
-        raise NotImplementedError
+        return sub(r"^[a-zA-Z-]+", "", self.name)
 
     @property
     def port_number(self) -> int:
         return int(self.name.split("/")[-1].split(".")[0])
 
     @property
-    def speed(self) -> tuple[int, ...] | None:
-        raise NotImplementedError
-
-    @property
-    def subinterface_number(self) -> int | None:
-        raise NotImplementedError
-
-    @property
     def tagged_all(self) -> bool:
-        raise NotImplementedError
+        return bool(
+            self.config.get_child(equals="switchport mode trunk")
+            and not self.tagged_vlans,
+        )
 
     @property
     def tagged_vlans(self) -> tuple[int, ...]:
-        raise NotImplementedError
+        if child := self.config.get_child(
+            re_search="^switchport trunk allowed vlan [0-9,-]+$",
+        ):
+            return expand_range(child.text.split()[4])
+        return ()
 
     @property
     def vrf(self) -> str:
-        raise NotImplementedError
+        if vrf := self.config.get_child(startswith="vrf "):
+            words = vrf.text.split()
+            return words[2] if words[1] == "forwarding" else words[1]
+        return ""
 
     @property
     def _bundle_prefix(self) -> str:
-        raise NotImplementedError
+        return "Port-Channel"
 
 
 class HConfigViewAristaEOS(HConfigViewBase):
@@ -156,7 +146,7 @@ class HConfigViewAristaEOS(HConfigViewBase):
     @property
     def interface_names_mentioned(self) -> frozenset[str]:
         """Returns a set with all the interface names mentioned in the config."""
-        raise NotImplementedError
+        return frozenset(model.name for model in self.interface_views)
 
     @property
     def interface_views(self) -> Iterable[ConfigViewInterfaceAristaEOS]:
@@ -169,16 +159,45 @@ class HConfigViewAristaEOS(HConfigViewBase):
 
     @property
     def ipv4_default_gw(self) -> IPv4Address | None:
-        raise NotImplementedError
+        if gateway := self.config.get_child(startswith="ip route 0.0.0.0/0 "):
+            return IPv4Address(gateway.text.split()[3])
+        return None
 
     @property
     def location(self) -> str:
-        raise NotImplementedError
+        if location := self.config.get_child(startswith="snmp-server location "):
+            return location.text.split(maxsplit=2)[2].replace('"', "")
+        return ""
 
     @property
     def stack_members(self) -> Iterable[StackMember]:
-        raise NotImplementedError
+        """Arista EOS does not support stacking."""
+        return ()
 
     @property
     def vlans(self) -> Iterable[Vlan]:
-        raise NotImplementedError
+        yielded_vlans: set[int] = set()
+
+        # Yield explicitly defined VLANs
+        for child in self.config.get_children(re_search="^vlan [0-9,-]+$"):
+            vlan_name = None
+            if name := child.get_child(startswith="name "):
+                _, vlan_name = name.text.split(maxsplit=1)
+                vlan_name = vlan_name.replace('"', "")
+            for vlan_id in expand_range(child.text.split()[1]):
+                yielded_vlans.add(vlan_id)
+                yield Vlan(
+                    id=vlan_id,
+                    name=vlan_name or None,
+                )
+
+        # Yield any remaining unnamed VLANs mentioned on interfaces
+        for interface_view in self.interface_views:
+            if (
+                native_vlan := interface_view.native_vlan
+            ) and native_vlan not in yielded_vlans:
+                yielded_vlans.add(native_vlan)
+                yield Vlan(
+                    id=native_vlan,
+                    name=None,
+                )

--- a/hier_config/platforms/cisco_ios/driver.py
+++ b/hier_config/platforms/cisco_ios/driver.py
@@ -3,7 +3,8 @@ from logging import getLogger
 from hier_config.models import (
     IdempotentCommandsRule,
     MatchRule,
-    NegationDefaultWithRule,
+    NegationRule,
+    NegationStrategy,
     OrderingRule,
     ParentAllowsDuplicateChildRule,
     PerLineSubRule,
@@ -90,8 +91,9 @@ class HConfigDriverCiscoIOS(HConfigDriverBase):
     @staticmethod
     def _instantiate_rules() -> HConfigDriverRules:
         return HConfigDriverRules(
-            negate_with=[
-                NegationDefaultWithRule(
+            negation=[
+                NegationRule(
+                    strategy=NegationStrategy.REPLACE,
                     match_rules=(MatchRule(startswith="logging console "),),
                     use="logging console debugging",
                 ),

--- a/hier_config/platforms/cisco_ios/view.py
+++ b/hier_config/platforms/cisco_ios/view.py
@@ -173,7 +173,7 @@ class ConfigViewInterfaceCiscoIOS(  # noqa: PLR0904
 
     @property
     def port_number(self) -> int:
-        return int(self.name.split("/")[-1].split(".")[0])
+        return int(self.number.split("/")[-1].split(".")[0])
 
     @property
     def speed(self) -> tuple[int, ...] | None:

--- a/hier_config/platforms/cisco_ios/view.py
+++ b/hier_config/platforms/cisco_ios/view.py
@@ -1,14 +1,12 @@
 from collections.abc import Iterable
-from ipaddress import AddressValueError, IPv4Address, IPv4Interface
-from re import sub
+from ipaddress import IPv4Address, IPv4Interface
 
 from hier_config.child import HConfigChild
-from hier_config.platforms.functions import expand_range
+from hier_config.platforms.functions import parse_ipv4_interface
 from hier_config.platforms.models import (
     InterfaceDuplex,
     NACHostMode,
     StackMember,
-    Vlan,
 )
 from hier_config.platforms.view_base import (
     HConfigViewBase,
@@ -19,7 +17,7 @@ from hier_config.platforms.view_base import (
 )
 
 
-class ConfigViewInterfaceCiscoIOS(  # noqa: PLR0904
+class ConfigViewInterfaceCiscoIOS(
     InterfaceBundleViewMixin,
     InterfaceNACViewMixin,
     InterfacePhysicalViewMixin,
@@ -27,37 +25,14 @@ class ConfigViewInterfaceCiscoIOS(  # noqa: PLR0904
 ):
     """Interface config view for Cisco IOS / IOS-XE."""
 
-    @property
-    def bundle_id(self) -> str | None:
-        if channel_group := self.config.get_child(startswith="channel-group"):
-            return channel_group.text.split()[1]
-        return None
-
-    @property
-    def bundle_member_interfaces(self) -> Iterable[str]:
-        if not self.is_bundle:
-            return
-        for interface in self.config.parent.get_children(startswith="interface "):
-            if (
-                channel_group := interface.get_child(startswith="channel-group ")
-            ) and channel_group.text.split()[1] == self.number:
-                yield interface.text.split()[1]
-
-    @property
-    def description(self) -> str:
-        if child := self.config.get_child(startswith="description "):
-            return child.text.split(maxsplit=1)[1]
-        return ""
+    _bundle_membership_prefix = "channel-group "
+    _encapsulation_prefix = "encapsulation dot1Q "
 
     @property
     def duplex(self) -> InterfaceDuplex:
         if duplex := self.config.get_child(startswith="duplex "):
             return InterfaceDuplex(duplex.text.split()[1])
         return InterfaceDuplex.AUTO
-
-    @property
-    def enabled(self) -> bool:
-        return not self.config.get_child(equals="shutdown")
 
     @property
     def has_nac(self) -> bool:
@@ -72,19 +47,8 @@ class ConfigViewInterfaceCiscoIOS(  # noqa: PLR0904
     @property
     def ipv4_interfaces(self) -> Iterable[IPv4Interface]:
         for ipv4_address_obj in self.config.get_children(startswith="ip address "):
-            ipv4_address = ipv4_address_obj.text.split()
-            try:
-                yield IPv4Interface("/".join(ipv4_address[2:4]))
-            except AddressValueError:
-                continue
-
-    @property
-    def is_loopback(self) -> bool:
-        return self.name.lower().startswith("loopback")
-
-    @property
-    def is_svi(self) -> bool:
-        return self.name.lower().startswith("vlan")
+            if interface := parse_ipv4_interface(ipv4_address_obj.text.split()[2:]):
+                yield interface
 
     @property
     def nac_control_direction_in(self) -> bool:
@@ -127,53 +91,8 @@ class ConfigViewInterfaceCiscoIOS(  # noqa: PLR0904
         raise NotImplementedError
 
     @property
-    def name(self) -> str:
-        return self.config.text.split()[1]
-
-    @property
-    def native_vlan(self) -> int | None:
-        # It's configured as a sub-interface
-        if self.is_subinterface and (
-            vlan := self.config.get_child(startswith="encapsulation dot1Q ")
-        ):
-            return int(vlan.text.split()[2])
-
-        # It's not a switchport
-        if (
-            self.config.get_child(equals="no switchport")
-            or self.config.get_child(startswith="ip address ")
-            or self.is_loopback
-            or self.is_svi
-        ):
-            return None
-
-        # It's configured as a trunk
-        if self.config.get_child(equals="switchport mode trunk"):
-            if vlan := self.config.get_child(
-                startswith="switchport trunk native vlan ",
-            ):
-                return int(vlan.text.split()[4])
-
-            return None
-
-        # It's either dynamic or configured as an access port
-        if vlan := self.config.get_child(startswith="switchport access vlan "):
-            return int(vlan.text.split()[3])
-
-        # Default VLAN
-        return 1
-
-    @property
-    def number(self) -> str:
-        return sub(r"^[a-zA-Z-]+", "", self.name)
-
-    @property
     def poe(self) -> bool:
         return not self.config.get_child(equals="power inline never")
-
-    @property
-    def port_number(self) -> int:
-        return int(self.number.split("/")[-1].split(".")[0])
 
     @property
     def speed(self) -> tuple[int, ...] | None:
@@ -182,21 +101,6 @@ class ConfigViewInterfaceCiscoIOS(  # noqa: PLR0904
                 return None
             return (int(speed.text.split()[1]),)
         return None
-
-    @property
-    def tagged_all(self) -> bool:
-        return bool(
-            self.config.get_child(equals="switchport mode trunk")
-            and not self.tagged_vlans,
-        )
-
-    @property
-    def tagged_vlans(self) -> tuple[int, ...]:
-        if child := self.config.get_child(
-            re_search="^switchport trunk allowed vlan [0-9,-]+$",
-        ):
-            return expand_range(child.text.split()[4])
-        return ()
 
     @property
     def vrf(self) -> str:
@@ -219,11 +123,6 @@ class HConfigViewCiscoIOS(HConfigViewBase):
         return None
 
     @property
-    def interface_names_mentioned(self) -> frozenset[str]:
-        """Returns a set with all the interface names mentioned in the config."""
-        return frozenset(model.name for model in self.interface_views)
-
-    @property
     def interface_views(self) -> Iterable[ConfigViewInterfaceCiscoIOS]:
         for interface in self.interfaces:
             yield ConfigViewInterfaceCiscoIOS(interface)
@@ -237,12 +136,6 @@ class HConfigViewCiscoIOS(HConfigViewBase):
         if gateway := self.config.get_child(startswith="ip default-gateway "):
             return IPv4Address(gateway.text.split()[2])
         return None
-
-    @property
-    def location(self) -> str:
-        if location := self.config.get_child(startswith="snmp-server location "):
-            return location.text.split(maxsplit=2)[2].replace('"', "")
-        return ""
 
     @property
     def stack_members(self) -> Iterable[StackMember]:
@@ -262,31 +155,3 @@ class HConfigViewCiscoIOS(HConfigViewBase):
                 mac_address=None,
                 model=words[3],
             )
-
-    @property
-    def vlans(self) -> Iterable[Vlan]:
-        yielded_vlans: set[int] = set()
-
-        # Yield explicitly defined VLANs
-        for child in self.config.get_children(re_search="^vlan [0-9,-]+$"):
-            vlan_name = None
-            if name := child.get_child(startswith="name "):
-                _, vlan_name = name.text.split(maxsplit=1)
-                vlan_name = vlan_name.replace('"', "")
-            for vlan_id in expand_range(child.text.split()[1]):
-                yielded_vlans.add(vlan_id)
-                yield Vlan(
-                    id=vlan_id,
-                    name=vlan_name or None,
-                )
-
-        # Yield any remaining unnamed VLANs mentioned on interfaces
-        for interface_view in self.interface_views:
-            if (
-                native_vlan := interface_view.native_vlan
-            ) and native_vlan not in yielded_vlans:
-                yielded_vlans.add(native_vlan)
-                yield Vlan(
-                    id=native_vlan,
-                    name=None,
-                )

--- a/hier_config/platforms/cisco_ios/view.py
+++ b/hier_config/platforms/cisco_ios/view.py
@@ -11,12 +11,20 @@ from hier_config.platforms.models import (
     Vlan,
 )
 from hier_config.platforms.view_base import (
-    ConfigViewInterfaceBase,
     HConfigViewBase,
+    InterfaceBundleViewMixin,
+    InterfaceNACViewMixin,
+    InterfacePhysicalViewMixin,
+    InterfaceVlanViewMixin,
 )
 
 
-class ConfigViewInterfaceCiscoIOS(ConfigViewInterfaceBase):  # noqa: PLR0904
+class ConfigViewInterfaceCiscoIOS(  # noqa: PLR0904
+    InterfaceBundleViewMixin,
+    InterfaceNACViewMixin,
+    InterfacePhysicalViewMixin,
+    InterfaceVlanViewMixin,
+):
     """Interface config view for Cisco IOS / IOS-XE."""
 
     @property
@@ -27,13 +35,13 @@ class ConfigViewInterfaceCiscoIOS(ConfigViewInterfaceBase):  # noqa: PLR0904
 
     @property
     def bundle_member_interfaces(self) -> Iterable[str]:
-        raise NotImplementedError
-
-    @property
-    def bundle_name(self) -> str | None:
-        if self.bundle_id:
-            return f"{self._bundle_prefix}{self.bundle_id}"
-        return None
+        if not self.is_bundle:
+            return
+        for interface in self.config.parent.get_children(startswith="interface "):
+            if (
+                channel_group := interface.get_child(startswith="channel-group ")
+            ) and channel_group.text.split()[1] == self.number:
+                yield interface.text.split()[1]
 
     @property
     def description(self) -> str:
@@ -62,10 +70,6 @@ class ConfigViewInterfaceCiscoIOS(ConfigViewInterfaceBase):  # noqa: PLR0904
         )
 
     @property
-    def ipv4_interface(self) -> IPv4Interface | None:
-        return next(iter(self.ipv4_interfaces), None)
-
-    @property
     def ipv4_interfaces(self) -> Iterable[IPv4Interface]:
         for ipv4_address_obj in self.config.get_children(startswith="ip address "):
             ipv4_address = ipv4_address_obj.text.split()
@@ -75,27 +79,12 @@ class ConfigViewInterfaceCiscoIOS(ConfigViewInterfaceBase):  # noqa: PLR0904
                 continue
 
     @property
-    def is_bundle(self) -> bool:
-        return self.name.lower().startswith(self._bundle_prefix)
-
-    @property
     def is_loopback(self) -> bool:
         return self.name.lower().startswith("loopback")
 
     @property
-    def is_subinterface(self) -> bool:
-        return "." in self.name
-
-    @property
     def is_svi(self) -> bool:
         return self.name.lower().startswith("vlan")
-
-    @property
-    def module_number(self) -> int | None:
-        words = self.number.split("/", 1)
-        if len(words) == 1:
-            return None
-        return int(words[0])
 
     @property
     def nac_control_direction_in(self) -> bool:
@@ -179,12 +168,6 @@ class ConfigViewInterfaceCiscoIOS(ConfigViewInterfaceBase):  # noqa: PLR0904
         return sub(r"^[a-zA-Z-]+", "", self.name)
 
     @property
-    def parent_name(self) -> str | None:
-        if self.is_subinterface:
-            return self.name.split(".")[0]
-        return None
-
-    @property
     def poe(self) -> bool:
         return not self.config.get_child(equals="power inline never")
 
@@ -199,10 +182,6 @@ class ConfigViewInterfaceCiscoIOS(ConfigViewInterfaceBase):  # noqa: PLR0904
                 return None
             return (int(speed.text.split()[1]),)
         return None
-
-    @property
-    def subinterface_number(self) -> int | None:
-        return int(self.name.split(".")[0 - 1]) if self.is_subinterface else None
 
     @property
     def tagged_all(self) -> bool:

--- a/hier_config/platforms/cisco_nxos/driver.py
+++ b/hier_config/platforms/cisco_nxos/driver.py
@@ -2,8 +2,8 @@ from hier_config.models import (
     IdempotentCommandsAvoidRule,
     IdempotentCommandsRule,
     MatchRule,
-    NegationDefaultWhenRule,
-    NegationDefaultWithRule,
+    NegationRule,
+    NegationStrategy,
     PerLineSubRule,
 )
 from hier_config.platforms.cisco_nxos.view import HConfigViewCiscoNXOS
@@ -362,8 +362,9 @@ class HConfigDriverCiscoNXOS(HConfigDriverBase):
                     ),
                 ),
             ],
-            negation_default_when=[
-                NegationDefaultWhenRule(
+            negation=[
+                NegationRule(
+                    strategy=NegationStrategy.DEFAULT,
                     match_rules=(
                         MatchRule(startswith="interface"),
                         MatchRule(
@@ -372,7 +373,8 @@ class HConfigDriverCiscoNXOS(HConfigDriverBase):
                         ),
                     ),
                 ),
-                NegationDefaultWhenRule(
+                NegationRule(
+                    strategy=NegationStrategy.DEFAULT,
                     match_rules=(
                         MatchRule(startswith="router bgp"),
                         MatchRule(startswith="neighbor"),
@@ -380,21 +382,22 @@ class HConfigDriverCiscoNXOS(HConfigDriverBase):
                         MatchRule(equals="send-community"),
                     ),
                 ),
-                NegationDefaultWhenRule(
+                NegationRule(
+                    strategy=NegationStrategy.DEFAULT,
                     match_rules=(
                         MatchRule(startswith="interface"),
                         MatchRule(contains="ip ospf passive-interface"),
                     ),
                 ),
-                NegationDefaultWhenRule(
+                NegationRule(
+                    strategy=NegationStrategy.DEFAULT,
                     match_rules=(
                         MatchRule(startswith="interface"),
                         MatchRule(contains="ospfv3 passive-interface"),
                     ),
                 ),
-            ],
-            negate_with=[
-                NegationDefaultWithRule(
+                NegationRule(
+                    strategy=NegationStrategy.REPLACE,
                     match_rules=(
                         MatchRule(startswith="router bgp"),
                         MatchRule(startswith="address-family"),
@@ -402,7 +405,8 @@ class HConfigDriverCiscoNXOS(HConfigDriverBase):
                     ),
                     use="default maximum-paths ibgp",
                 ),
-                NegationDefaultWithRule(
+                NegationRule(
+                    strategy=NegationStrategy.REPLACE,
                     match_rules=(
                         MatchRule(startswith="router bgp"),
                         MatchRule(startswith="vrf"),
@@ -411,7 +415,8 @@ class HConfigDriverCiscoNXOS(HConfigDriverBase):
                     ),
                     use="default maximum-paths ibgp",
                 ),
-                NegationDefaultWithRule(
+                NegationRule(
+                    strategy=NegationStrategy.REPLACE,
                     match_rules=(
                         MatchRule(equals="line vty"),
                         MatchRule(startswith="session-limit"),

--- a/hier_config/platforms/cisco_nxos/view.py
+++ b/hier_config/platforms/cisco_nxos/view.py
@@ -1,10 +1,8 @@
 from collections.abc import Iterable
 from ipaddress import IPv4Address, IPv4Interface
-from re import sub
 
 from hier_config.child import HConfigChild
-from hier_config.platforms.functions import expand_range
-from hier_config.platforms.models import StackMember, Vlan
+from hier_config.platforms.functions import parse_ipv4_interface
 from hier_config.platforms.view_base import (
     HConfigViewBase,
     InterfaceBundleViewMixin,
@@ -18,109 +16,13 @@ class ConfigViewInterfaceCiscoNXOS(
 ):
     """Interface config view for Cisco NX-OS."""
 
-    @property
-    def bundle_id(self) -> str | None:
-        if channel_group := self.config.get_child(startswith="channel-group "):
-            return channel_group.text.split()[1]
-        return None
-
-    @property
-    def bundle_member_interfaces(self) -> Iterable[str]:
-        if not self.is_bundle:
-            return
-        for interface in self.config.parent.get_children(startswith="interface "):
-            if (
-                channel_group := interface.get_child(startswith="channel-group ")
-            ) and channel_group.text.split()[1] == self.number:
-                yield interface.text.split()[1]
-
-    @property
-    def description(self) -> str:
-        if child := self.config.get_child(startswith="description "):
-            return child.text.split(maxsplit=1)[1]
-        return ""
-
-    @property
-    def enabled(self) -> bool:
-        return not self.config.get_child(equals="shutdown")
+    _bundle_membership_prefix = "channel-group "
 
     @property
     def ipv4_interfaces(self) -> Iterable[IPv4Interface]:
         for ipv4_address_obj in self.config.get_children(startswith="ip address "):
-            words = ipv4_address_obj.text.split()
-            address = words[2] if "/" in words[2] else "/".join(words[2:4])
-            try:
-                yield IPv4Interface(address)
-            except ValueError:
-                continue
-
-    @property
-    def is_loopback(self) -> bool:
-        return self.name.lower().startswith("loopback")
-
-    @property
-    def is_svi(self) -> bool:
-        return self.name.lower().startswith("vlan")
-
-    @property
-    def name(self) -> str:
-        return self.config.text.split()[1]
-
-    @property
-    def native_vlan(self) -> int | None:
-        # It's configured as a sub-interface
-        if self.is_subinterface and (
-            vlan := self.config.get_child(startswith="encapsulation dot1q ")
-        ):
-            return int(vlan.text.split()[2])
-
-        # It's not a switchport
-        if (
-            self.config.get_child(equals="no switchport")
-            or self.config.get_child(startswith="ip address ")
-            or self.is_loopback
-            or self.is_svi
-        ):
-            return None
-
-        # It's configured as a trunk
-        if self.config.get_child(equals="switchport mode trunk"):
-            if vlan := self.config.get_child(
-                startswith="switchport trunk native vlan ",
-            ):
-                return int(vlan.text.split()[4])
-
-            return None
-
-        # It's either dynamic or configured as an access port
-        if vlan := self.config.get_child(startswith="switchport access vlan "):
-            return int(vlan.text.split()[3])
-
-        # Default VLAN
-        return 1
-
-    @property
-    def number(self) -> str:
-        return sub(r"^[a-zA-Z-]+", "", self.name)
-
-    @property
-    def port_number(self) -> int:
-        return int(self.number.split("/")[-1].split(".")[0])
-
-    @property
-    def tagged_all(self) -> bool:
-        return bool(
-            self.config.get_child(equals="switchport mode trunk")
-            and not self.tagged_vlans,
-        )
-
-    @property
-    def tagged_vlans(self) -> tuple[int, ...]:
-        if child := self.config.get_child(
-            re_search="^switchport trunk allowed vlan [0-9,-]+$",
-        ):
-            return expand_range(child.text.split()[4])
-        return ()
+            if interface := parse_ipv4_interface(ipv4_address_obj.text.split()[2:]):
+                yield interface
 
     @property
     def vrf(self) -> str:
@@ -143,11 +45,6 @@ class HConfigViewCiscoNXOS(HConfigViewBase):
         return None
 
     @property
-    def interface_names_mentioned(self) -> frozenset[str]:
-        """Returns a set with all the interface names mentioned in the config."""
-        return frozenset(model.name for model in self.interface_views)
-
-    @property
     def interface_views(self) -> Iterable[ConfigViewInterfaceCiscoNXOS]:
         for interface in self.interfaces:
             yield ConfigViewInterfaceCiscoNXOS(interface)
@@ -161,42 +58,3 @@ class HConfigViewCiscoNXOS(HConfigViewBase):
         if gateway := self.config.get_child(startswith="ip route 0.0.0.0/0 "):
             return IPv4Address(gateway.text.split()[3])
         return None
-
-    @property
-    def location(self) -> str:
-        if location := self.config.get_child(startswith="snmp-server location "):
-            return location.text.split(maxsplit=2)[2].replace('"', "")
-        return ""
-
-    @property
-    def stack_members(self) -> Iterable[StackMember]:
-        """Cisco NX-OS does not support stacking."""
-        return ()
-
-    @property
-    def vlans(self) -> Iterable[Vlan]:
-        yielded_vlans: set[int] = set()
-
-        # Yield explicitly defined VLANs
-        for child in self.config.get_children(re_search="^vlan [0-9,-]+$"):
-            vlan_name = None
-            if name := child.get_child(startswith="name "):
-                _, vlan_name = name.text.split(maxsplit=1)
-                vlan_name = vlan_name.replace('"', "")
-            for vlan_id in expand_range(child.text.split()[1]):
-                yielded_vlans.add(vlan_id)
-                yield Vlan(
-                    id=vlan_id,
-                    name=vlan_name or None,
-                )
-
-        # Yield any remaining unnamed VLANs mentioned on interfaces
-        for interface_view in self.interface_views:
-            if (
-                native_vlan := interface_view.native_vlan
-            ) and native_vlan not in yielded_vlans:
-                yielded_vlans.add(native_vlan)
-                yield Vlan(
-                    id=native_vlan,
-                    name=None,
-                )

--- a/hier_config/platforms/cisco_nxos/view.py
+++ b/hier_config/platforms/cisco_nxos/view.py
@@ -105,7 +105,7 @@ class ConfigViewInterfaceCiscoNXOS(
 
     @property
     def port_number(self) -> int:
-        return int(self.name.split("/")[-1].split(".")[0])
+        return int(self.number.split("/")[-1].split(".")[0])
 
     @property
     def tagged_all(self) -> bool:

--- a/hier_config/platforms/cisco_nxos/view.py
+++ b/hier_config/platforms/cisco_nxos/view.py
@@ -1,34 +1,38 @@
 from collections.abc import Iterable
-from ipaddress import AddressValueError, IPv4Address, IPv4Interface
+from ipaddress import IPv4Address, IPv4Interface
 from re import sub
 
 from hier_config.child import HConfigChild
-from hier_config.platforms.models import (
-    InterfaceDuplex,
-    NACHostMode,
-    StackMember,
-    Vlan,
-)
+from hier_config.platforms.functions import expand_range
+from hier_config.platforms.models import StackMember, Vlan
 from hier_config.platforms.view_base import (
-    ConfigViewInterfaceBase,
     HConfigViewBase,
+    InterfaceBundleViewMixin,
+    InterfaceVlanViewMixin,
 )
 
 
-class ConfigViewInterfaceCiscoNXOS(ConfigViewInterfaceBase):  # noqa: PLR0904
+class ConfigViewInterfaceCiscoNXOS(
+    InterfaceBundleViewMixin,
+    InterfaceVlanViewMixin,
+):
     """Interface config view for Cisco NX-OS."""
 
     @property
     def bundle_id(self) -> str | None:
-        raise NotImplementedError
+        if channel_group := self.config.get_child(startswith="channel-group "):
+            return channel_group.text.split()[1]
+        return None
 
     @property
     def bundle_member_interfaces(self) -> Iterable[str]:
-        raise NotImplementedError
-
-    @property
-    def bundle_name(self) -> str | None:
-        raise NotImplementedError
+        if not self.is_bundle:
+            return
+        for interface in self.config.parent.get_children(startswith="interface "):
+            if (
+                channel_group := interface.get_child(startswith="channel-group ")
+            ) and channel_group.text.split()[1] == self.number:
+                yield interface.text.split()[1]
 
     @property
     def description(self) -> str:
@@ -37,78 +41,26 @@ class ConfigViewInterfaceCiscoNXOS(ConfigViewInterfaceBase):  # noqa: PLR0904
         return ""
 
     @property
-    def duplex(self) -> InterfaceDuplex:
-        raise NotImplementedError
-
-    @property
     def enabled(self) -> bool:
-        raise NotImplementedError
-
-    @property
-    def has_nac(self) -> bool:
-        """Determine if the interface has NAC configured."""
-        raise NotImplementedError
-
-    @property
-    def ipv4_interface(self) -> IPv4Interface | None:
-        return next(iter(self.ipv4_interfaces), None)
+        return not self.config.get_child(equals="shutdown")
 
     @property
     def ipv4_interfaces(self) -> Iterable[IPv4Interface]:
         for ipv4_address_obj in self.config.get_children(startswith="ip address "):
-            ipv4_address = ipv4_address_obj.text.split()
+            words = ipv4_address_obj.text.split()
+            address = words[2] if "/" in words[2] else "/".join(words[2:4])
             try:
-                yield IPv4Interface("/".join(ipv4_address[2:4]))
-            except AddressValueError:
+                yield IPv4Interface(address)
+            except ValueError:
                 continue
-
-    @property
-    def is_bundle(self) -> bool:
-        return self.name.lower().startswith(self._bundle_prefix)
 
     @property
     def is_loopback(self) -> bool:
         return self.name.lower().startswith("loopback")
 
     @property
-    def is_subinterface(self) -> bool:
-        return "." in self.name
-
-    @property
     def is_svi(self) -> bool:
         return self.name.lower().startswith("vlan")
-
-    @property
-    def module_number(self) -> int | None:
-        words = self.number.split("/", 1)
-        if len(words) == 1:
-            return None
-        return int(words[0])
-
-    @property
-    def nac_control_direction_in(self) -> bool:
-        """Determine if the interface has NAC control direction in configured."""
-        raise NotImplementedError
-
-    @property
-    def nac_host_mode(self) -> NACHostMode | None:
-        """Determine the NAC host mode."""
-        raise NotImplementedError
-
-    @property
-    def nac_mab_first(self) -> bool:
-        """Determine if the interface has NAC configured for MAB first."""
-        raise NotImplementedError
-
-    @property
-    def nac_max_dot1x_clients(self) -> int:
-        """Determine the max dot1x clients."""
-        raise NotImplementedError
-
-    @property
-    def nac_max_mab_clients(self) -> int:
-        """Determine the max mab clients."""
-        raise NotImplementedError
 
     @property
     def name(self) -> str:
@@ -116,45 +68,65 @@ class ConfigViewInterfaceCiscoNXOS(ConfigViewInterfaceBase):  # noqa: PLR0904
 
     @property
     def native_vlan(self) -> int | None:
-        raise NotImplementedError
+        # It's configured as a sub-interface
+        if self.is_subinterface and (
+            vlan := self.config.get_child(startswith="encapsulation dot1q ")
+        ):
+            return int(vlan.text.split()[2])
+
+        # It's not a switchport
+        if (
+            self.config.get_child(equals="no switchport")
+            or self.config.get_child(startswith="ip address ")
+            or self.is_loopback
+            or self.is_svi
+        ):
+            return None
+
+        # It's configured as a trunk
+        if self.config.get_child(equals="switchport mode trunk"):
+            if vlan := self.config.get_child(
+                startswith="switchport trunk native vlan ",
+            ):
+                return int(vlan.text.split()[4])
+
+            return None
+
+        # It's either dynamic or configured as an access port
+        if vlan := self.config.get_child(startswith="switchport access vlan "):
+            return int(vlan.text.split()[3])
+
+        # Default VLAN
+        return 1
 
     @property
     def number(self) -> str:
         return sub(r"^[a-zA-Z-]+", "", self.name)
 
     @property
-    def parent_name(self) -> str | None:
-        if self.is_subinterface:
-            return self.name.split(".")[0]
-        return None
-
-    @property
-    def poe(self) -> bool:
-        raise NotImplementedError
-
-    @property
     def port_number(self) -> int:
         return int(self.name.split("/")[-1].split(".")[0])
 
     @property
-    def speed(self) -> tuple[int, ...] | None:
-        raise NotImplementedError
-
-    @property
-    def subinterface_number(self) -> int | None:
-        return int(self.name.split(".")[0 - 1]) if self.is_subinterface else None
-
-    @property
     def tagged_all(self) -> bool:
-        raise NotImplementedError
+        return bool(
+            self.config.get_child(equals="switchport mode trunk")
+            and not self.tagged_vlans,
+        )
 
     @property
     def tagged_vlans(self) -> tuple[int, ...]:
-        raise NotImplementedError
+        if child := self.config.get_child(
+            re_search="^switchport trunk allowed vlan [0-9,-]+$",
+        ):
+            return expand_range(child.text.split()[4])
+        return ()
 
     @property
     def vrf(self) -> str:
-        raise NotImplementedError
+        if vrf := self.config.get_child(startswith="vrf member "):
+            return vrf.text.split()[2]
+        return ""
 
     @property
     def _bundle_prefix(self) -> str:
@@ -173,7 +145,7 @@ class HConfigViewCiscoNXOS(HConfigViewBase):
     @property
     def interface_names_mentioned(self) -> frozenset[str]:
         """Returns a set with all the interface names mentioned in the config."""
-        raise NotImplementedError
+        return frozenset(model.name for model in self.interface_views)
 
     @property
     def interface_views(self) -> Iterable[ConfigViewInterfaceCiscoNXOS]:
@@ -186,16 +158,45 @@ class HConfigViewCiscoNXOS(HConfigViewBase):
 
     @property
     def ipv4_default_gw(self) -> IPv4Address | None:
-        raise NotImplementedError
+        if gateway := self.config.get_child(startswith="ip route 0.0.0.0/0 "):
+            return IPv4Address(gateway.text.split()[3])
+        return None
 
     @property
     def location(self) -> str:
-        raise NotImplementedError
+        if location := self.config.get_child(startswith="snmp-server location "):
+            return location.text.split(maxsplit=2)[2].replace('"', "")
+        return ""
 
     @property
     def stack_members(self) -> Iterable[StackMember]:
-        raise NotImplementedError
+        """Cisco NX-OS does not support stacking."""
+        return ()
 
     @property
     def vlans(self) -> Iterable[Vlan]:
-        raise NotImplementedError
+        yielded_vlans: set[int] = set()
+
+        # Yield explicitly defined VLANs
+        for child in self.config.get_children(re_search="^vlan [0-9,-]+$"):
+            vlan_name = None
+            if name := child.get_child(startswith="name "):
+                _, vlan_name = name.text.split(maxsplit=1)
+                vlan_name = vlan_name.replace('"', "")
+            for vlan_id in expand_range(child.text.split()[1]):
+                yielded_vlans.add(vlan_id)
+                yield Vlan(
+                    id=vlan_id,
+                    name=vlan_name or None,
+                )
+
+        # Yield any remaining unnamed VLANs mentioned on interfaces
+        for interface_view in self.interface_views:
+            if (
+                native_vlan := interface_view.native_vlan
+            ) and native_vlan not in yielded_vlans:
+                yielded_vlans.add(native_vlan)
+                yield Vlan(
+                    id=native_vlan,
+                    name=None,
+                )

--- a/hier_config/platforms/cisco_xr/view.py
+++ b/hier_config/platforms/cisco_xr/view.py
@@ -1,9 +1,8 @@
 from collections.abc import Iterable
 from ipaddress import IPv4Address, IPv4Interface
-from re import sub
 
 from hier_config.child import HConfigChild
-from hier_config.platforms.models import StackMember, Vlan
+from hier_config.platforms.functions import parse_ipv4_interface
 from hier_config.platforms.view_base import (
     HConfigViewBase,
     InterfaceBundleViewMixin,
@@ -15,63 +14,20 @@ class ConfigViewInterfaceCiscoIOSXR(
     InterfaceBundleViewMixin,
     InterfaceVlanViewMixin,
 ):
-    """Interface config view for Cisco IOS XR."""
+    """Interface config view for Cisco IOS XR.
 
-    @property
-    def bundle_id(self) -> str | None:
-        if bundle := self.config.get_child(startswith="bundle id "):
-            return bundle.text.split()[2]
-        return None
+    IOS XR has no switchports, so the VLAN view only reports sub-interface
+    dot1q encapsulations; ``tagged_all`` is always False and ``tagged_vlans``
+    is always empty.
+    """
 
-    @property
-    def bundle_member_interfaces(self) -> Iterable[str]:
-        if not self.is_bundle:
-            return
-        for interface in self.config.parent.get_children(startswith="interface "):
-            if (
-                bundle := interface.get_child(startswith="bundle id ")
-            ) and bundle.text.split()[2] == self.number:
-                yield interface.text.split()[1]
-
-    @property
-    def description(self) -> str:
-        if child := self.config.get_child(startswith="description "):
-            return child.text.split(maxsplit=1)[1]
-        return ""
-
-    @property
-    def enabled(self) -> bool:
-        return not self.config.get_child(equals="shutdown")
+    _bundle_membership_prefix = "bundle id "
 
     @property
     def ipv4_interfaces(self) -> Iterable[IPv4Interface]:
         for ipv4_address_obj in self.config.get_children(startswith="ipv4 address "):
-            words = ipv4_address_obj.text.split()[2:]
-            if len(words) == 1:
-                # ipv4 address x.x.x.x/nn
-                address = words[0]
-            elif words[1].startswith("/"):
-                # ipv4 address x.x.x.x /nn
-                address = f"{words[0]}{words[1]}"
-            else:
-                # ipv4 address x.x.x.x y.y.y.y
-                address = f"{words[0]}/{words[1]}"
-            try:
-                yield IPv4Interface(address)
-            except ValueError:
-                continue
-
-    @property
-    def is_loopback(self) -> bool:
-        return self.name.lower().startswith("loopback")
-
-    @property
-    def is_svi(self) -> bool:
-        return self.name.lower().startswith("vlan")
-
-    @property
-    def name(self) -> str:
-        return self.config.text.split()[1]
+            if interface := parse_ipv4_interface(ipv4_address_obj.text.split()[2:]):
+                yield interface
 
     @property
     def native_vlan(self) -> int | None:
@@ -81,24 +37,6 @@ class ConfigViewInterfaceCiscoIOSXR(
         ):
             return int(vlan.text.split()[2])
         return None
-
-    @property
-    def number(self) -> str:
-        return sub(r"^[a-zA-Z-]+", "", self.name)
-
-    @property
-    def port_number(self) -> int:
-        return int(self.number.split("/")[-1].split(".")[0])
-
-    @property
-    def tagged_all(self) -> bool:
-        """Cisco IOS XR has no switchports; interfaces never tag all VLANs."""
-        return False
-
-    @property
-    def tagged_vlans(self) -> tuple[int, ...]:
-        """Cisco IOS XR has no switchports; interfaces carry no tagged VLANs."""
-        return ()
 
     @property
     def vrf(self) -> str:
@@ -112,18 +50,17 @@ class ConfigViewInterfaceCiscoIOSXR(
 
 
 class HConfigViewCiscoIOSXR(HConfigViewBase):
-    """Full-tree config view for Cisco IOS XR."""
+    """Full-tree config view for Cisco IOS XR.
+
+    VLANs are derived from sub-interface encapsulations; IOS XR does not
+    support stacking.
+    """
 
     @property
     def hostname(self) -> str | None:
         if child := self.config.get_child(startswith="hostname "):
             return child.text.split()[1].lower()
         return None
-
-    @property
-    def interface_names_mentioned(self) -> frozenset[str]:
-        """Returns a set with all the interface names mentioned in the config."""
-        return frozenset(model.name for model in self.interface_views)
 
     @property
     def interface_views(self) -> Iterable[ConfigViewInterfaceCiscoIOSXR]:
@@ -147,28 +84,3 @@ class HConfigViewCiscoIOSXR(HConfigViewBase):
         ):
             return IPv4Address(route.text.split()[1])
         return None
-
-    @property
-    def location(self) -> str:
-        if location := self.config.get_child(startswith="snmp-server location "):
-            return location.text.split(maxsplit=2)[2].replace('"', "")
-        return ""
-
-    @property
-    def stack_members(self) -> Iterable[StackMember]:
-        """Cisco IOS XR does not support stacking."""
-        return ()
-
-    @property
-    def vlans(self) -> Iterable[Vlan]:
-        """Yield the VLANs encapsulated on sub-interfaces."""
-        yielded_vlans: set[int] = set()
-        for interface_view in self.interface_views:
-            if (
-                native_vlan := interface_view.native_vlan
-            ) and native_vlan not in yielded_vlans:
-                yielded_vlans.add(native_vlan)
-                yield Vlan(
-                    id=native_vlan,
-                    name=None,
-                )

--- a/hier_config/platforms/cisco_xr/view.py
+++ b/hier_config/platforms/cisco_xr/view.py
@@ -88,7 +88,7 @@ class ConfigViewInterfaceCiscoIOSXR(
 
     @property
     def port_number(self) -> int:
-        return int(self.name.split("/")[-1].split(".")[0])
+        return int(self.number.split("/")[-1].split(".")[0])
 
     @property
     def tagged_all(self) -> bool:

--- a/hier_config/platforms/cisco_xr/view.py
+++ b/hier_config/platforms/cisco_xr/view.py
@@ -1,40 +1,37 @@
 from collections.abc import Iterable
-from ipaddress import AddressValueError, IPv4Address, IPv4Interface
+from ipaddress import IPv4Address, IPv4Interface
 from re import sub
 
 from hier_config.child import HConfigChild
-from hier_config.platforms.models import (
-    InterfaceDuplex,
-    NACHostMode,
-    StackMember,
-    Vlan,
-)
+from hier_config.platforms.models import StackMember, Vlan
 from hier_config.platforms.view_base import (
-    ConfigViewInterfaceBase,
     HConfigViewBase,
+    InterfaceBundleViewMixin,
+    InterfaceVlanViewMixin,
 )
 
 
-class ConfigViewInterfaceCiscoIOSXR(ConfigViewInterfaceBase):  # noqa: PLR0904
+class ConfigViewInterfaceCiscoIOSXR(
+    InterfaceBundleViewMixin,
+    InterfaceVlanViewMixin,
+):
     """Interface config view for Cisco IOS XR."""
 
     @property
-    def _bundle_prefix(self) -> str:
-        return "Bundle-Ether"
-
-    @property
     def bundle_id(self) -> str | None:
-        raise NotImplementedError
+        if bundle := self.config.get_child(startswith="bundle id "):
+            return bundle.text.split()[2]
+        return None
 
     @property
     def bundle_member_interfaces(self) -> Iterable[str]:
-        raise NotImplementedError
-
-    @property
-    def bundle_name(self) -> str | None:
-        if self.bundle_id:
-            return f"{self._bundle_prefix}{self.bundle_id}"
-        return None
+        if not self.is_bundle:
+            return
+        for interface in self.config.parent.get_children(startswith="interface "):
+            if (
+                bundle := interface.get_child(startswith="bundle id ")
+            ) and bundle.text.split()[2] == self.number:
+                yield interface.text.split()[1]
 
     @property
     def description(self) -> str:
@@ -43,78 +40,34 @@ class ConfigViewInterfaceCiscoIOSXR(ConfigViewInterfaceBase):  # noqa: PLR0904
         return ""
 
     @property
-    def duplex(self) -> InterfaceDuplex:
-        raise NotImplementedError
-
-    @property
     def enabled(self) -> bool:
-        raise NotImplementedError
-
-    @property
-    def has_nac(self) -> bool:
-        """Determine if the interface has NAC configured."""
-        raise NotImplementedError
-
-    @property
-    def ipv4_interface(self) -> IPv4Interface | None:
-        return next(iter(self.ipv4_interfaces), None)
+        return not self.config.get_child(equals="shutdown")
 
     @property
     def ipv4_interfaces(self) -> Iterable[IPv4Interface]:
         for ipv4_address_obj in self.config.get_children(startswith="ipv4 address "):
-            ipv4_address = ipv4_address_obj.text.split()
+            words = ipv4_address_obj.text.split()[2:]
+            if len(words) == 1:
+                # ipv4 address x.x.x.x/nn
+                address = words[0]
+            elif words[1].startswith("/"):
+                # ipv4 address x.x.x.x /nn
+                address = f"{words[0]}{words[1]}"
+            else:
+                # ipv4 address x.x.x.x y.y.y.y
+                address = f"{words[0]}/{words[1]}"
             try:
-                yield IPv4Interface("/".join(ipv4_address[2:4]))
-            except AddressValueError:
+                yield IPv4Interface(address)
+            except ValueError:
                 continue
-
-    @property
-    def is_bundle(self) -> bool:
-        return self.name.lower().startswith(self._bundle_prefix)
 
     @property
     def is_loopback(self) -> bool:
         return self.name.lower().startswith("loopback")
 
     @property
-    def is_subinterface(self) -> bool:
-        return "." in self.name
-
-    @property
     def is_svi(self) -> bool:
         return self.name.lower().startswith("vlan")
-
-    @property
-    def module_number(self) -> int | None:
-        words = self.number.split("/", 1)
-        if len(words) == 1:
-            return None
-        return int(words[0])
-
-    @property
-    def nac_control_direction_in(self) -> bool:
-        """Determine if the interface has NAC control direction in configured."""
-        raise NotImplementedError
-
-    @property
-    def nac_host_mode(self) -> NACHostMode | None:
-        """Determine the NAC host mode."""
-        raise NotImplementedError
-
-    @property
-    def nac_mab_first(self) -> bool:
-        """Determine if the interface has NAC configured for MAB first."""
-        raise NotImplementedError
-
-    @property
-    def nac_max_dot1x_clients(self) -> int:
-        """Determine the max dot1x clients."""
-        raise NotImplementedError
-
-    @property
-    def nac_max_mab_clients(self) -> int:
-        """Determine the max mab clients."""
-        raise NotImplementedError
 
     @property
     def name(self) -> str:
@@ -122,45 +75,40 @@ class ConfigViewInterfaceCiscoIOSXR(ConfigViewInterfaceBase):  # noqa: PLR0904
 
     @property
     def native_vlan(self) -> int | None:
-        raise NotImplementedError
+        # VLANs only exist on sub-interfaces (e.g. `encapsulation dot1q 100`)
+        if self.is_subinterface and (
+            vlan := self.config.get_child(startswith="encapsulation dot1q ")
+        ):
+            return int(vlan.text.split()[2])
+        return None
 
     @property
     def number(self) -> str:
         return sub(r"^[a-zA-Z-]+", "", self.name)
 
     @property
-    def parent_name(self) -> str | None:
-        if self.is_subinterface:
-            return self.name.split(".")[0]
-        return None
-
-    @property
-    def poe(self) -> bool:
-        raise NotImplementedError
-
-    @property
     def port_number(self) -> int:
         return int(self.name.split("/")[-1].split(".")[0])
 
     @property
-    def speed(self) -> tuple[int, ...] | None:
-        raise NotImplementedError
-
-    @property
-    def subinterface_number(self) -> int | None:
-        return int(self.name.split(".")[0 - 1]) if self.is_subinterface else None
-
-    @property
     def tagged_all(self) -> bool:
-        raise NotImplementedError
+        """Cisco IOS XR has no switchports; interfaces never tag all VLANs."""
+        return False
 
     @property
     def tagged_vlans(self) -> tuple[int, ...]:
-        raise NotImplementedError
+        """Cisco IOS XR has no switchports; interfaces carry no tagged VLANs."""
+        return ()
 
     @property
     def vrf(self) -> str:
-        raise NotImplementedError
+        if vrf := self.config.get_child(startswith="vrf "):
+            return vrf.text.split()[1]
+        return ""
+
+    @property
+    def _bundle_prefix(self) -> str:
+        return "Bundle-Ether"
 
 
 class HConfigViewCiscoIOSXR(HConfigViewBase):
@@ -174,7 +122,8 @@ class HConfigViewCiscoIOSXR(HConfigViewBase):
 
     @property
     def interface_names_mentioned(self) -> frozenset[str]:
-        raise NotImplementedError
+        """Returns a set with all the interface names mentioned in the config."""
+        return frozenset(model.name for model in self.interface_views)
 
     @property
     def interface_views(self) -> Iterable[ConfigViewInterfaceCiscoIOSXR]:
@@ -187,16 +136,39 @@ class HConfigViewCiscoIOSXR(HConfigViewBase):
 
     @property
     def ipv4_default_gw(self) -> IPv4Address | None:
-        raise NotImplementedError
+        if (
+            (router_static := self.config.get_child(equals="router static"))
+            and (
+                address_family := router_static.get_child(
+                    equals="address-family ipv4 unicast",
+                )
+            )
+            and (route := address_family.get_child(startswith="0.0.0.0/0 "))
+        ):
+            return IPv4Address(route.text.split()[1])
+        return None
 
     @property
     def location(self) -> str:
-        raise NotImplementedError
+        if location := self.config.get_child(startswith="snmp-server location "):
+            return location.text.split(maxsplit=2)[2].replace('"', "")
+        return ""
 
     @property
     def stack_members(self) -> Iterable[StackMember]:
-        raise NotImplementedError
+        """Cisco IOS XR does not support stacking."""
+        return ()
 
     @property
     def vlans(self) -> Iterable[Vlan]:
-        raise NotImplementedError
+        """Yield the VLANs encapsulated on sub-interfaces."""
+        yielded_vlans: set[int] = set()
+        for interface_view in self.interface_views:
+            if (
+                native_vlan := interface_view.native_vlan
+            ) and native_vlan not in yielded_vlans:
+                yielded_vlans.add(native_vlan)
+                yield Vlan(
+                    id=native_vlan,
+                    name=None,
+                )

--- a/hier_config/platforms/driver_base.py
+++ b/hier_config/platforms/driver_base.py
@@ -117,6 +117,9 @@ class HConfigDriverRules(BaseModel):  # pylint: disable=too-many-instance-attrib
     post_load_callbacks: list[Callable[[HConfig], None]] = Field(
         default_factory=_post_load_callbacks_default
     )
+    remediation_transform_callbacks: list[Callable[[HConfig], None]] = Field(
+        default_factory=_post_load_callbacks_default
+    )
     sectional_exiting: list[SectionalExitingRule] = Field(
         default_factory=_sectional_exiting_rules_default
     )

--- a/hier_config/platforms/driver_base.py
+++ b/hier_config/platforms/driver_base.py
@@ -13,9 +13,8 @@ from hier_config.models import (
     IdempotentCommandsRule,
     IndentAdjustRule,
     MatchRule,
-    NegationDefaultWhenRule,
-    NegationDefaultWithRule,
-    NegationSubRule,
+    NegationRule,
+    NegationStrategy,
     OrderingRule,
     ParentAllowsDuplicateChildRule,
     PerLineSubRule,
@@ -46,11 +45,7 @@ def _indent_adjust_rules_default() -> list[IndentAdjustRule]:
     return []
 
 
-def _negation_default_when_rules_default() -> list[NegationDefaultWhenRule]:
-    return []
-
-
-def _negate_with_rules_default() -> list[NegationDefaultWithRule]:
+def _negation_rules_default() -> list[NegationRule]:
     return []
 
 
@@ -86,10 +81,6 @@ def _sectional_overwrite_no_negate_rules_default() -> list[
     return []
 
 
-def _negation_sub_rules_default() -> list[NegationSubRule]:
-    return []
-
-
 def _unused_object_rules_default() -> list[UnusedObjectRule]:
     return []
 
@@ -115,12 +106,7 @@ class HConfigDriverRules(BaseModel):  # pylint: disable=too-many-instance-attrib
         default_factory=_indent_adjust_rules_default
     )
     indentation: PositiveInt = 2
-    negation_default_when: list[NegationDefaultWhenRule] = Field(
-        default_factory=_negation_default_when_rules_default
-    )
-    negate_with: list[NegationDefaultWithRule] = Field(
-        default_factory=_negate_with_rules_default
-    )
+    negation: list[NegationRule] = Field(default_factory=_negation_rules_default)
     ordering: list[OrderingRule] = Field(default_factory=_ordering_rules_default)
     parent_allows_duplicate_child: list[ParentAllowsDuplicateChildRule] = Field(
         default_factory=_parent_allows_duplicate_child_rules_default
@@ -139,9 +125,6 @@ class HConfigDriverRules(BaseModel):  # pylint: disable=too-many-instance-attrib
     )
     sectional_overwrite_no_negate: list[SectionalOverwriteNoNegateRule] = Field(
         default_factory=_sectional_overwrite_no_negate_rules_default
-    )
-    negation_sub: list[NegationSubRule] = Field(
-        default_factory=_negation_sub_rules_default
     )
     unused_objects: list[UnusedObjectRule] = Field(
         default_factory=_unused_object_rules_default
@@ -182,9 +165,16 @@ class HConfigDriverBase(ABC):
         return None
 
     def negate_with(self, config: HConfigChild) -> str | None:
-        for with_rule in self.rules.negate_with:
-            if config.is_lineage_match(with_rule.match_rules):
-                return with_rule.use
+        """Return a fixed replacement negation string for `config`, if any.
+
+        Reads REPLACE-strategy rules from the unified `negation` rule list.
+        Drivers may override this method for imperative negation logic.
+        """
+        for rule in self.rules.negation:
+            if rule.strategy is NegationStrategy.REPLACE and config.is_lineage_match(
+                rule.match_rules
+            ):
+                return rule.use
         return None
 
     def sectional_exit(self, config: HConfigChild) -> str | None:

--- a/hier_config/platforms/functions.py
+++ b/hier_config/platforms/functions.py
@@ -1,3 +1,31 @@
+from ipaddress import IPv4Interface
+
+
+def parse_ipv4_interface(words: list[str]) -> IPv4Interface | None:
+    """Parse the address words of an interface IPv4 address command.
+
+    Handles the three common forms:
+
+    - a single CIDR word: ``10.0.0.1/24``
+    - an address and a slash-prefixed length: ``10.0.0.1 /24``
+    - an address and a netmask: ``10.0.0.1 255.255.255.0``
+
+    Returns None when the words do not form a valid IPv4 interface.
+    """
+    if not words:
+        return None
+    if len(words) == 1 or "/" in words[0]:
+        address = words[0]
+    elif words[1].startswith("/"):
+        address = f"{words[0]}{words[1]}"
+    else:
+        address = f"{words[0]}/{words[1]}"
+    try:
+        return IPv4Interface(address)
+    except ValueError:
+        return None
+
+
 def expand_range(number_range_str: str) -> tuple[int, ...]:
     """Expand ranges like 2-5,8,22-45."""
     numbers: list[int] = []

--- a/hier_config/platforms/hp_procurve/driver.py
+++ b/hier_config/platforms/hp_procurve/driver.py
@@ -5,7 +5,8 @@ from hier_config.child import HConfigChild
 from hier_config.models import (
     IdempotentCommandsRule,
     MatchRule,
-    NegationDefaultWithRule,
+    NegationRule,
+    NegationStrategy,
     OrderingRule,
     PerLineSubRule,
 )
@@ -226,15 +227,17 @@ class HConfigDriverHPProcurve(HConfigDriverBase):
     @staticmethod
     def _instantiate_rules() -> HConfigDriverRules:
         return HConfigDriverRules(
-            negate_with=[
-                NegationDefaultWithRule(
+            negation=[
+                NegationRule(
+                    strategy=NegationStrategy.REPLACE,
                     match_rules=(
                         MatchRule(startswith="interface "),
                         MatchRule(equals="disable"),
                     ),
                     use="enable",
                 ),
-                NegationDefaultWithRule(
+                NegationRule(
+                    strategy=NegationStrategy.REPLACE,
                     match_rules=(
                         MatchRule(startswith="interface "),
                         MatchRule(startswith="name "),

--- a/hier_config/platforms/hp_procurve/view.py
+++ b/hier_config/platforms/hp_procurve/view.py
@@ -168,7 +168,7 @@ class ConfigViewInterfaceHPProcurve(  # noqa: PLR0904
 
     @property
     def port_number(self) -> int:
-        return int(self.name.split("/")[-1].split(".")[0])
+        return int(self.number.split("/")[-1].split(".")[0])
 
     @property
     def speed(self) -> tuple[int, ...] | None:

--- a/hier_config/platforms/hp_procurve/view.py
+++ b/hier_config/platforms/hp_procurve/view.py
@@ -20,7 +20,7 @@ from hier_config.platforms.view_base import (
 )
 
 
-class ConfigViewInterfaceHPProcurve(  # noqa: PLR0904
+class ConfigViewInterfaceHPProcurve(
     InterfaceBundleViewMixin,
     InterfaceNACViewMixin,
     InterfacePhysicalViewMixin,
@@ -98,14 +98,6 @@ class ConfigViewInterfaceHPProcurve(  # noqa: PLR0904
                 continue
 
     @property
-    def is_loopback(self) -> bool:
-        return self.name.lower().startswith("loopback")
-
-    @property
-    def is_svi(self) -> bool:
-        return self.name.lower().startswith("vlan")
-
-    @property
     def nac_control_direction_in(self) -> bool:
         """Determine if the interface has NAC control direction in configured."""
         return (
@@ -159,16 +151,8 @@ class ConfigViewInterfaceHPProcurve(  # noqa: PLR0904
         return None
 
     @property
-    def number(self) -> str:
-        return re.sub(r"^[a-zA-Z-]+", "", self.name)
-
-    @property
     def poe(self) -> bool:
         return not self.config.get_child(equals="no power-over-ethernet")
-
-    @property
-    def port_number(self) -> int:
-        return int(self.number.split("/")[-1].split(".")[0])
 
     @property
     def speed(self) -> tuple[int, ...] | None:
@@ -255,12 +239,6 @@ class HConfigViewHPProcurve(HConfigViewBase):
         if gateway := self.config.get_child(startswith="ip default-gateway "):
             return IPv4Address(gateway.text.split()[2])
         return None
-
-    @property
-    def location(self) -> str:
-        if location := self.config.get_child(startswith="snmp-server location "):
-            return location.text.split(maxsplit=2)[2].replace('"', "")
-        return ""
 
     @property
     def stack_members(self) -> Iterable[StackMember]:

--- a/hier_config/platforms/hp_procurve/view.py
+++ b/hier_config/platforms/hp_procurve/view.py
@@ -12,19 +12,27 @@ from hier_config.platforms.models import (
     Vlan,
 )
 from hier_config.platforms.view_base import (
-    ConfigViewInterfaceBase,
     HConfigViewBase,
+    InterfaceBundleViewMixin,
+    InterfaceNACViewMixin,
+    InterfacePhysicalViewMixin,
+    InterfaceVlanViewMixin,
 )
 
 
-class ConfigViewInterfaceHPProcurve(  # noqa: PLR0904 pylint: disable=abstract-method
-    ConfigViewInterfaceBase,
+class ConfigViewInterfaceHPProcurve(  # noqa: PLR0904
+    InterfaceBundleViewMixin,
+    InterfaceNACViewMixin,
+    InterfacePhysicalViewMixin,
+    InterfaceVlanViewMixin,
 ):
     """Interface config view for HP ProCurve / Aruba AOSS."""
 
     @property
     def bundle_id(self) -> str | None:
-        raise NotImplementedError
+        if bundle_name := self.bundle_name:
+            return bundle_name.lower().removeprefix(self._bundle_prefix.lower())
+        return None
 
     @property
     def bundle_member_interfaces(self) -> Iterable[str]:
@@ -81,10 +89,6 @@ class ConfigViewInterfaceHPProcurve(  # noqa: PLR0904 pylint: disable=abstract-m
         )
 
     @property
-    def ipv4_interface(self) -> IPv4Interface | None:
-        return next(iter(self.ipv4_interfaces), None)
-
-    @property
     def ipv4_interfaces(self) -> Iterable[IPv4Interface]:
         for ipv4_address_obj in self.config.get_children(startswith="ip address "):
             ipv4_address = ipv4_address_obj.text.split()
@@ -94,27 +98,12 @@ class ConfigViewInterfaceHPProcurve(  # noqa: PLR0904 pylint: disable=abstract-m
                 continue
 
     @property
-    def is_bundle(self) -> bool:
-        return self.name.lower().startswith(self._bundle_prefix)
-
-    @property
     def is_loopback(self) -> bool:
         return self.name.lower().startswith("loopback")
 
     @property
-    def is_subinterface(self) -> bool:
-        return "." in self.name
-
-    @property
     def is_svi(self) -> bool:
         return self.name.lower().startswith("vlan")
-
-    @property
-    def module_number(self) -> int | None:
-        words = self.number.split("/", 1)
-        if len(words) == 1:
-            return None
-        return int(words[0])
 
     @property
     def nac_control_direction_in(self) -> bool:
@@ -174,12 +163,6 @@ class ConfigViewInterfaceHPProcurve(  # noqa: PLR0904 pylint: disable=abstract-m
         return re.sub(r"^[a-zA-Z-]+", "", self.name)
 
     @property
-    def parent_name(self) -> str | None:
-        if self.is_subinterface:
-            return self.name.split(".")[0]
-        return None
-
-    @property
     def poe(self) -> bool:
         return not self.config.get_child(equals="no power-over-ethernet")
 
@@ -192,10 +175,6 @@ class ConfigViewInterfaceHPProcurve(  # noqa: PLR0904 pylint: disable=abstract-m
         if speed := self.config.get_child(startswith="speed-duplex "):
             return _speed_from_speed_duplex(speed.text)
         return None
-
-    @property
-    def subinterface_number(self) -> int | None:
-        return int(self.name.split(".")[0 - 1]) if self.is_subinterface else None
 
     @property
     def tagged_all(self) -> bool:

--- a/hier_config/platforms/view_base.py
+++ b/hier_config/platforms/view_base.py
@@ -13,12 +13,18 @@ from hier_config.platforms.models import (
 from hier_config.root import HConfig
 
 
-class ConfigViewInterfaceBase:  # noqa: PLR0904
+class ConfigViewInterfaceBase(ABC):
     """Abstract base providing a typed view over a single interface config node.
 
     Subclasses parse the child tree of one ``interface ...`` block and expose
-    structured properties (IP address, duplex, VLAN membership, bundle state,
-    etc.) in a platform-independent way.
+    structured properties (IP address, description, enabled state, etc.) in a
+    platform-independent way.
+
+    Optional capabilities (bundles, VLANs, NAC, physical-layer settings) are
+    modeled as mixins (:class:`InterfaceBundleViewMixin`,
+    :class:`InterfaceVlanViewMixin`, :class:`InterfaceNACViewMixin`,
+    :class:`InterfacePhysicalViewMixin`). Platform views inherit the mixins
+    they genuinely support, and users check capability with ``isinstance()``.
     """
 
     def __init__(self, config: HConfigChild) -> None:
@@ -26,49 +32,13 @@ class ConfigViewInterfaceBase:  # noqa: PLR0904
 
     @property
     @abstractmethod
-    def bundle_id(self) -> str | None:
-        """Determine the bundle ID."""
-
-    @property
-    @abstractmethod
-    def bundle_member_interfaces(self) -> Iterable[str]:
-        """Determine the member interfaces of a bundle."""
-
-    @property
-    @abstractmethod
-    def bundle_name(self) -> str | None:
-        """Determine the bundle name of a bundle member."""
-
-    @property
-    @abstractmethod
     def description(self) -> str:
         """Determine the interface's description."""
-
-    @property
-    def dot1q_mode(self) -> InterfaceDot1qMode | None:
-        """Derive the configured 802.1Q mode."""
-        if self.tagged_all:
-            return InterfaceDot1qMode.TAGGED_ALL
-        if self.tagged_vlans:
-            return InterfaceDot1qMode.TAGGED
-        if self.native_vlan and not self.is_svi:
-            return InterfaceDot1qMode.ACCESS
-        return None
-
-    @property
-    @abstractmethod
-    def duplex(self) -> InterfaceDuplex:
-        """Determine the configured Duplex of the interface."""
 
     @property
     @abstractmethod
     def enabled(self) -> bool:
         """Determines if the interface is enabled."""
-
-    @property
-    @abstractmethod
-    def has_nac(self) -> bool:
-        """Determine if the interface has NAC configured."""
 
     @property
     def ipv4_interface(self) -> IPv4Interface | None:
@@ -79,11 +49,6 @@ class ConfigViewInterfaceBase:  # noqa: PLR0904
     @abstractmethod
     def ipv4_interfaces(self) -> Iterable[IPv4Interface]:
         """Determine the configured IPv4Interface, address/prefix, objects."""
-
-    @property
-    @abstractmethod
-    def is_bundle(self) -> bool:
-        """Determine if the interface is a bundle."""
 
     @property
     @abstractmethod
@@ -102,8 +67,105 @@ class ConfigViewInterfaceBase:  # noqa: PLR0904
 
     @property
     @abstractmethod
-    def module_number(self) -> int | None:
-        """Determine the module number of the interface."""
+    def name(self) -> str:
+        """Determine the name of the interface."""
+
+    @property
+    @abstractmethod
+    def number(self) -> str:
+        """Remove letters from the interface name, leaving just numbers and symbols."""
+
+    @property
+    def parent_name(self) -> str | None:
+        """Determine the parent interface name of a subinterface."""
+        if self.is_subinterface:
+            return self.name.split(".")[0]
+        return None
+
+    @property
+    @abstractmethod
+    def port_number(self) -> int:
+        """Determine the interface port number."""
+
+    @property
+    def subinterface_number(self) -> int | None:
+        """Determine the sub-interface number."""
+        return int(self.name.split(".")[-1]) if self.is_subinterface else None
+
+    @property
+    @abstractmethod
+    def vrf(self) -> str:
+        """Determine the VRF."""
+
+
+class InterfaceBundleViewMixin(ConfigViewInterfaceBase, ABC):
+    """Mixin for platforms that support bundle (LAG/port-channel) interfaces."""
+
+    @property
+    @abstractmethod
+    def bundle_id(self) -> str | None:
+        """Determine the bundle ID."""
+
+    @property
+    @abstractmethod
+    def bundle_member_interfaces(self) -> Iterable[str]:
+        """Determine the member interfaces of a bundle."""
+
+    @property
+    def bundle_name(self) -> str | None:
+        """Determine the bundle name of a bundle member."""
+        if self.bundle_id:
+            return f"{self._bundle_prefix}{self.bundle_id}"
+        return None
+
+    @property
+    def is_bundle(self) -> bool:
+        """Determine if the interface is a bundle."""
+        return self.name.lower().startswith(self._bundle_prefix.lower())
+
+    @property
+    @abstractmethod
+    def _bundle_prefix(self) -> str:
+        """Determine the platform's bundle interface name prefix."""
+
+
+class InterfaceVlanViewMixin(ConfigViewInterfaceBase, ABC):
+    """Mixin for platforms that support 802.1Q VLAN interface configuration."""
+
+    @property
+    def dot1q_mode(self) -> InterfaceDot1qMode | None:
+        """Derive the configured 802.1Q mode."""
+        if self.tagged_all:
+            return InterfaceDot1qMode.TAGGED_ALL
+        if self.tagged_vlans:
+            return InterfaceDot1qMode.TAGGED
+        if self.native_vlan and not self.is_svi:
+            return InterfaceDot1qMode.ACCESS
+        return None
+
+    @property
+    @abstractmethod
+    def native_vlan(self) -> int | None:
+        """Determine the native VLAN."""
+
+    @property
+    @abstractmethod
+    def tagged_all(self) -> bool:
+        """Determine if all the VLANs are tagged."""
+
+    @property
+    @abstractmethod
+    def tagged_vlans(self) -> tuple[int, ...]:
+        """Determine the tagged VLANs."""
+
+
+class InterfaceNACViewMixin(ConfigViewInterfaceBase, ABC):
+    """Mixin for platforms that support NAC (802.1X/MAB) interface configuration."""
+
+    @property
+    @abstractmethod
+    def has_nac(self) -> bool:
+        """Determine if the interface has NAC configured."""
 
     @property
     @abstractmethod
@@ -130,25 +192,22 @@ class ConfigViewInterfaceBase:  # noqa: PLR0904
     def nac_max_mab_clients(self) -> int:
         """Determine the max mab clients."""
 
-    @property
-    @abstractmethod
-    def name(self) -> str:
-        """Determine the name of the interface."""
+
+class InterfacePhysicalViewMixin(ConfigViewInterfaceBase, ABC):
+    """Mixin for platforms that expose physical-layer interface settings."""
 
     @property
     @abstractmethod
-    def native_vlan(self) -> int | None:
-        """Determine the native VLAN."""
+    def duplex(self) -> InterfaceDuplex:
+        """Determine the configured Duplex of the interface."""
 
     @property
-    @abstractmethod
-    def number(self) -> str:
-        """Remove letters from the interface name, leaving just numbers and symbols."""
-
-    @property
-    @abstractmethod
-    def parent_name(self) -> str | None:
-        """Determine the parent bundle interface name."""
+    def module_number(self) -> int | None:
+        """Determine the module number of the interface."""
+        words = self.number.split("/", 1)
+        if len(words) == 1:
+            return None
+        return int(words[0])
 
     @property
     @abstractmethod
@@ -157,38 +216,8 @@ class ConfigViewInterfaceBase:  # noqa: PLR0904
 
     @property
     @abstractmethod
-    def port_number(self) -> int:
-        """Determine the interface port number."""
-
-    @property
-    @abstractmethod
     def speed(self) -> tuple[int, ...] | None:
         """Determine the statically allowed speeds the interface can operate at. In Mbps."""
-
-    @property
-    @abstractmethod
-    def subinterface_number(self) -> int | None:
-        """Determine the sub-interface number."""
-
-    @property
-    @abstractmethod
-    def tagged_all(self) -> bool:
-        """Determine if all the VLANs are tagged."""
-
-    @property
-    @abstractmethod
-    def tagged_vlans(self) -> tuple[int, ...]:
-        """Determine the tagged VLANs."""
-
-    @property
-    @abstractmethod
-    def vrf(self) -> str:
-        """Determine the VRF."""
-
-    @property
-    @abstractmethod
-    def _bundle_prefix(self) -> str:
-        pass
 
 
 class HConfigViewBase(ABC):
@@ -202,9 +231,12 @@ class HConfigViewBase(ABC):
         self.config = config
 
     @property
-    def bundle_interface_views(self) -> Iterable[ConfigViewInterfaceBase]:
+    def bundle_interface_views(self) -> Iterable[InterfaceBundleViewMixin]:
         for interface_view in self.interface_views:
-            if interface_view.is_bundle:
+            if (
+                isinstance(interface_view, InterfaceBundleViewMixin)
+                and interface_view.is_bundle
+            ):
                 yield interface_view
 
     @staticmethod
@@ -268,6 +300,8 @@ class HConfigViewBase(ABC):
     def module_numbers(self) -> Iterable[int]:
         seen: set[int] = set()
         for interface_view in self.interface_views:
+            if not isinstance(interface_view, InterfacePhysicalViewMixin):
+                continue
             if module_number := interface_view.module_number:
                 if module_number in seen:
                     continue

--- a/hier_config/platforms/view_base.py
+++ b/hier_config/platforms/view_base.py
@@ -117,6 +117,8 @@ class InterfaceBundleViewMixin(ConfigViewInterfaceBase, ABC):
     @property
     def bundle_id(self) -> str | None:
         """Determine the bundle ID."""
+        if not self._bundle_membership_prefix:
+            return None
         if membership := self.config.get_child(
             startswith=self._bundle_membership_prefix,
         ):
@@ -126,7 +128,7 @@ class InterfaceBundleViewMixin(ConfigViewInterfaceBase, ABC):
     @property
     def bundle_member_interfaces(self) -> Iterable[str]:
         """Determine the member interfaces of a bundle."""
-        if not self.is_bundle:
+        if not (self._bundle_membership_prefix and self.is_bundle):
             return
         id_index = len(self._bundle_membership_prefix.split())
         number = self.number

--- a/hier_config/platforms/view_base.py
+++ b/hier_config/platforms/view_base.py
@@ -1,8 +1,10 @@
 from abc import ABC, abstractmethod
 from collections.abc import Iterable
 from ipaddress import IPv4Address, IPv4Interface
+from re import sub
 
 from hier_config.child import HConfigChild
+from hier_config.platforms.functions import expand_range
 from hier_config.platforms.models import (
     InterfaceDot1qMode,
     InterfaceDuplex,
@@ -31,14 +33,16 @@ class ConfigViewInterfaceBase(ABC):
         self.config = config
 
     @property
-    @abstractmethod
     def description(self) -> str:
         """Determine the interface's description."""
+        if child := self.config.get_child(startswith="description "):
+            return child.text.split(maxsplit=1)[1]
+        return ""
 
     @property
-    @abstractmethod
     def enabled(self) -> bool:
         """Determines if the interface is enabled."""
+        return not self.config.get_child(equals="shutdown")
 
     @property
     def ipv4_interface(self) -> IPv4Interface | None:
@@ -51,9 +55,9 @@ class ConfigViewInterfaceBase(ABC):
         """Determine the configured IPv4Interface, address/prefix, objects."""
 
     @property
-    @abstractmethod
     def is_loopback(self) -> bool:
         """Determine if the interface is a loopback."""
+        return self.name.lower().startswith("loopback")
 
     @property
     def is_subinterface(self) -> bool:
@@ -61,19 +65,19 @@ class ConfigViewInterfaceBase(ABC):
         return "." in self.name
 
     @property
-    @abstractmethod
     def is_svi(self) -> bool:
         """Determine if the interface is an SVI."""
+        return self.name.lower().startswith("vlan")
 
     @property
-    @abstractmethod
     def name(self) -> str:
         """Determine the name of the interface."""
+        return self.config.text.split()[1]
 
     @property
-    @abstractmethod
     def number(self) -> str:
         """Remove letters from the interface name, leaving just numbers and symbols."""
+        return sub(r"^[a-zA-Z-]+", "", self.name)
 
     @property
     def parent_name(self) -> str | None:
@@ -83,9 +87,9 @@ class ConfigViewInterfaceBase(ABC):
         return None
 
     @property
-    @abstractmethod
     def port_number(self) -> int:
         """Determine the interface port number."""
+        return int(self.number.split("/")[-1].split(".")[0])
 
     @property
     def subinterface_number(self) -> int | None:
@@ -99,17 +103,40 @@ class ConfigViewInterfaceBase(ABC):
 
 
 class InterfaceBundleViewMixin(ConfigViewInterfaceBase, ABC):
-    """Mixin for platforms that support bundle (LAG/port-channel) interfaces."""
+    """Mixin for platforms that support bundle (LAG/port-channel) interfaces.
+
+    ``_bundle_membership_prefix`` is the child command prefix that assigns an
+    interface to a bundle, e.g. ``"channel-group "`` / ``"bundle id "``. It is
+    required by the default ``bundle_id``/``bundle_member_interfaces``
+    implementations; the bundle id is the word at index
+    ``len(_bundle_membership_prefix.split())`` of the matching child.
+    """
+
+    _bundle_membership_prefix: str = ""
 
     @property
-    @abstractmethod
     def bundle_id(self) -> str | None:
         """Determine the bundle ID."""
+        if membership := self.config.get_child(
+            startswith=self._bundle_membership_prefix,
+        ):
+            return membership.text.split()[len(self._bundle_membership_prefix.split())]
+        return None
 
     @property
-    @abstractmethod
     def bundle_member_interfaces(self) -> Iterable[str]:
         """Determine the member interfaces of a bundle."""
+        if not self.is_bundle:
+            return
+        id_index = len(self._bundle_membership_prefix.split())
+        number = self.number
+        for interface in self.config.parent.get_children(startswith="interface "):
+            if (
+                membership := interface.get_child(
+                    startswith=self._bundle_membership_prefix,
+                )
+            ) and membership.text.split()[id_index] == number:
+                yield interface.text.split()[1]
 
     @property
     def bundle_name(self) -> str | None:
@@ -130,7 +157,15 @@ class InterfaceBundleViewMixin(ConfigViewInterfaceBase, ABC):
 
 
 class InterfaceVlanViewMixin(ConfigViewInterfaceBase, ABC):
-    """Mixin for platforms that support 802.1Q VLAN interface configuration."""
+    """Mixin for platforms that support 802.1Q VLAN interface configuration.
+
+    ``_encapsulation_prefix`` is the subinterface dot1q encapsulation command
+    prefix used by the default ``native_vlan`` implementation; the VLAN id is
+    the word at index ``len(_encapsulation_prefix.split())`` of the matching
+    child.
+    """
+
+    _encapsulation_prefix: str = "encapsulation dot1q "
 
     @property
     def dot1q_mode(self) -> InterfaceDot1qMode | None:
@@ -144,19 +179,55 @@ class InterfaceVlanViewMixin(ConfigViewInterfaceBase, ABC):
         return None
 
     @property
-    @abstractmethod
     def native_vlan(self) -> int | None:
         """Determine the native VLAN."""
+        # It's configured as a sub-interface
+        if self.is_subinterface and (
+            vlan := self.config.get_child(startswith=self._encapsulation_prefix)
+        ):
+            return int(vlan.text.split()[len(self._encapsulation_prefix.split())])
+
+        # It's not a switchport
+        if (
+            self.config.get_child(equals="no switchport")
+            or self.config.get_child(startswith="ip address ")
+            or self.is_loopback
+            or self.is_svi
+        ):
+            return None
+
+        # It's configured as a trunk
+        if self.config.get_child(equals="switchport mode trunk"):
+            if vlan := self.config.get_child(
+                startswith="switchport trunk native vlan ",
+            ):
+                return int(vlan.text.split()[4])
+
+            return None
+
+        # It's either dynamic or configured as an access port
+        if vlan := self.config.get_child(startswith="switchport access vlan "):
+            return int(vlan.text.split()[3])
+
+        # Default VLAN
+        return 1
 
     @property
-    @abstractmethod
     def tagged_all(self) -> bool:
         """Determine if all the VLANs are tagged."""
+        return bool(
+            self.config.get_child(equals="switchport mode trunk")
+            and not self.tagged_vlans,
+        )
 
     @property
-    @abstractmethod
     def tagged_vlans(self) -> tuple[int, ...]:
         """Determine the tagged VLANs."""
+        if child := self.config.get_child(
+            re_search="^switchport trunk allowed vlan [0-9,-]+$",
+        ):
+            return expand_range(child.text.split()[4])
+        return ()
 
 
 class InterfaceNACViewMixin(ConfigViewInterfaceBase, ABC):
@@ -261,9 +332,9 @@ class HConfigViewBase(ABC):
         pass
 
     @property
-    @abstractmethod
     def interface_names_mentioned(self) -> frozenset[str]:
-        """Returns a set with all the interface names mentioned in the config."""
+        """Determine all the interface names mentioned in the config."""
+        return frozenset(model.name for model in self.interface_views)
 
     def interface_view_by_name(self, name: str) -> ConfigViewInterfaceBase | None:
         for interface_view in self.interface_views:
@@ -292,9 +363,11 @@ class HConfigViewBase(ABC):
         pass
 
     @property
-    @abstractmethod
     def location(self) -> str:
-        pass
+        """Determine the SNMP location."""
+        if location := self.config.get_child(startswith="snmp-server location "):
+            return location.text.split(maxsplit=2)[2].replace('"', "")
+        return ""
 
     @property
     def module_numbers(self) -> Iterable[int]:
@@ -309,9 +382,12 @@ class HConfigViewBase(ABC):
                 yield module_number
 
     @property
-    @abstractmethod
     def stack_members(self) -> Iterable[StackMember]:
-        """Determine the configured stack members."""
+        """Determine the configured stack members.
+
+        Defaults to an empty tuple for platforms without stacking support.
+        """
+        return ()
 
     @property
     def vlan_ids(self) -> frozenset[int]:
@@ -319,6 +395,37 @@ class HConfigViewBase(ABC):
         return frozenset(vlan.id for vlan in self.vlans)
 
     @property
-    @abstractmethod
     def vlans(self) -> Iterable[Vlan]:
-        """Determine the configured VLANs."""
+        """Determine the configured VLANs.
+
+        Yields explicitly defined VLAN blocks first, then any remaining
+        unnamed VLANs mentioned on interfaces (e.g. subinterface
+        encapsulations or switchport membership).
+        """
+        yielded_vlans: set[int] = set()
+
+        # Yield explicitly defined VLANs
+        for child in self.config.get_children(re_search="^vlan [0-9,-]+$"):
+            vlan_name = None
+            if name := child.get_child(startswith="name "):
+                _, vlan_name = name.text.split(maxsplit=1)
+                vlan_name = vlan_name.replace('"', "")
+            for vlan_id in expand_range(child.text.split()[1]):
+                yielded_vlans.add(vlan_id)
+                yield Vlan(
+                    id=vlan_id,
+                    name=vlan_name or None,
+                )
+
+        # Yield any remaining unnamed VLANs mentioned on interfaces
+        for interface_view in self.interface_views:
+            if not isinstance(interface_view, InterfaceVlanViewMixin):
+                continue
+            if (
+                native_vlan := interface_view.native_vlan
+            ) and native_vlan not in yielded_vlans:
+                yielded_vlans.add(native_vlan)
+                yield Vlan(
+                    id=native_vlan,
+                    name=None,
+                )

--- a/hier_config/plugins.py
+++ b/hier_config/plugins.py
@@ -1,0 +1,39 @@
+"""User-extensible remediation plugin system (#181).
+
+Plugins let users package custom remediation transforms — organization
+policies, safety sequences, provisioning workflows — outside the hier_config
+codebase and apply them via ``WorkflowRemediation(plugins=...)``. Driver
+authors should prefer ``remediation_transform_callbacks`` on
+``HConfigDriverRules`` (#180) for platform-level transforms.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .root import HConfig
+
+
+class RemediationPlugin(ABC):
+    """Base class for user-defined remediation plugins.
+
+    Subclasses implement ``transform()``, which receives the computed
+    remediation config and may mutate it in place (add safety commands,
+    reorder sections, drop disallowed changes, etc.).
+    """
+
+    @property
+    @abstractmethod
+    def name(self) -> str:
+        """Unique identifier for this plugin."""
+
+    @property
+    def description(self) -> str:
+        """Human-readable description of what this plugin does."""
+        return ""
+
+    @abstractmethod
+    def transform(self, remediation: HConfig) -> None:
+        """Transform the remediation config in place."""

--- a/hier_config/plugins.py
+++ b/hier_config/plugins.py
@@ -21,8 +21,14 @@ class RemediationPlugin(ABC):
 
     Subclasses implement ``transform()``, which receives the computed
     remediation config and may mutate it in place (add safety commands,
-    reorder sections, drop disallowed changes, etc.).
+    reorder sections, drop disallowed changes, etc.). Instances are
+    callable, so anywhere a plain ``Callable[[HConfig], None]`` transform
+    is accepted, a plugin works too.
     """
+
+    def __call__(self, remediation: HConfig) -> None:
+        """Apply this plugin's transform."""
+        self.transform(remediation)
 
     @property
     @abstractmethod

--- a/hier_config/registry.py
+++ b/hier_config/registry.py
@@ -1,0 +1,91 @@
+"""Driver registration system (#226).
+
+Built-in drivers are registered at import time. Users can register drivers for
+custom platforms (by string name), override built-in drivers, and restore
+built-in defaults by unregistering the override.
+"""
+
+from hier_config.exceptions import DriverNotFoundError
+from hier_config.models import Platform
+from hier_config.platforms.arista_eos.driver import HConfigDriverAristaEOS
+from hier_config.platforms.cisco_ios.driver import HConfigDriverCiscoIOS
+from hier_config.platforms.cisco_nxos.driver import HConfigDriverCiscoNXOS
+from hier_config.platforms.cisco_xr.driver import HConfigDriverCiscoIOSXR
+from hier_config.platforms.driver_base import HConfigDriverBase
+from hier_config.platforms.fortinet_fortios.driver import HConfigDriverFortinetFortiOS
+from hier_config.platforms.generic.driver import HConfigDriverGeneric
+from hier_config.platforms.hp_comware5.driver import HConfigDriverHPComware5
+from hier_config.platforms.hp_procurve.driver import HConfigDriverHPProcurve
+from hier_config.platforms.huawei_vrp.driver import HConfigDriverHuaweiVrp
+from hier_config.platforms.juniper_junos.driver import HConfigDriverJuniperJUNOS
+from hier_config.platforms.nokia_srl.driver import HConfigDriverNokiaSRL
+from hier_config.platforms.vyos.driver import HConfigDriverVYOS
+
+_BUILTIN_DRIVERS: dict[Platform, type[HConfigDriverBase]] = {
+    Platform.ARISTA_EOS: HConfigDriverAristaEOS,
+    Platform.CISCO_IOS: HConfigDriverCiscoIOS,
+    Platform.CISCO_NXOS: HConfigDriverCiscoNXOS,
+    Platform.CISCO_XR: HConfigDriverCiscoIOSXR,
+    Platform.FORTINET_FORTIOS: HConfigDriverFortinetFortiOS,
+    Platform.GENERIC: HConfigDriverGeneric,
+    Platform.HP_PROCURVE: HConfigDriverHPProcurve,
+    Platform.HP_COMWARE5: HConfigDriverHPComware5,
+    Platform.HUAWEI_VRP: HConfigDriverHuaweiVrp,
+    Platform.JUNIPER_JUNOS: HConfigDriverJuniperJUNOS,
+    Platform.NOKIA_SRL: HConfigDriverNokiaSRL,
+    Platform.VYOS: HConfigDriverVYOS,
+}
+
+_registry: dict[Platform | str, type[HConfigDriverBase]] = dict(_BUILTIN_DRIVERS)
+
+
+def _normalize(platform: Platform | str) -> Platform | str:
+    if isinstance(platform, Platform):
+        return platform
+    name = platform.upper()
+    try:
+        return Platform[name]
+    except KeyError:
+        return name
+
+
+def register_driver(
+    platform: Platform | str,
+    driver_class: type[HConfigDriverBase],
+) -> None:
+    """Register a driver for a platform.
+
+    Passing a string registers a custom platform usable anywhere a `Platform`
+    is accepted (names are case-insensitive). Passing an existing `Platform`
+    member overrides the built-in driver for that platform.
+    """
+    _registry[_normalize(platform)] = driver_class
+
+
+def unregister_driver(platform: Platform | str) -> None:
+    """Remove a custom platform, or restore an overridden built-in driver."""
+    platform = _normalize(platform)
+    if platform not in _registry:
+        message = f"Unsupported platform: {platform}"
+        raise DriverNotFoundError(message)
+    if isinstance(platform, Platform):
+        if _registry[platform] is _BUILTIN_DRIVERS[platform]:
+            message = f"Built-in platform {platform} is not overridden"
+            raise DriverNotFoundError(message)
+        _registry[platform] = _BUILTIN_DRIVERS[platform]
+    else:
+        del _registry[platform]
+
+
+def get_registered_platforms() -> tuple[Platform | str, ...]:
+    """Return all registered platforms, built-in and custom."""
+    return tuple(_registry)
+
+
+def get_hconfig_driver(platform: Platform | str) -> HConfigDriverBase:
+    """Instantiate the driver registered for a platform."""
+    driver_class = _registry.get(_normalize(platform))
+    if driver_class is None:
+        message = f"Unsupported platform: {platform}"
+        raise DriverNotFoundError(message)
+    return driver_class()

--- a/hier_config/registry.py
+++ b/hier_config/registry.py
@@ -21,7 +21,7 @@ from hier_config.platforms.juniper_junos.driver import HConfigDriverJuniperJUNOS
 from hier_config.platforms.nokia_srl.driver import HConfigDriverNokiaSRL
 from hier_config.platforms.vyos.driver import HConfigDriverVYOS
 
-_BUILTIN_DRIVERS: dict[Platform, type[HConfigDriverBase]] = {
+_BUILTIN_DRIVERS: dict[Platform | str, type[HConfigDriverBase]] = {
     Platform.ARISTA_EOS: HConfigDriverAristaEOS,
     Platform.CISCO_IOS: HConfigDriverCiscoIOS,
     Platform.CISCO_NXOS: HConfigDriverCiscoNXOS,

--- a/hier_config/registry.py
+++ b/hier_config/registry.py
@@ -3,6 +3,9 @@
 Built-in drivers are registered at import time. Users can register drivers for
 custom platforms (by string name), override built-in drivers, and restore
 built-in defaults by unregistering the override.
+
+The registry is not synchronized; register drivers at application startup,
+before configs are parsed concurrently.
 """
 
 from hier_config.exceptions import DriverNotFoundError

--- a/hier_config/reporting.py
+++ b/hier_config/reporting.py
@@ -18,7 +18,7 @@ from hier_config.models import ChangeDetail, ReportSummary, TagRule, TextStyle
 from hier_config.root import HConfig
 
 
-class RemediationReporter:  # noqa: PLR0904
+class RemediationReporter:  # ruff:ignore[too-many-public-methods]
     """A reporting tool for aggregating and analyzing remediation configurations.
 
     This class provides methods to merge multiple device remediations,
@@ -49,7 +49,7 @@ class RemediationReporter:  # noqa: PLR0904
 
     @property
     def merged_config(self) -> HConfig:
-        """Get the merged configuration.
+        """The merged configuration.
 
         Raises:
             ValueError: If no remediations have been added yet.
@@ -62,7 +62,7 @@ class RemediationReporter:  # noqa: PLR0904
 
     @property
     def device_count(self) -> int:
-        """Get the number of unique devices that have been added."""
+        """The number of unique devices that have been added."""
         return self._device_count
 
     def add_remediation(self, remediation: HConfig) -> None:

--- a/hier_config/reporting.py
+++ b/hier_config/reporting.py
@@ -133,7 +133,7 @@ class RemediationReporter:  # noqa: PLR0904
 
         Example:
             ```python
-            merged = get_hconfig(Platform.CISCO_IOS)
+            merged = HConfig.from_text(Platform.CISCO_IOS)
             merged.merge([device1, device2])
             reporter = RemediationReporter.from_merged_config(merged)
             ```

--- a/hier_config/root.py
+++ b/hier_config/root.py
@@ -6,6 +6,12 @@ from typing import TYPE_CHECKING
 from .base import HConfigBase
 from .child import HConfigChild
 from .models import Dump, DumpLine, Platform, ReferenceLocation
+from .tree_algorithms import (
+    compute_difference,
+    compute_future,
+    compute_remediation,
+    compute_with_tags,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Iterator
@@ -19,7 +25,7 @@ logger = getLogger(__name__)
 # - Cases of children.index() could be replaced with an identity based approach.
 
 
-class HConfig(HConfigBase):  # noqa: PLR0904
+class HConfig(HConfigBase):  # ruff:ignore[too-many-public-methods]
     """A class for representing and comparing Cisco like configurations in a
     hierarchical tree data structure.
     """
@@ -37,7 +43,9 @@ class HConfig(HConfigBase):  # noqa: PLR0904
         config_text: Path | str = "",
     ) -> HConfig:
         """Create an HConfig from raw configuration text (or a Path to it)."""
-        from .constructors import hconfig_from_text  # noqa: PLC0415
+        from .constructors import (
+            hconfig_from_text,
+        )
 
         return hconfig_from_text(platform_or_driver, config_text)
 
@@ -48,7 +56,9 @@ class HConfig(HConfigBase):  # noqa: PLR0904
         lines: list[str] | tuple[str, ...] | str,
     ) -> HConfig:
         """Create an HConfig from pre-split configuration lines (fast load)."""
-        from .constructors import hconfig_from_lines  # noqa: PLC0415
+        from .constructors import (
+            hconfig_from_lines,
+        )
 
         return hconfig_from_lines(platform_or_driver, lines)
 
@@ -59,7 +69,9 @@ class HConfig(HConfigBase):  # noqa: PLR0904
         dump: Dump,
     ) -> HConfig:
         """Reconstruct an HConfig from a serialized Dump."""
-        from .constructors import hconfig_from_dump  # noqa: PLC0415
+        from .constructors import (
+            hconfig_from_dump,
+        )
 
         return hconfig_from_dump(platform_or_driver, dump)
 
@@ -94,17 +106,17 @@ class HConfig(HConfigBase):  # noqa: PLR0904
 
     @property
     def root(self) -> HConfig:
-        """Returns the HConfig object at the base of the tree."""
+        """The HConfig object at the base of the tree."""
         return self
 
     @property
     def is_leaf(self) -> bool:
-        """Returns True if there are no children and is not an instance of HConfig."""
+        """True if there are no children and is not an instance of HConfig."""
         return False
 
     @property
     def is_branch(self) -> bool:
-        """Returns True if there are children or is an instance of HConfig."""
+        """True if there are children or is an instance of HConfig."""
         return True
 
     def instantiate_child(self, text: str) -> HConfigChild:
@@ -144,7 +156,7 @@ class HConfig(HConfigBase):  # noqa: PLR0904
             raise TypeError(message)
         return base
 
-    def lineage(self) -> Iterator[HConfigChild]:  # noqa: PLR6301
+    def lineage(self) -> Iterator[HConfigChild]:  # ruff:ignore[no-self-use]
         """Yields the lineage of parent objects, up to but excluding the root."""
         yield from ()
 
@@ -172,12 +184,12 @@ class HConfig(HConfigBase):  # noqa: PLR0904
 
     @property
     def depth(self) -> int:
-        """Returns the distance to the root HConfig object i.e. indent level."""
+        """The distance to the root HConfig object i.e. indent level."""
         return 0
 
     def difference(self, target: HConfig) -> HConfig:
         """Creates a new HConfig object with the config from self that is not in target."""
-        return self._difference(target, HConfig(self.driver))
+        return compute_difference(self, target, HConfig(self.driver))
 
     def remediation(
         self,
@@ -191,7 +203,7 @@ class HConfig(HConfigBase):  # noqa: PLR0904
         if delta is None:
             delta = HConfig(self.driver)
 
-        return self._remediation(target, delta)
+        return compute_remediation(self, target, delta)
 
     def add_ancestor_copy_of(
         self,
@@ -222,12 +234,12 @@ class HConfig(HConfigBase):  # noqa: PLR0904
         especially important.
         """
         future_config = HConfig(self.driver)
-        self._future(config, future_config)
+        compute_future(self, config, future_config)
         return future_config
 
     def with_tags(self, tags: Iterable[str]) -> HConfig:
         """Returns a new instance recursively containing children that only have a subset of tags."""
-        return self._with_tags(frozenset(tags), HConfig(self.driver))
+        return compute_with_tags(self, frozenset(tags), HConfig(self.driver))
 
     def all_children_sorted_by_tags(
         self,
@@ -252,7 +264,7 @@ class HConfig(HConfigBase):  # noqa: PLR0904
         extract their names, and search for references across the config tree.
         Objects with zero references are yielded.
         """
-        from re import search as _re_search  # noqa: PLC0415
+        from re import search as _re_search
 
         for rule in self.driver.rules.unused_objects:
             seen_names: set[str] = set()
@@ -274,8 +286,8 @@ class HConfig(HConfigBase):  # noqa: PLR0904
         reference_locations: tuple[ReferenceLocation, ...],
     ) -> bool:
         """Return True if *name* is found in any reference location."""
-        from re import escape as _re_escape  # noqa: PLC0415
-        from re import search as _re_search  # noqa: PLC0415
+        from re import escape as _re_escape
+        from re import search as _re_search
 
         for ref_location in reference_locations:
             pattern = ref_location.reference_re.format(name=_re_escape(name))

--- a/hier_config/root.py
+++ b/hier_config/root.py
@@ -37,9 +37,9 @@ class HConfig(HConfigBase):  # noqa: PLR0904
         config_text: Path | str = "",
     ) -> HConfig:
         """Create an HConfig from raw configuration text (or a Path to it)."""
-        from .constructors import _hconfig_from_text  # noqa: PLC0415
+        from .constructors import hconfig_from_text  # noqa: PLC0415
 
-        return _hconfig_from_text(platform_or_driver, config_text)
+        return hconfig_from_text(platform_or_driver, config_text)
 
     @classmethod
     def from_lines(
@@ -48,9 +48,9 @@ class HConfig(HConfigBase):  # noqa: PLR0904
         lines: list[str] | tuple[str, ...] | str,
     ) -> HConfig:
         """Create an HConfig from pre-split configuration lines (fast load)."""
-        from .constructors import _hconfig_from_lines  # noqa: PLC0415
+        from .constructors import hconfig_from_lines  # noqa: PLC0415
 
-        return _hconfig_from_lines(platform_or_driver, lines)
+        return hconfig_from_lines(platform_or_driver, lines)
 
     @classmethod
     def from_dump(
@@ -59,9 +59,9 @@ class HConfig(HConfigBase):  # noqa: PLR0904
         dump: Dump,
     ) -> HConfig:
         """Reconstruct an HConfig from a serialized Dump."""
-        from .constructors import _hconfig_from_dump  # noqa: PLC0415
+        from .constructors import hconfig_from_dump  # noqa: PLC0415
 
-        return _hconfig_from_dump(platform_or_driver, dump)
+        return hconfig_from_dump(platform_or_driver, dump)
 
     def __str__(self) -> str:
         return "\n".join(str(c) for c in sorted(self.children))

--- a/hier_config/root.py
+++ b/hier_config/root.py
@@ -284,6 +284,14 @@ class HConfig(HConfigBase):  # noqa: PLR0904
                     return True
         return False
 
-    def _is_duplicate_child_allowed(self) -> bool:  # noqa: PLR6301
-        """Determine if duplicate(identical text) children are allowed under the parent."""
-        return False
+    def _is_duplicate_child_allowed(self) -> bool:
+        """Determine if duplicate(identical text) children are allowed at the root.
+
+        A `ParentAllowsDuplicateChildRule` with empty `match_rules` applies to
+        the root (#215); children can never match an empty rule because lineage
+        matching requires equal lengths.
+        """
+        return any(
+            not rule.match_rules
+            for rule in self.driver.rules.parent_allows_duplicate_child
+        )

--- a/hier_config/root.py
+++ b/hier_config/root.py
@@ -5,10 +5,11 @@ from typing import TYPE_CHECKING
 
 from .base import HConfigBase
 from .child import HConfigChild
-from .models import Dump, DumpLine, ReferenceLocation
+from .models import Dump, DumpLine, Platform, ReferenceLocation
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Iterator
+    from pathlib import Path
 
     from hier_config.platforms.driver_base import HConfigDriverBase
 
@@ -28,6 +29,39 @@ class HConfig(HConfigBase):  # noqa: PLR0904
     def __init__(self, driver: HConfigDriverBase) -> None:
         super().__init__()
         self._driver = driver
+
+    @classmethod
+    def from_text(
+        cls,
+        platform_or_driver: Platform | str | HConfigDriverBase,
+        config_text: Path | str = "",
+    ) -> HConfig:
+        """Create an HConfig from raw configuration text (or a Path to it)."""
+        from .constructors import _hconfig_from_text  # noqa: PLC0415
+
+        return _hconfig_from_text(platform_or_driver, config_text)
+
+    @classmethod
+    def from_lines(
+        cls,
+        platform_or_driver: Platform | str | HConfigDriverBase,
+        lines: list[str] | tuple[str, ...] | str,
+    ) -> HConfig:
+        """Create an HConfig from pre-split configuration lines (fast load)."""
+        from .constructors import _hconfig_from_lines  # noqa: PLC0415
+
+        return _hconfig_from_lines(platform_or_driver, lines)
+
+    @classmethod
+    def from_dump(
+        cls,
+        platform_or_driver: Platform | str | HConfigDriverBase,
+        dump: Dump,
+    ) -> HConfig:
+        """Reconstruct an HConfig from a serialized Dump."""
+        from .constructors import _hconfig_from_dump  # noqa: PLC0415
+
+        return _hconfig_from_dump(platform_or_driver, dump)
 
     def __str__(self) -> str:
         return "\n".join(str(c) for c in sorted(self.children))

--- a/hier_config/tree_algorithms.py
+++ b/hier_config/tree_algorithms.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, TypeVar
 
 if TYPE_CHECKING:
+    from .base import HConfigBase
     from .child import HConfigChild
     from .root import HConfig
 
@@ -19,7 +20,7 @@ if TYPE_CHECKING:
 
 
 def compute_remediation(
-    source: HConfig | HConfigChild,
+    source: HConfigBase,
     target: _HConfigRootOrChildT,
     delta: _HConfigRootOrChildT,
 ) -> _HConfigRootOrChildT:
@@ -35,7 +36,7 @@ def compute_remediation(
 
 
 def _remediation_left(
-    source: HConfig | HConfigChild,
+    source: HConfigBase,
     target: HConfig | HConfigChild,
     delta: HConfig | HConfigChild,
 ) -> None:
@@ -57,7 +58,7 @@ def _remediation_left(
 
 
 def _remediation_right(
-    source: HConfig | HConfigChild,
+    source: HConfigBase,
     target: HConfig | HConfigChild,
     delta: HConfig | HConfigChild,
 ) -> None:
@@ -102,7 +103,7 @@ def _strip_acl_sequence_number(hier_child: HConfigChild) -> str:
 
 
 def compute_difference(
-    source: HConfig | HConfigChild,
+    source: HConfigBase,
     target: _HConfigRootOrChildT,
     delta: _HConfigRootOrChildT,
     target_acl_children: dict[str, HConfigChild] | None = None,
@@ -138,8 +139,7 @@ def compute_difference(
                     target_child,
                     delta_child,
                     target_acl_children={
-                        _strip_acl_sequence_number(c): c
-                        for c in target_child.children
+                        _strip_acl_sequence_number(c): c for c in target_child.children
                     },
                     in_acl=True,
                 )
@@ -152,7 +152,7 @@ def compute_difference(
 
 
 def _future_pre(
-    source: HConfig | HConfigChild,
+    source: HConfigBase,
     config: HConfig | HConfigChild,
 ) -> tuple[set[str], set[str]]:
     negated_or_recursed: set[str] = set()
@@ -168,7 +168,7 @@ def _future_pre(
 
 
 def compute_future(  # noqa: C901
-    source: HConfig | HConfigChild,
+    source: HConfigBase,
     config: HConfig | HConfigChild,
     future_config: HConfig | HConfigChild,
 ) -> None:
@@ -235,7 +235,7 @@ def compute_future(  # noqa: C901
 
 
 def compute_with_tags(
-    source: HConfig | HConfigChild,
+    source: HConfigBase,
     tags: frozenset[str],
     new_instance: _HConfigRootOrChildT,
 ) -> _HConfigRootOrChildT:

--- a/hier_config/tree_algorithms.py
+++ b/hier_config/tree_algorithms.py
@@ -1,0 +1,248 @@
+"""Tree comparison algorithms extracted from HConfigBase (#217).
+
+These functions implement diffing (`compute_difference`), remediation
+(`compute_remediation`), future-config prediction (`compute_future`), and
+tag-filtered copying (`compute_with_tags`) over configuration trees. They
+operate on `HConfig` / `HConfigChild` nodes through their public tree API,
+so they can be tested and extended independently of the tree structure.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, TypeVar
+
+if TYPE_CHECKING:
+    from .child import HConfigChild
+    from .root import HConfig
+
+    _HConfigRootOrChildT = TypeVar("_HConfigRootOrChildT", bound=HConfig | HConfigChild)
+
+
+def compute_remediation(
+    source: HConfig | HConfigChild,
+    target: _HConfigRootOrChildT,
+    delta: _HConfigRootOrChildT,
+) -> _HConfigRootOrChildT:
+    """Compute the commands needed to transition from source to target.
+
+    source is the running_config, target is the generated_config; the result
+    is written into delta (left pass negates missing, right pass adds new).
+    """
+    _remediation_left(source, target, delta)
+    _remediation_right(source, target, delta)
+
+    return delta
+
+
+def _remediation_left(
+    source: HConfig | HConfigChild,
+    target: HConfig | HConfigChild,
+    delta: HConfig | HConfigChild,
+) -> None:
+    # find source.children that are not in target.children
+    # i.e. what needs to be negated or defaulted
+    # Also, find out if another command in source.children will overwrite
+    # i.e. be idempotent
+    for self_child in source.children:
+        if self_child.text in target.children:
+            continue
+        if self_child.is_idempotent_command(target.children):
+            continue
+
+        # in other but not self
+        # add this node but not any children
+        negated = delta.add_child(self_child.text).negate()
+        if self_child.children:
+            negated.comments.add(f"removes {len(self_child.children) + 1} lines")
+
+
+def _remediation_right(
+    source: HConfig | HConfigChild,
+    target: HConfig | HConfigChild,
+    delta: HConfig | HConfigChild,
+) -> None:
+    # Find what would need to be added to source_config to get to self
+    for target_child in target.children:
+        # If the child exist, recurse into its children
+        if self_child := source.children.get(target_child.text):
+            # Do we need to rewrite the child and its children as well?
+            if self_child.use_sectional_overwrite():
+                self_child.overwrite_with(target_child, delta)
+                continue
+            if self_child.use_sectional_overwrite_without_negation():
+                self_child.overwrite_with(target_child, delta, negate=False)
+                continue
+            # Matched leaves can never produce delta lines - neither pass
+            # has children to visit - so skip the subtree allocation (#191).
+            if not (self_child.children or target_child.children):
+                continue
+            subtree = delta.instantiate_child(target_child.text)
+            compute_remediation(self_child, target_child, subtree)
+            if subtree.children:
+                delta.children.append(subtree)
+        # The child is absent, add it.
+        else:
+            # If the target_child is already in the delta, that means it was negated in the target config
+            if target_child.text in delta.children:
+                continue
+            new_item = delta.add_deep_copy_of(target_child)
+            # Mark the new item and all of its children as new_in_config.
+            new_item.new_in_config = True
+            for child in new_item.all_children():
+                child.new_in_config = True
+            if new_item.children:
+                new_item.comments.add("new section")
+
+
+def _strip_acl_sequence_number(hier_child: HConfigChild) -> str:
+    words = hier_child.text.split()
+    if words[0].isdecimal():
+        words.pop(0)
+    return " ".join(words)
+
+
+def compute_difference(
+    source: HConfig | HConfigChild,
+    target: _HConfigRootOrChildT,
+    delta: _HConfigRootOrChildT,
+    target_acl_children: dict[str, HConfigChild] | None = None,
+    *,
+    in_acl: bool = False,
+) -> _HConfigRootOrChildT:
+    """Compute the config from source that is not in target, writing into delta."""
+    acl_sw_matches = tuple(f"ip{x} access-list " for x in ("", "v4", "v6"))
+
+    for self_child in source.children:
+        # Not dealing with negations and defaults for now
+        if self_child.text.startswith((source.driver.negation_prefix, "default ")):
+            continue
+
+        if in_acl:
+            # Ignore ACL sequence numbers
+            if target_acl_children is None:
+                message = "target_acl_children cannot be None"
+                raise TypeError(message)
+            target_child = target_acl_children.get(
+                _strip_acl_sequence_number(self_child),
+            )
+        else:
+            target_child = target.get_child(equals=self_child.text)
+
+        if target_child is None:
+            delta.add_deep_copy_of(self_child)
+        else:
+            delta_child = delta.add_child(self_child.text)
+            if self_child.text.startswith(acl_sw_matches):
+                compute_difference(
+                    self_child,
+                    target_child,
+                    delta_child,
+                    target_acl_children={
+                        _strip_acl_sequence_number(c): c
+                        for c in target_child.children
+                    },
+                    in_acl=True,
+                )
+            else:
+                compute_difference(self_child, target_child, delta_child)
+            if not delta_child.children:
+                delta_child.delete()
+
+    return delta
+
+
+def _future_pre(
+    source: HConfig | HConfigChild,
+    config: HConfig | HConfigChild,
+) -> tuple[set[str], set[str]]:
+    negated_or_recursed: set[str] = set()
+    config_children_ignore: set[str] = set()
+    for self_child in source.children:
+        # Is the command effectively negating a command in source.children?
+        if (negation_text := source.root.driver.negate_with(self_child)) and (
+            config_child := config.get_child(equals=negation_text)
+        ):
+            negated_or_recursed.add(self_child.text)
+            config_children_ignore.add(config_child.text)
+    return negated_or_recursed, config_children_ignore
+
+
+def compute_future(  # noqa: C901
+    source: HConfig | HConfigChild,
+    config: HConfig | HConfigChild,
+    future_config: HConfig | HConfigChild,
+) -> None:
+    """Recursively compute the future configuration subtree.
+
+    Called by :meth:`HConfig.future` to walk the config tree and merge
+    ``config`` on top of ``source``, applying driver-specific rules for
+    sectional overwrite, idempotency, and negation.  The result is written
+    into ``future_config``.
+
+    Known gaps (not yet accounted for):
+
+    - Negating a numbered ACL when removing a single entry
+    - Idempotent command avoid list
+    - And likely other edge cases
+    """
+    negated_or_recursed, config_children_ignore = _future_pre(source, config)
+
+    for config_child in config.children:
+        if config_child.text in config_children_ignore:
+            continue
+        # sectional_overwrite
+        # sectional_overwrite_no_negate
+        if (
+            config_child.use_sectional_overwrite()
+            or config_child.use_sectional_overwrite_without_negation()
+        ):
+            future_config.add_deep_copy_of(config_child)
+        # Idempotent commands
+        elif self_child := source.root.driver.idempotent_for(
+            config_child,
+            source.children,
+        ):
+            future_config.add_deep_copy_of(config_child)
+            negated_or_recursed.add(self_child.text)
+        # config_child is already in source
+        elif self_child := source.get_child(equals=config_child.text):
+            future_child = future_config.add_shallow_copy_of(self_child)
+            compute_future(self_child, config_child, future_child)
+            negated_or_recursed.add(config_child.text)
+        # config_child is being negated
+        elif config_child.text.startswith(source.driver.negation_prefix):
+            unnegated_command = config_child.text_without_negation
+            if source.get_child(equals=unnegated_command):
+                negated_or_recursed.add(unnegated_command)
+            # Account for "no ..." commands in the running config
+            else:
+                future_config.add_shallow_copy_of(config_child)
+        # The negated form of config_child is in source.children
+        elif self_child := source.get_child(
+            equals=f"{source.driver.negation_prefix}{config_child.text}",
+        ):
+            negated_or_recursed.add(self_child.text)
+        # config_child is not in source and doesn't match a special case
+        else:
+            future_config.add_deep_copy_of(config_child)
+
+    for self_child in source.children:
+        # self_child matched an above special case and should be ignored
+        if self_child.text in negated_or_recursed:
+            continue
+        # self_child was not modified above and should be present in the future config
+        future_config.add_deep_copy_of(self_child)
+
+
+def compute_with_tags(
+    source: HConfig | HConfigChild,
+    tags: frozenset[str],
+    new_instance: _HConfigRootOrChildT,
+) -> _HConfigRootOrChildT:
+    """Add children recursively that have a subset of tags."""
+    for child in source.children:
+        if tags.issubset(child.tags):
+            new_child = new_instance.add_shallow_copy_of(child)
+            compute_with_tags(child, tags, new_child)
+
+    return new_instance

--- a/hier_config/tree_algorithms.py
+++ b/hier_config/tree_algorithms.py
@@ -167,7 +167,7 @@ def _future_pre(
     return negated_or_recursed, config_children_ignore
 
 
-def compute_future(  # noqa: C901
+def compute_future(  # ruff:ignore[complex-structure]
     source: HConfigBase,
     config: HConfig | HConfigChild,
     future_config: HConfig | HConfigChild,

--- a/hier_config/utils.py
+++ b/hier_config/utils.py
@@ -12,9 +12,8 @@ from hier_config.models import (
     IdempotentCommandsRule,
     IndentAdjustRule,
     MatchRule,
-    NegationDefaultWhenRule,
-    NegationDefaultWithRule,
-    NegationSubRule,
+    NegationRule,
+    NegationStrategy,
     OrderingRule,
     ParentAllowsDuplicateChildRule,
     PerLineSubRule,
@@ -134,15 +133,20 @@ def _process_custom_rules(options: dict[str, Any], driver: HConfigDriverBase) ->
 
     for rule in options.get("negation_negate_with", ()):
         match_rules = _collect_match_rules(rule.get("lineage", []))
-        driver.rules.negate_with.append(
-            NegationDefaultWithRule(match_rules=match_rules, use=rule.get("use", "")),
+        driver.rules.negation.append(
+            NegationRule(
+                match_rules=match_rules,
+                strategy=NegationStrategy.REPLACE,
+                use=rule.get("use", ""),
+            ),
         )
 
     for rule in options.get("negation_sub", ()):
         match_rules = _collect_match_rules(rule.get("lineage", []))
-        driver.rules.negation_sub.append(
-            NegationSubRule(
+        driver.rules.negation.append(
+            NegationRule(
                 match_rules=match_rules,
+                strategy=NegationStrategy.REGEX_SUB,
                 search=rule.get("search", ""),
                 replace=rule.get("replace", ""),
             ),
@@ -216,14 +220,15 @@ def load_driver_rules(
             IdempotentCommandsRule,
             driver.rules.idempotent_commands.append,
         ),
-        (
-            "negation_default_when",
-            NegationDefaultWhenRule,
-            driver.rules.negation_default_when.append,
-        ),
     )
     for key, rule_class, append_to in simple_rules:
         _process_simple_rules(options, key, rule_class, append_to)
+
+    for rule in options.get("negation_default_when", ()):
+        match_rules = _collect_match_rules(rule.get("lineage", []))
+        driver.rules.negation.append(
+            NegationRule(match_rules=match_rules, strategy=NegationStrategy.DEFAULT),
+        )
 
     # Process rules that require custom handling
     _process_custom_rules(options, driver)

--- a/hier_config/workflows.py
+++ b/hier_config/workflows.py
@@ -3,6 +3,7 @@ from logging import getLogger
 
 from .exceptions import IncompatibleDriverError
 from .models import TagRule
+from .plugins import RemediationPlugin
 from .root import HConfig
 
 logger = getLogger(__name__)
@@ -56,9 +57,11 @@ class WorkflowRemediation:
         self,
         running_config: HConfig,
         generated_config: HConfig,
+        plugins: Iterable[RemediationPlugin] = (),
     ) -> None:
         self.running_config = running_config
         self.generated_config = generated_config
+        self.plugins = tuple(plugins)
 
         if running_config.driver.__class__ is not generated_config.driver.__class__:
             message = "The running and generated configs must use the same driver."
@@ -85,6 +88,12 @@ class WorkflowRemediation:
         remediation_config = self.running_config.remediation(
             self.generated_config
         ).set_order_weight()
+
+        # Driver-level transforms (#180), then user plugins (#181).
+        for callback in remediation_config.driver.rules.remediation_transform_callbacks:
+            callback(remediation_config)
+        for plugin in self.plugins:
+            plugin.transform(remediation_config)
 
         self._remediation_config = remediation_config
 

--- a/hier_config/workflows.py
+++ b/hier_config/workflows.py
@@ -29,8 +29,8 @@ class WorkflowRemediation:
         from hier_config.model import Platform
 
         # Create running and generated configurations as HConfig objects
-        running_config = get_hconfig(Platform.CISCO_IOS, "running_config_text")
-        generated_config = get_hconfig(Platform.CISCO_IOS, "generated_config_text")
+        running_config = HConfig.from_text(Platform.CISCO_IOS, "running_config_text")
+        generated_config = HConfig.from_text(Platform.CISCO_IOS, "generated_config_text")
 
         # Initialize WorkflowRemediation with running and generated configurations
         workflow = WorkflowRemediation(running_config, generated_config)

--- a/hier_config/workflows.py
+++ b/hier_config/workflows.py
@@ -30,7 +30,9 @@ class WorkflowRemediation:
 
         # Create running and generated configurations as HConfig objects
         running_config = HConfig.from_text(Platform.CISCO_IOS, "running_config_text")
-        generated_config = HConfig.from_text(Platform.CISCO_IOS, "generated_config_text")
+        generated_config = HConfig.from_text(
+            Platform.CISCO_IOS, "generated_config_text"
+        )
 
         # Initialize WorkflowRemediation with running and generated configurations
         workflow = WorkflowRemediation(running_config, generated_config)

--- a/hier_config/workflows.py
+++ b/hier_config/workflows.py
@@ -1,9 +1,8 @@
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable
 from logging import getLogger
 
 from .exceptions import IncompatibleDriverError
 from .models import TagRule
-from .plugins import RemediationPlugin
 from .root import HConfig
 
 logger = getLogger(__name__)
@@ -57,7 +56,7 @@ class WorkflowRemediation:
         self,
         running_config: HConfig,
         generated_config: HConfig,
-        plugins: Iterable[RemediationPlugin] = (),
+        plugins: Iterable[Callable[[HConfig], None]] = (),
     ) -> None:
         self.running_config = running_config
         self.generated_config = generated_config
@@ -93,7 +92,7 @@ class WorkflowRemediation:
         for callback in remediation_config.driver.rules.remediation_transform_callbacks:
             callback(remediation_config)
         for plugin in self.plugins:
-            plugin.transform(remediation_config)
+            plugin(remediation_config)
 
         self._remediation_config = remediation_config
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -25,6 +25,50 @@ files = [
 ]
 
 [[package]]
+name = "ast-serialize"
+version = "0.6.0"
+description = "Python bindings for mypy AST serialization"
+optional = false
+python-versions = ">=3.7"
+groups = ["dev"]
+files = [
+    {file = "ast_serialize-0.6.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:a7520b672827885bafeae7501f684d14d47d17e5f45256f9df547686cca52264"},
+    {file = "ast_serialize-0.6.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a14191beec7e0c078d2fc1f6edc0aee88bcd4db9f18e1bc9f8052b559c22dddc"},
+    {file = "ast_serialize-0.6.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:32ef62ec34cf6be20ad77d4799556638fbdf187f3ae10698dfb20ef9f2c89516"},
+    {file = "ast_serialize-0.6.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:13b7769970a39983b0adf2f38917b1cd3b8946f76df045756c3d741bc689f089"},
+    {file = "ast_serialize-0.6.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6f7a408601bb3edaefb3bc67a4c01f5235e3253653b6a5729a2ee2382b35341c"},
+    {file = "ast_serialize-0.6.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8670bfa51208a2c0c8d138928e40e998fab158f9200d53bb80c088b5b8eda7b8"},
+    {file = "ast_serialize-0.6.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a4826809eb8597a8cd59fd924b6d7c285b8969a1e0007e2cb652cab62376270f"},
+    {file = "ast_serialize-0.6.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:577a6c189068686869f5f1ddc38363f3ae1808a4753b577266f9202071a7bb66"},
+    {file = "ast_serialize-0.6.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:085de7f62dc9cc247eb01e965a362707d1d90b1d89a82c5bf78301a60a3c417b"},
+    {file = "ast_serialize-0.6.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:9f8a8b78b13173de6a9ec22111d9be674874cd5bdccda04f14ae5ebc2bef403a"},
+    {file = "ast_serialize-0.6.0-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:f2ff3baffc3a29c1f15bc9098aa0c09763410262d5e6cef42116f7356c184554"},
+    {file = "ast_serialize-0.6.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:0067b25fce104eaae5b88383de9ab803faeb671831e14ca698b771b356e2600f"},
+    {file = "ast_serialize-0.6.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:c617417f9cbb0cb144f6283c3cbe0d2e0f01beaf9f608f662b21191058a626ec"},
+    {file = "ast_serialize-0.6.0-cp314-cp314t-win32.whl", hash = "sha256:5337cb256dcea3df9288205213d1601581536526b8f4da44b6974f1180f3252a"},
+    {file = "ast_serialize-0.6.0-cp314-cp314t-win_amd64.whl", hash = "sha256:2d947e45cafc4b09bd7528917fa84c517654a43de173c79785574b7b3068ac24"},
+    {file = "ast_serialize-0.6.0-cp314-cp314t-win_arm64.whl", hash = "sha256:6e15ec740436e1a0d62de848641abe5f3a2f89a7f94907d534795ac91bbacf14"},
+    {file = "ast_serialize-0.6.0-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:093cb8bb91b720d8523580498d031791bb1bbaa048599c3d21085d380e11a596"},
+    {file = "ast_serialize-0.6.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:e61580a69faf47e3689795367ed211f2a10fd741478cc0f36a0f128793360aad"},
+    {file = "ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:305802f2ce2a7c4e87835078ea85c58b586ddda8095b92fe2ead9364ae19c80a"},
+    {file = "ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c7b8b8f0c42f752ea00b2b7d7c090b3f80d9c1c5c75cadf16423790a0cc74081"},
+    {file = "ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:cd5b91b9e6f2356ace3a556963b0cd783b395fbbb0bb17b4defc283415466e77"},
+    {file = "ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4d6ef91590258ada18909b9caea344dac4de2013906b035473cd674a43f4b790"},
+    {file = "ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dcbed41e9386059fc0261d602445ede0976c2ecec2939688bcbcb9ed0b6f28b7"},
+    {file = "ast_serialize-0.6.0-cp39-abi3-manylinux_2_31_riscv64.whl", hash = "sha256:cdc4e6f930b9090c2f92c9036ad12ffb8e6e44d4a5ba06f1458a05d60f203f7b"},
+    {file = "ast_serialize-0.6.0-cp39-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:897ac47b5637be41c0c07061c8a912fafa967ef1dc73fa115e4bfa70882a093b"},
+    {file = "ast_serialize-0.6.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:c4af9a1386166e40ed01464991806f89038a2d89782576c7774876fa77034e32"},
+    {file = "ast_serialize-0.6.0-cp39-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:c901adbd750029b9ac4ad3d6aa56853e0ad4875119fbf52b7b8298afc223828b"},
+    {file = "ast_serialize-0.6.0-cp39-abi3-musllinux_1_2_i686.whl", hash = "sha256:3ae22a366b752ab4496191525b78b097b5b72d531752e3c1dd7e383a8f2c8a1a"},
+    {file = "ast_serialize-0.6.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:4ed29121da8b3fdc291002801a1de0f76248fa07dce89157a5f277842cf6126e"},
+    {file = "ast_serialize-0.6.0-cp39-abi3-pyemscripten_2026_0_wasm32.whl", hash = "sha256:b1dac4e09d341c1300ba69cdcbe62867b32a8c75d90db9bf4d083bec3b039f0b"},
+    {file = "ast_serialize-0.6.0-cp39-abi3-win32.whl", hash = "sha256:82c312a7844d2fdeb4d5c48bd3d215bf940dafd4704e1a9bcf252a99010a99b1"},
+    {file = "ast_serialize-0.6.0-cp39-abi3-win_amd64.whl", hash = "sha256:113b58346f9ceb664352032770caca817d4a3c86f611c6088e6ef65ddaa70f0e"},
+    {file = "ast_serialize-0.6.0-cp39-abi3-win_arm64.whl", hash = "sha256:ccd132fe8db56f61fe743b1f644d01b8d65b83248a8da506f3132bda86d6ed5e"},
+    {file = "ast_serialize-0.6.0.tar.gz", hash = "sha256:aadd3ffcf4858c9726bf3515f7b199c7eadbe504f96028e4a87172c0da65a8fe"},
+]
+
+[[package]]
 name = "astroid"
 version = "4.0.4"
 description = "An abstract syntax tree for Python with inference support."
@@ -41,26 +85,26 @@ typing-extensions = {version = ">=4", markers = "python_version < \"3.11\""}
 
 [[package]]
 name = "bracex"
-version = "2.6"
+version = "3.0"
 description = "Bash style brace expander."
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 groups = ["dev"]
 files = [
-    {file = "bracex-2.6-py3-none-any.whl", hash = "sha256:0b0049264e7340b3ec782b5cb99beb325f36c3782a32e36e876452fd49a09952"},
-    {file = "bracex-2.6.tar.gz", hash = "sha256:98f1347cd77e22ee8d967a30ad4e310b233f7754dbf31ff3fceb76145ba47dc7"},
+    {file = "bracex-3.0-py3-none-any.whl", hash = "sha256:3833e61c2f092d5aa0468fa2e6c6e990a306185abf763b6d122f0158e59c58a5"},
+    {file = "bracex-3.0.tar.gz", hash = "sha256:b73f718d6bd98d8419e45df02426c86e9967c179949f779340d6c3a8c83b9111"},
 ]
 
 [[package]]
 name = "click"
-version = "8.3.3"
+version = "8.4.2"
 description = "Composable command line interface toolkit"
 optional = false
 python-versions = ">=3.10"
 groups = ["dev"]
 files = [
-    {file = "click-8.3.3-py3-none-any.whl", hash = "sha256:a2bf429bb3033c89fa4936ffb35d5cb471e3719e1f3c8a7c3fff0b8314305613"},
-    {file = "click-8.3.3.tar.gz", hash = "sha256:398329ad4837b2ff7cbe1dd166a4c0f8900c3ca3a218de04466f38f6497f18a2"},
+    {file = "click-8.4.2-py3-none-any.whl", hash = "sha256:e6f9f66136c816745b9d65817da91d61d957fb16e02e4dcd0552553c5a197b76"},
+    {file = "click-8.4.2.tar.gz", hash = "sha256:9a6cea6e60b17ebe0a44c5cc636d94f09bd66142c1cd7d8b4cd731c4917a15f6"},
 ]
 
 [package.dependencies]
@@ -81,118 +125,103 @@ files = [
 
 [[package]]
 name = "coverage"
-version = "7.13.5"
+version = "7.15.2"
 description = "Code coverage measurement for Python"
 optional = false
 python-versions = ">=3.10"
 groups = ["dev"]
 files = [
-    {file = "coverage-7.13.5-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:e0723d2c96324561b9aa76fb982406e11d93cdb388a7a7da2b16e04719cf7ca5"},
-    {file = "coverage-7.13.5-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:52f444e86475992506b32d4e5ca55c24fc88d73bcbda0e9745095b28ef4dc0cf"},
-    {file = "coverage-7.13.5-cp310-cp310-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:704de6328e3d612a8f6c07000a878ff38181ec3263d5a11da1db294fa6a9bdf8"},
-    {file = "coverage-7.13.5-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:a1a6d79a14e1ec1832cabc833898636ad5f3754a678ef8bb4908515208bf84f4"},
-    {file = "coverage-7.13.5-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:79060214983769c7ba3f0cee10b54c97609dca4d478fa1aa32b914480fd5738d"},
-    {file = "coverage-7.13.5-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:356e76b46783a98c2a2fe81ec79df4883a1e62895ea952968fb253c114e7f930"},
-    {file = "coverage-7.13.5-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:0cef0cdec915d11254a7f549c1170afecce708d30610c6abdded1f74e581666d"},
-    {file = "coverage-7.13.5-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:dc022073d063b25a402454e5712ef9e007113e3a676b96c5f29b2bda29352f40"},
-    {file = "coverage-7.13.5-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:9b74db26dfea4f4e50d48a4602207cd1e78be33182bc9cbf22da94f332f99878"},
-    {file = "coverage-7.13.5-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:ad146744ca4fd09b50c482650e3c1b1f4dfa1d4792e0a04a369c7f23336f0400"},
-    {file = "coverage-7.13.5-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:c555b48be1853fe3997c11c4bd521cdd9a9612352de01fa4508f16ec341e6fe0"},
-    {file = "coverage-7.13.5-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:7034b5c56a58ae5e85f23949d52c14aca2cfc6848a31764995b7de88f13a1ea0"},
-    {file = "coverage-7.13.5-cp310-cp310-win32.whl", hash = "sha256:eb7fdf1ef130660e7415e0253a01a7d5a88c9c4d158bcf75cbbd922fd65a5b58"},
-    {file = "coverage-7.13.5-cp310-cp310-win_amd64.whl", hash = "sha256:3e1bb5f6c78feeb1be3475789b14a0f0a5b47d505bfc7267126ccbd50289999e"},
-    {file = "coverage-7.13.5-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:66a80c616f80181f4d643b0f9e709d97bcea413ecd9631e1dedc7401c8e6695d"},
-    {file = "coverage-7.13.5-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:145ede53ccbafb297c1c9287f788d1bc3efd6c900da23bf6931b09eafc931587"},
-    {file = "coverage-7.13.5-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:0672854dc733c342fa3e957e0605256d2bf5934feeac328da9e0b5449634a642"},
-    {file = "coverage-7.13.5-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:ec10e2a42b41c923c2209b846126c6582db5e43a33157e9870ba9fb70dc7854b"},
-    {file = "coverage-7.13.5-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:be3d4bbad9d4b037791794ddeedd7d64a56f5933a2c1373e18e9e568b9141686"},
-    {file = "coverage-7.13.5-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:4d2afbc5cc54d286bfb54541aa50b64cdb07a718227168c87b9e2fb8f25e1743"},
-    {file = "coverage-7.13.5-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3ad050321264c49c2fa67bb599100456fc51d004b82534f379d16445da40fb75"},
-    {file = "coverage-7.13.5-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:7300c8a6d13335b29bb76d7651c66af6bd8658517c43499f110ddc6717bfc209"},
-    {file = "coverage-7.13.5-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:eb07647a5738b89baab047f14edd18ded523de60f3b30e75c2acc826f79c839a"},
-    {file = "coverage-7.13.5-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:9adb6688e3b53adffefd4a52d72cbd8b02602bfb8f74dcd862337182fd4d1a4e"},
-    {file = "coverage-7.13.5-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:7c8d4bc913dd70b93488d6c496c77f3aff5ea99a07e36a18f865bca55adef8bd"},
-    {file = "coverage-7.13.5-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:0e3c426ffc4cd952f54ee9ffbdd10345709ecc78a3ecfd796a57236bfad0b9b8"},
-    {file = "coverage-7.13.5-cp311-cp311-win32.whl", hash = "sha256:259b69bb83ad9894c4b25be2528139eecba9a82646ebdda2d9db1ba28424a6bf"},
-    {file = "coverage-7.13.5-cp311-cp311-win_amd64.whl", hash = "sha256:258354455f4e86e3e9d0d17571d522e13b4e1e19bf0f8596bcf9476d61e7d8a9"},
-    {file = "coverage-7.13.5-cp311-cp311-win_arm64.whl", hash = "sha256:bff95879c33ec8da99fc9b6fe345ddb5be6414b41d6d1ad1c8f188d26f36e028"},
-    {file = "coverage-7.13.5-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:460cf0114c5016fa841214ff5564aa4864f11948da9440bc97e21ad1f4ba1e01"},
-    {file = "coverage-7.13.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0e223ce4b4ed47f065bfb123687686512e37629be25cc63728557ae7db261422"},
-    {file = "coverage-7.13.5-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:6e3370441f4513c6252bf042b9c36d22491142385049243253c7e48398a15a9f"},
-    {file = "coverage-7.13.5-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:03ccc709a17a1de074fb1d11f217342fb0d2b1582ed544f554fc9fc3f07e95f5"},
-    {file = "coverage-7.13.5-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3f4818d065964db3c1c66dc0fbdac5ac692ecbc875555e13374fdbe7eedb4376"},
-    {file = "coverage-7.13.5-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:012d5319e66e9d5a218834642d6c35d265515a62f01157a45bcc036ecf947256"},
-    {file = "coverage-7.13.5-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:8dd02af98971bdb956363e4827d34425cb3df19ee550ef92855b0acb9c7ce51c"},
-    {file = "coverage-7.13.5-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:f08fd75c50a760c7eb068ae823777268daaf16a80b918fa58eea888f8e3919f5"},
-    {file = "coverage-7.13.5-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:843ea8643cf967d1ac7e8ecd4bb00c99135adf4816c0c0593fdcc47b597fcf09"},
-    {file = "coverage-7.13.5-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:9d44d7aa963820b1b971dbecd90bfe5fe8f81cff79787eb6cca15750bd2f79b9"},
-    {file = "coverage-7.13.5-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:7132bed4bd7b836200c591410ae7d97bf7ae8be6fc87d160b2bd881df929e7bf"},
-    {file = "coverage-7.13.5-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a698e363641b98843c517817db75373c83254781426e94ada3197cabbc2c919c"},
-    {file = "coverage-7.13.5-cp312-cp312-win32.whl", hash = "sha256:bdba0a6b8812e8c7df002d908a9a2ea3c36e92611b5708633c50869e6d922fdf"},
-    {file = "coverage-7.13.5-cp312-cp312-win_amd64.whl", hash = "sha256:d2c87e0c473a10bffe991502eac389220533024c8082ec1ce849f4218dded810"},
-    {file = "coverage-7.13.5-cp312-cp312-win_arm64.whl", hash = "sha256:bf69236a9a81bdca3bff53796237aab096cdbf8d78a66ad61e992d9dac7eb2de"},
-    {file = "coverage-7.13.5-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5ec4af212df513e399cf11610cc27063f1586419e814755ab362e50a85ea69c1"},
-    {file = "coverage-7.13.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:941617e518602e2d64942c88ec8499f7fbd49d3f6c4327d3a71d43a1973032f3"},
-    {file = "coverage-7.13.5-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:da305e9937617ee95c2e39d8ff9f040e0487cbf1ac174f777ed5eddd7a7c1f26"},
-    {file = "coverage-7.13.5-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:78e696e1cc714e57e8b25760b33a8b1026b7048d270140d25dafe1b0a1ee05a3"},
-    {file = "coverage-7.13.5-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:02ca0eed225b2ff301c474aeeeae27d26e2537942aa0f87491d3e147e784a82b"},
-    {file = "coverage-7.13.5-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:04690832cbea4e4663d9149e05dba142546ca05cb1848816760e7f58285c970a"},
-    {file = "coverage-7.13.5-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:0590e44dd2745c696a778f7bab6aa95256de2cbc8b8cff4f7db8ff09813d6969"},
-    {file = "coverage-7.13.5-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d7cfad2d6d81dd298ab6b89fe72c3b7b05ec7544bdda3b707ddaecff8d25c161"},
-    {file = "coverage-7.13.5-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:e092b9499de38ae0fbfbc603a74660eb6ff3e869e507b50d85a13b6db9863e15"},
-    {file = "coverage-7.13.5-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:48c39bc4a04d983a54a705a6389512883d4a3b9862991b3617d547940e9f52b1"},
-    {file = "coverage-7.13.5-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:2d3807015f138ffea1ed9afeeb8624fd781703f2858b62a8dd8da5a0994c57b6"},
-    {file = "coverage-7.13.5-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:ee2aa19e03161671ec964004fb74b2257805d9710bf14a5c704558b9d8dbaf17"},
-    {file = "coverage-7.13.5-cp313-cp313-win32.whl", hash = "sha256:ce1998c0483007608c8382f4ff50164bfc5bd07a2246dd272aa4043b75e61e85"},
-    {file = "coverage-7.13.5-cp313-cp313-win_amd64.whl", hash = "sha256:631efb83f01569670a5e866ceb80fe483e7c159fac6f167e6571522636104a0b"},
-    {file = "coverage-7.13.5-cp313-cp313-win_arm64.whl", hash = "sha256:f4cd16206ad171cbc2470dbea9103cf9a7607d5fe8c242fdf1edf36174020664"},
-    {file = "coverage-7.13.5-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:0428cbef5783ad91fe240f673cc1f76b25e74bbfe1a13115e4aa30d3f538162d"},
-    {file = "coverage-7.13.5-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e0b216a19534b2427cc201a26c25da4a48633f29a487c61258643e89d28200c0"},
-    {file = "coverage-7.13.5-cp313-cp313t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:972a9cd27894afe4bc2b1480107054e062df08e671df7c2f18c205e805ccd806"},
-    {file = "coverage-7.13.5-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:4b59148601efcd2bac8c4dbf1f0ad6391693ccf7a74b8205781751637076aee3"},
-    {file = "coverage-7.13.5-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:505d7083c8b0c87a8fa8c07370c285847c1f77739b22e299ad75a6af6c32c5c9"},
-    {file = "coverage-7.13.5-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:60365289c3741e4db327e7baff2a4aaacf22f788e80fa4683393891b70a89fbd"},
-    {file = "coverage-7.13.5-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:1b88c69c8ef5d4b6fe7dea66d6636056a0f6a7527c440e890cf9259011f5e606"},
-    {file = "coverage-7.13.5-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:5b13955d31d1633cf9376908089b7cebe7d15ddad7aeaabcbe969a595a97e95e"},
-    {file = "coverage-7.13.5-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:f70c9ab2595c56f81a89620e22899eea8b212a4041bd728ac6f4a28bf5d3ddd0"},
-    {file = "coverage-7.13.5-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:084b84a8c63e8d6fc7e3931b316a9bcafca1458d753c539db82d31ed20091a87"},
-    {file = "coverage-7.13.5-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:ad14385487393e386e2ea988b09d62dd42c397662ac2dabc3832d71253eee479"},
-    {file = "coverage-7.13.5-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:7f2c47b36fe7709a6e83bfadf4eefb90bd25fbe4014d715224c4316f808e59a2"},
-    {file = "coverage-7.13.5-cp313-cp313t-win32.whl", hash = "sha256:67e9bc5449801fad0e5dff329499fb090ba4c5800b86805c80617b4e29809b2a"},
-    {file = "coverage-7.13.5-cp313-cp313t-win_amd64.whl", hash = "sha256:da86cdcf10d2519e10cabb8ac2de03da1bcb6e4853790b7fbd48523332e3a819"},
-    {file = "coverage-7.13.5-cp313-cp313t-win_arm64.whl", hash = "sha256:0ecf12ecb326fe2c339d93fc131816f3a7367d223db37817208905c89bded911"},
-    {file = "coverage-7.13.5-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:fbabfaceaeb587e16f7008f7795cd80d20ec548dc7f94fbb0d4ec2e038ce563f"},
-    {file = "coverage-7.13.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:9bb2a28101a443669a423b665939381084412b81c3f8c0fcfbac57f4e30b5b8e"},
-    {file = "coverage-7.13.5-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:bd3a2fbc1c6cccb3c5106140d87cc6a8715110373ef42b63cf5aea29df8c217a"},
-    {file = "coverage-7.13.5-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:6c36ddb64ed9d7e496028d1d00dfec3e428e0aabf4006583bb1839958d280510"},
-    {file = "coverage-7.13.5-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:380e8e9084d8eb38db3a9176a1a4f3c0082c3806fa0dc882d1d87abc3c789247"},
-    {file = "coverage-7.13.5-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e808af52a0513762df4d945ea164a24b37f2f518cbe97e03deaa0ee66139b4d6"},
-    {file = "coverage-7.13.5-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e301d30dd7e95ae068671d746ba8c34e945a82682e62918e41b2679acd2051a0"},
-    {file = "coverage-7.13.5-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:800bc829053c80d240a687ceeb927a94fd108bbdc68dfbe505d0d75ab578a882"},
-    {file = "coverage-7.13.5-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:0b67af5492adb31940ee418a5a655c28e48165da5afab8c7fa6fd72a142f8740"},
-    {file = "coverage-7.13.5-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:c9136ff29c3a91e25b1d1552b5308e53a1e0653a23e53b6366d7c2dcbbaf8a16"},
-    {file = "coverage-7.13.5-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:cff784eef7f0b8f6cb28804fbddcfa99f89efe4cc35fb5627e3ac58f91ed3ac0"},
-    {file = "coverage-7.13.5-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:68a4953be99b17ac3c23b6efbc8a38330d99680c9458927491d18700ef23ded0"},
-    {file = "coverage-7.13.5-cp314-cp314-win32.whl", hash = "sha256:35a31f2b1578185fbe6aa2e74cea1b1d0bbf4c552774247d9160d29b80ed56cc"},
-    {file = "coverage-7.13.5-cp314-cp314-win_amd64.whl", hash = "sha256:2aa055ae1857258f9e0045be26a6d62bdb47a72448b62d7b55f4820f361a2633"},
-    {file = "coverage-7.13.5-cp314-cp314-win_arm64.whl", hash = "sha256:1b11eef33edeae9d142f9b4358edb76273b3bfd30bc3df9a4f95d0e49caf94e8"},
-    {file = "coverage-7.13.5-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:10a0c37f0b646eaff7cce1874c31d1f1ccb297688d4c747291f4f4c70741cc8b"},
-    {file = "coverage-7.13.5-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:b5db73ba3c41c7008037fa731ad5459fc3944cb7452fc0aa9f822ad3533c583c"},
-    {file = "coverage-7.13.5-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:750db93a81e3e5a9831b534be7b1229df848b2e125a604fe6651e48aa070e5f9"},
-    {file = "coverage-7.13.5-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9ddb4f4a5479f2539644be484da179b653273bca1a323947d48ab107b3ed1f29"},
-    {file = "coverage-7.13.5-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d8a7a2049c14f413163e2bdabd37e41179b1d1ccb10ffc6ccc4b7a718429c607"},
-    {file = "coverage-7.13.5-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e1c85e0b6c05c592ea6d8768a66a254bfb3874b53774b12d4c89c481eb78cb90"},
-    {file = "coverage-7.13.5-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:777c4d1eff1b67876139d24288aaf1817f6c03d6bae9c5cc8d27b83bcfe38fe3"},
-    {file = "coverage-7.13.5-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:6697e29b93707167687543480a40f0db8f356e86d9f67ddf2e37e2dfd91a9dab"},
-    {file = "coverage-7.13.5-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:8fdf453a942c3e4d99bd80088141c4c6960bb232c409d9c3558e2dbaa3998562"},
-    {file = "coverage-7.13.5-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:32ca0c0114c9834a43f045a87dcebd69d108d8ffb666957ea65aa132f50332e2"},
-    {file = "coverage-7.13.5-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:8769751c10f339021e2638cd354e13adeac54004d1941119b2c96fe5276d45ea"},
-    {file = "coverage-7.13.5-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:cec2d83125531bd153175354055cdb7a09987af08a9430bd173c937c6d0fba2a"},
-    {file = "coverage-7.13.5-cp314-cp314t-win32.whl", hash = "sha256:0cd9ed7a8b181775459296e402ca4fb27db1279740a24e93b3b41942ebe4b215"},
-    {file = "coverage-7.13.5-cp314-cp314t-win_amd64.whl", hash = "sha256:301e3b7dfefecaca37c9f1aa6f0049b7d4ab8dd933742b607765d757aca77d43"},
-    {file = "coverage-7.13.5-cp314-cp314t-win_arm64.whl", hash = "sha256:9dacc2ad679b292709e0f5fc1ac74a6d4d5562e424058962c7bb0c658ad25e45"},
-    {file = "coverage-7.13.5-py3-none-any.whl", hash = "sha256:34b02417cf070e173989b3db962f7ed56d2f644307b2cf9d5a0f258e13084a61"},
-    {file = "coverage-7.13.5.tar.gz", hash = "sha256:c81f6515c4c40141f83f502b07bbfa5c240ba25bbe73da7b33f1e5b6120ff179"},
+    {file = "coverage-7.15.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:9b5bd92ff1ec22e535eab0de75fa6db021992791f461a2aceb7822c625a1187d"},
+    {file = "coverage-7.15.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:44826758cfe73fcd0e6af5deb4ba6d5417cc1d13df3acb35c93484a11160f846"},
+    {file = "coverage-7.15.2-cp310-cp310-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:09f5c6ec5901f667bd97dd140b5b9a2586b10efec66f46fb1e6d8135f8b95bdf"},
+    {file = "coverage-7.15.2-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:1d16e3a7104ea84f03e614611b3edbf6fb6892554b3ab0fe7fbb3f2b2ef04376"},
+    {file = "coverage-7.15.2-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d46e62cb35d91e6e2589fda6d28074426b0e276422b5d2ebef2c6b11dc60dbfd"},
+    {file = "coverage-7.15.2-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:dfd3db045e95960ae3683059571e597fda7cc610106a8916f77c5839048c1deb"},
+    {file = "coverage-7.15.2-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:affd532502d34c0472d0cdb181325c89f1d2c44992fef0c17e88e7b1576259a1"},
+    {file = "coverage-7.15.2-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:d17d7512151fedfcc64c1821a8977fc9be0dbf495754669afcab7b57abc98ae9"},
+    {file = "coverage-7.15.2-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:e26ff680768b8095e8874aabe0e9d3a47a2a9f176a8340d05f8604c56457c23a"},
+    {file = "coverage-7.15.2-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:7e8f27131dc7cd53de2c137dd207b3720919320b3c20d499dc30aa9ee6173287"},
+    {file = "coverage-7.15.2-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:728a33676d4c3f0db977990a4bd421dcaa3be3e53b5b6273036fff6666008e89"},
+    {file = "coverage-7.15.2-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:29c052f7c83ccfcc5c577eaae025d2e4a9bb80daf03c0ac31c996e83b000ce88"},
+    {file = "coverage-7.15.2-cp310-cp310-win32.whl", hash = "sha256:1268ac8fb9ddcd783d3948dbabaf80a5d53bfdaa0575e873e2139a692f797443"},
+    {file = "coverage-7.15.2-cp310-cp310-win_amd64.whl", hash = "sha256:9f4432898c4bf2fba0435bbe35dd4437d7264565e5a88a21f5b49d8662a6b629"},
+    {file = "coverage-7.15.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:2f1ec6f304b156669cfde653b4e9a953f5de87e247ea02ac599bce0ab2744036"},
+    {file = "coverage-7.15.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4d3361879d736f469f45723c11ea1a5bbdaf1f6928f0e632c940378b5aa9b660"},
+    {file = "coverage-7.15.2-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:c6a98d698f9e2c8008d0370ec7fc452ebfcc530002ae2d0061170d768b992589"},
+    {file = "coverage-7.15.2-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:d50dd325e18ec25bfcc10cd7f99b04df1ab9ec76b0918c260e60817ad0643dee"},
+    {file = "coverage-7.15.2-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:67d7602480a47bdf5b675635403625553ebaa70d5a62a657c035149fd401cea0"},
+    {file = "coverage-7.15.2-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:cee0f89f4767a6057c8fbf168f8135f18be651300496086bd873e3189fed0487"},
+    {file = "coverage-7.15.2-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a29ec5305a7335aacee2d799e3422e91e1c8a12474986e2b3b07e315c91be82f"},
+    {file = "coverage-7.15.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:48ccc6395958eda89093ecdc35644c86f23a8b23a7f4d44958812b721aad67c1"},
+    {file = "coverage-7.15.2-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:81f382c5a94b434ec1f6da607edb904c76d7212e618cd4d1bc9f97bed4120ef5"},
+    {file = "coverage-7.15.2-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:bbc808daf4f5cd567af8075ecc72d21c6dfef9a254709a621a84c217c935ebc0"},
+    {file = "coverage-7.15.2-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:a4c46b247b5d4b78f613bd89fea926d32b25c6cc61a50bd1e99ba310348f3dad"},
+    {file = "coverage-7.15.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:094dd37f3ef7b2da8b068b583d1f4c40f91c65197e16c52a71962d5d537fc5db"},
+    {file = "coverage-7.15.2-cp311-cp311-win32.whl", hash = "sha256:a63b9e190711134d581c4d703df5df09851b1acf99792c7aacbbe9f41f0283c9"},
+    {file = "coverage-7.15.2-cp311-cp311-win_amd64.whl", hash = "sha256:8bb9f4b4279187560796a4cdaca3b0a93dd97e48ee667df005f4ed9a97403688"},
+    {file = "coverage-7.15.2-cp311-cp311-win_arm64.whl", hash = "sha256:8c726b232659cbd2ae57ade46509eb068c9bd7a06df9fcbff6fe484870006934"},
+    {file = "coverage-7.15.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:1adac78e5abc7c5438f7a209c9ca69d06542f0bf481d728b6989ea80b813fdf9"},
+    {file = "coverage-7.15.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:b868acc62aa5de3be7a9d05c2333bf8359ca987e43f9cb30ff8fbda6a024ab73"},
+    {file = "coverage-7.15.2-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:6f6966fc30e6f06ca8f98fb0ce51eda6b111b3ee8d066a8b1ec9e77fa06ab55d"},
+    {file = "coverage-7.15.2-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:68af907f595ab01a78f794932ff3bdf929c316d3000810d38dbc247129e26f8b"},
+    {file = "coverage-7.15.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:afa29e2eff3d5729267e2cb2fd4ce9d61c952932fb2694e34ccb5d9540c6a296"},
+    {file = "coverage-7.15.2-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:bbf44513ceb1589e31948e20eafbde9deaface90e1a1afa5f5f77b4423d17ce6"},
+    {file = "coverage-7.15.2-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9deddf09eecb717b7f980414b43d90a5b22ff3967d2949ab29cb0aa83d9e9098"},
+    {file = "coverage-7.15.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:ae901f7e55ba405c84ee1cab3d3e962e4e871e4a2bcb9c90911adbd69b42ac5a"},
+    {file = "coverage-7.15.2-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:a0f47002c6eeb7c280228467a4cb0cc15ca2103a8421b986b2d3ec04a0f9bd8b"},
+    {file = "coverage-7.15.2-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:1cd7a5beb7af3e864a13b1f0fb26efd3695da43ef0daf71e586adfffaf34d5b2"},
+    {file = "coverage-7.15.2-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:97a5c5457a9fb1d6c4e06cfb5dc835871fbfb6a6a51addc9e925bdeff5ef7440"},
+    {file = "coverage-7.15.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:0901cfe6c13bcd2302da4f83e884555d2a22bda6e4c476f09ef204ba20ca536e"},
+    {file = "coverage-7.15.2-cp312-cp312-win32.whl", hash = "sha256:b171bdd71cb7ff792bf32e376173b0ace7e7963e7e57c58dfc42063a6a7174cd"},
+    {file = "coverage-7.15.2-cp312-cp312-win_amd64.whl", hash = "sha256:582edc45c2040543fef83341be23c43024a3ab3ae0c2d8bc498a06282905ad40"},
+    {file = "coverage-7.15.2-cp312-cp312-win_arm64.whl", hash = "sha256:a638db90c61cd219aeee65e83a24fdaa57269a741ae0cf773309208ac862cee3"},
+    {file = "coverage-7.15.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:1121caa19159a38b5463eaae4b1e1fde81e525b15ecc5e000cd5b1a108f743a8"},
+    {file = "coverage-7.15.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a300c6934e0989c327b9e8a1e110329da4641149f872bbe9f70168be66da76c1"},
+    {file = "coverage-7.15.2-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:2617f8799d268fabdeef42a7e89ac3a23e1deee9025427db2df970f99a89a578"},
+    {file = "coverage-7.15.2-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:7dc2950a2992cd676d35c20ae63522836deeb034f08874699d14068710af3dc1"},
+    {file = "coverage-7.15.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9e36686f7a442185db2400b3df171aac520869faf9deb59df687d28659eda2a6"},
+    {file = "coverage-7.15.2-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7d29ca7bd67af6e12e74632d65f026eabc1364da5c254494cd914446a28a3ef7"},
+    {file = "coverage-7.15.2-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:db9c8438057e5b0f6a22a0af99c0c1d26b57fbbdbd1be5861ddb8f897fcc3a2d"},
+    {file = "coverage-7.15.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:63022c4c8dec1d0342f05c3ede99842fe3d007689acc45e86f123a1746e4a026"},
+    {file = "coverage-7.15.2-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:6c0be82b4d4aa5b2704e08518e2252f3e3d110164bcca826816801052e48a7aa"},
+    {file = "coverage-7.15.2-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:4510fb9cdf6bb02dfa6af0be4a534b8102d086e22e4a33f8836df663da3d660d"},
+    {file = "coverage-7.15.2-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:42ec3d989421b174a2ab607c1539f24127ad362757b7f1c0c0d7a2993f7eb37b"},
+    {file = "coverage-7.15.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:e8f91bce78e32343af184c3b7fa28fcf5a9e2641f4b6623d392038f804939188"},
+    {file = "coverage-7.15.2-cp313-cp313-win32.whl", hash = "sha256:434e68d531858205895eb0d74b73d20b84260de426387d53c422a5acda2cf050"},
+    {file = "coverage-7.15.2-cp313-cp313-win_amd64.whl", hash = "sha256:26c3b04a6377fd7c09800921fa934e3a17c0020439cd59df73e73ae1d4b6a78c"},
+    {file = "coverage-7.15.2-cp313-cp313-win_arm64.whl", hash = "sha256:3ed010aa1b69cda8e827aabfca9866216c980e2dca82ab9a78c5f83689964c8b"},
+    {file = "coverage-7.15.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:40f633c5c5fc783732f6312280122e859538fa24461235597c13d803ea9a108a"},
+    {file = "coverage-7.15.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:075560438765b7a2ef43bf7aa7758661b53d889df47f062a31bda6c1ade553a2"},
+    {file = "coverage-7.15.2-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:25fd15dd40a0a2c51a500d664ca29053c09c3259d998407bf982b6e114696138"},
+    {file = "coverage-7.15.2-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:b9a6367e4aff723e8ee8190836836124284e8fcd4265e307c844010cfa074f3f"},
+    {file = "coverage-7.15.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9854ca62c152874b2060772503535be2e8f53f70b8aaa7686b094888d872f984"},
+    {file = "coverage-7.15.2-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:913b6c56e110da40e035bbd168353bf7aaa2544a5eaccea5d98a4629aac156c7"},
+    {file = "coverage-7.15.2-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:aaccad4129d735a8a4d526f26929894c9a4e8ef7034566f210b176749d6906e3"},
+    {file = "coverage-7.15.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:a164b50081fc7357331c4024ef4d17b78ba325f8380d05f5a69599a7e05257ee"},
+    {file = "coverage-7.15.2-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:bfd341ccf78128e72c094bc70cc25b3ef309c33c7c2c66ba3ed4309549e02de1"},
+    {file = "coverage-7.15.2-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:1473b3ba8e7ee0f076117b1a72c23f579a2b9e2bb742f48a8d86ea27ca93f91a"},
+    {file = "coverage-7.15.2-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:17c432b5f73ad52ef46fb06019f6fa7c66ce381961cf0f7dfd1d3a4bd3a98145"},
+    {file = "coverage-7.15.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:77f0ef5011df53a4bd1b35211ab122287f8d9b8d7aa1c4553e5c2deb24b1d446"},
+    {file = "coverage-7.15.2-cp314-cp314-win32.whl", hash = "sha256:f653e5d7248c1191ec988a85c72edeab46c3ff44f90639a4ed4874ec0be90243"},
+    {file = "coverage-7.15.2-cp314-cp314-win_amd64.whl", hash = "sha256:9911f31aad8906abe337c271343485cf20df5e70df5d2f57f9f136e7b55f26bc"},
+    {file = "coverage-7.15.2-cp314-cp314-win_arm64.whl", hash = "sha256:e38def96ad59853824c97953fdcd2c320a84ba3ce99b417db78af8bb6c3db635"},
+    {file = "coverage-7.15.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:835ec4e20b45f0a7f63ed78f94065aca00de033403df8377bfe8b9c6abc0a7be"},
+    {file = "coverage-7.15.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7466cc7ab6dc0db871d264bf99e8779f0917ee63d40730af0552f71535a6e072"},
+    {file = "coverage-7.15.2-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:e370c12133095ff18432de8c044962be85a5a96d90c6fcbce8e17e76236d2328"},
+    {file = "coverage-7.15.2-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:fe41909c9515c3bfdb5f02c4d1f857dba322d9a9a1178069b91eea77889df63a"},
+    {file = "coverage-7.15.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6aa28cfb6488e5453b5b762d65f73aa586380f6693a04d58078ce228a29b06c0"},
+    {file = "coverage-7.15.2-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:bcc0aae933921d03096f53b0b03eeb702129fd406dee59f08d2efacc68681fa5"},
+    {file = "coverage-7.15.2-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:7c63387e21ab21f512c69c9756a8c7dadd322c7275edb064064433c9a09c3743"},
+    {file = "coverage-7.15.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:0e55510bc98ae943cece9e667a6c0fe94c6a92913720dea34243657a17993d0c"},
+    {file = "coverage-7.15.2-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:2ff08701be2d1556fc78b326c80a3e8042da09352ecb3819105f8e386c8a3071"},
+    {file = "coverage-7.15.2-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:38c9518b7103826c403a461544e3c2e77151e8676d06eaed85911a97e962584a"},
+    {file = "coverage-7.15.2-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:dee88b1ed88587abd8c0269a1fc1f4cc77f7750d1dfde2869e2a123af420e67d"},
+    {file = "coverage-7.15.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:2fbeeeecea279727f8ac16c8e1133ddfeee793e985c86ae343d6a5ce744eef8c"},
+    {file = "coverage-7.15.2-cp314-cp314t-win32.whl", hash = "sha256:cb0fddaa6884be6aae36ced9544b5e90f7d5f03845a2853bf47a14953a4e8688"},
+    {file = "coverage-7.15.2-cp314-cp314t-win_amd64.whl", hash = "sha256:77f091ea3a9cc611cd29f433565476bc1936c084ac8eee00ea0e7e70c27e4199"},
+    {file = "coverage-7.15.2-cp314-cp314t-win_arm64.whl", hash = "sha256:6fc448c377d6eeb00a47c673494bd9bae29280ca53987e1869e67ebedfe20658"},
+    {file = "coverage-7.15.2-py3-none-any.whl", hash = "sha256:eb6bcae8d1a9d305351ecb108232441d11c5cfe9de840a04388ba5d2db8d735c"},
+    {file = "coverage-7.15.2.tar.gz", hash = "sha256:3df60dc267f0a2ca23cb7a9ab1109c62b9335ffbf519fcfe167157c28c09b81d"},
 ]
 
 [package.dependencies]
@@ -301,14 +330,14 @@ files = [
 
 [[package]]
 name = "griffelib"
-version = "2.0.2"
+version = "2.1.0"
 description = "Signatures for entire Python programs. Extract the structure, the frame, the skeleton of your project, to generate API documentation or find breaking changes in your API."
 optional = false
 python-versions = ">=3.10"
 groups = ["dev"]
 files = [
-    {file = "griffelib-2.0.2-py3-none-any.whl", hash = "sha256:925c857658fb1ba40c0772c37acbc2ab650bd794d9c1b9726922e36ea4117ea1"},
-    {file = "griffelib-2.0.2.tar.gz", hash = "sha256:3cf20b3bc470e83763ffbf236e0076b1211bac1bc67de13daf494640f2de707e"},
+    {file = "griffelib-2.1.0-py3-none-any.whl", hash = "sha256:cc7b3d2d2865ad0b909fcc38086e3f554b5ea7acbaa7bbb7ecaa3f5dfb7d9f00"},
+    {file = "griffelib-2.1.0.tar.gz", hash = "sha256:762a186d2c6fd6794d4ea20d428d597ffb857cb56b66421651cbba15bdd5e813"},
 ]
 
 [package.extras]
@@ -361,103 +390,105 @@ i18n = ["Babel (>=2.7)"]
 
 [[package]]
 name = "librt"
-version = "0.9.0"
+version = "0.13.0"
 description = "Mypyc runtime library"
 optional = false
 python-versions = ">=3.9"
 groups = ["dev"]
 markers = "platform_python_implementation != \"PyPy\""
 files = [
-    {file = "librt-0.9.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:2f8e12706dcb8ff6b3ed57514a19e45c49ad00bcd423e87b2b2e4b5f64578443"},
-    {file = "librt-0.9.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:4e3dda8345307fd7306db0ed0cb109a63a2c85ba780eb9dc2d09b2049a931f9c"},
-    {file = "librt-0.9.0-cp310-cp310-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:de7dac64e3eb832ffc7b840eb8f52f76420cde1b845be51b2a0f6b870890645e"},
-    {file = "librt-0.9.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:22a904cbdb678f7cb348c90d543d3c52f581663d687992fee47fd566dcbf5285"},
-    {file = "librt-0.9.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:224b9727eb8bc188bc3bcf29d969dba0cd61b01d9bac80c41575520cc4baabb2"},
-    {file = "librt-0.9.0-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e94cbc6ad9a6aeea46d775cbb11f361022f778a9cc8cc90af653d3a594b057ce"},
-    {file = "librt-0.9.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:7bc30ad339f4e1a01d4917d645e522a0bc0030644d8973f6346397c93ba1503f"},
-    {file = "librt-0.9.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:56d65b583cf43b8cf4c8fbe1e1da20fa3076cc32a1149a141507af1062718236"},
-    {file = "librt-0.9.0-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:0a1be03168b2691ba61927e299b352a6315189199ca18a57b733f86cb3cc8d38"},
-    {file = "librt-0.9.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:63c12efcd160e1d14da11af0c46c0217473e1e0d2ae1acbccc83f561ea4c2a7b"},
-    {file = "librt-0.9.0-cp310-cp310-win32.whl", hash = "sha256:e9002e98dcb1c0a66723592520decd86238ddcef168b37ff6cfb559200b4b774"},
-    {file = "librt-0.9.0-cp310-cp310-win_amd64.whl", hash = "sha256:9fcb461fbf70654a52a7cc670e606f04449e2374c199b1825f754e16dacfedd8"},
-    {file = "librt-0.9.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:90904fac73c478f4b83f4ed96c99c8208b75e6f9a8a1910548f69a00f1eaa671"},
-    {file = "librt-0.9.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:789fff71757facc0738e8d89e3b84e4f0251c1c975e85e81b152cdaca927cc2d"},
-    {file = "librt-0.9.0-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:1bf465d1e5b0a27713862441f6467b5ab76385f4ecf8f1f3a44f8aa3c695b4b6"},
-    {file = "librt-0.9.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f819e0c6413e259a17a7c0d49f97f405abadd3c2a316a3b46c6440b7dbbedbb1"},
-    {file = "librt-0.9.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e0785c2fb4a81e1aece366aa3e2e039f4a4d7d21aaaded5227d7f3c703427882"},
-    {file = "librt-0.9.0-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:80b25c7b570a86c03b5da69e665809deb39265476e8e21d96a9328f9762f9990"},
-    {file = "librt-0.9.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d4d16b608a1c43d7e33142099a75cd93af482dadce0bf82421e91cad077157f4"},
-    {file = "librt-0.9.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:194fc1a32e1e21fe809d38b5faea66cc65eaa00217c8901fbdb99866938adbdb"},
-    {file = "librt-0.9.0-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:8c6bc1384d9738781cfd41d09ad7f6e8af13cfea2c75ece6bd6d2566cdea2076"},
-    {file = "librt-0.9.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:15cb151e52a044f06e54ac7f7b47adbfc89b5c8e2b63e1175a9d587c43e8942a"},
-    {file = "librt-0.9.0-cp311-cp311-win32.whl", hash = "sha256:f100bfe2acf8a3689af9d0cc660d89f17286c9c795f9f18f7b62dd1a6b247ae6"},
-    {file = "librt-0.9.0-cp311-cp311-win_amd64.whl", hash = "sha256:0b73e4266307e51c95e09c0750b7ec383c561d2e97d58e473f6f6a209952fbb8"},
-    {file = "librt-0.9.0-cp311-cp311-win_arm64.whl", hash = "sha256:bc5518873822d2faa8ebdd2c1a4d7c8ef47b01a058495ab7924cb65bdbf5fc9a"},
-    {file = "librt-0.9.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:9b3e3bc363f71bda1639a4ee593cb78f7fbfeacc73411ec0d4c92f00730010a4"},
-    {file = "librt-0.9.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0a09c2f5869649101738653a9b7ab70cf045a1105ac66cbb8f4055e61df78f2d"},
-    {file = "librt-0.9.0-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:5ca8e133d799c948db2ab1afc081c333a825b5540475164726dcbf73537e5c2f"},
-    {file = "librt-0.9.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:603138ee838ee1583f1b960b62d5d0007845c5c423feb68e44648b1359014e27"},
-    {file = "librt-0.9.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f4003f70c56a5addd6aa0897f200dd59afd3bf7bcd5b3cce46dd21f925743bc2"},
-    {file = "librt-0.9.0-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:78042f6facfd98ecb25e9829c7e37cce23363d9d7c83bc5f72702c5059eb082b"},
-    {file = "librt-0.9.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a361c9434a64d70a7dbb771d1de302c0cc9f13c0bffe1cf7e642152814b35265"},
-    {file = "librt-0.9.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:dd2c7e082b0b92e1baa4da28163a808672485617bc855cc22a2fd06978fa9084"},
-    {file = "librt-0.9.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:7e6274fd33fc5b2a14d41c9119629d3ff395849d8bcbc80cf637d9e8d2034da8"},
-    {file = "librt-0.9.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5093043afb226ecfa1400120d1ebd4442b4f99977783e4f4f7248879009b227f"},
-    {file = "librt-0.9.0-cp312-cp312-win32.whl", hash = "sha256:9edcc35d1cae9fd5320171b1a838c7da8a5c968af31e82ecc3dff30b4be0957f"},
-    {file = "librt-0.9.0-cp312-cp312-win_amd64.whl", hash = "sha256:3cc2917258e131ae5f958a4d872e07555b51cb7466a43433218061c74ef33745"},
-    {file = "librt-0.9.0-cp312-cp312-win_arm64.whl", hash = "sha256:90e6d5420fc8a300518d4d2288154ff45005e920425c22cbbfe8330f3f754bd9"},
-    {file = "librt-0.9.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:f29b68cd9714531672db62cc54f6e8ff981900f824d13fa0e00749189e13778e"},
-    {file = "librt-0.9.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:7d5c8a5929ac325729f6119802070b561f4db793dffc45e9ac750992a4ed4d22"},
-    {file = "librt-0.9.0-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:756775d25ec8345b837ab52effee3ad2f3b2dfd6bbee3e3f029c517bd5d8f05a"},
-    {file = "librt-0.9.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2b8f5d00b49818f4e2b1667db994488b045835e0ac16fe2f924f3871bd2b8ac5"},
-    {file = "librt-0.9.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c81aef782380f0f13ead670aae01825eb653b44b046aa0e5ebbb79f76ed4aa11"},
-    {file = "librt-0.9.0-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:66b58fed90a545328e80d575467244de3741e088c1af928f0b489ebec3ef3858"},
-    {file = "librt-0.9.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:e78fb7419e07d98c2af4b8567b72b3eaf8cb05caad642e9963465569c8b2d87e"},
-    {file = "librt-0.9.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:2c3786f0f4490a5cd87f1ed6cefae833ad6b1060d52044ce0434a2e85893afd0"},
-    {file = "librt-0.9.0-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:8494cfc61e03542f2d381e71804990b3931175a29b9278fdb4a5459948778dc2"},
-    {file = "librt-0.9.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:07cf11f769831186eeac424376e6189f20ace4f7263e2134bdb9757340d84d4d"},
-    {file = "librt-0.9.0-cp313-cp313-win32.whl", hash = "sha256:850d6d03177e52700af605fd60db7f37dcb89782049a149674d1a9649c2138fd"},
-    {file = "librt-0.9.0-cp313-cp313-win_amd64.whl", hash = "sha256:a5af136bfba820d592f86c67affcef9b3ff4d4360ac3255e341e964489b48519"},
-    {file = "librt-0.9.0-cp313-cp313-win_arm64.whl", hash = "sha256:4c4d0440a3a8e31d962340c3e1cc3fc9ee7febd34c8d8f770d06adb947779ea5"},
-    {file = "librt-0.9.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:3f05d145df35dca5056a8bc3838e940efebd893a54b3e19b2dda39ceaa299bcb"},
-    {file = "librt-0.9.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1c587494461ebd42229d0f1739f3aa34237dd9980623ecf1be8d3bcba79f4499"},
-    {file = "librt-0.9.0-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:b0a2040f801406b93657a70b72fa12311063a319fee72ce98e1524da7200171f"},
-    {file = "librt-0.9.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f38bc489037eca88d6ebefc9c4d41a4e07c8e8b4de5188a9e6d290273ad7ebb1"},
-    {file = "librt-0.9.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f3fd278f5e6bf7c75ccd6d12344eb686cc020712683363b66f46ac79d37c799f"},
-    {file = "librt-0.9.0-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:fcbdf2a9ca24e87bbebb47f1fe34e531ef06f104f98c9ccfc953a3f3344c567a"},
-    {file = "librt-0.9.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e306d956cfa027fe041585f02a1602c32bfa6bb8ebea4899d373383295a6c62f"},
-    {file = "librt-0.9.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:465814ab157986acb9dfa5ccd7df944be5eefc0d08d31ec6e8d88bc71251d845"},
-    {file = "librt-0.9.0-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:703f4ae36d6240bfe24f542bac784c7e4194ec49c3ba5a994d02891649e2d85b"},
-    {file = "librt-0.9.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:3be322a15ee5e70b93b7a59cfd074614f22cc8c9ff18bd27f474e79137ea8d3b"},
-    {file = "librt-0.9.0-cp314-cp314-win32.whl", hash = "sha256:b8da9f8035bb417770b1e1610526d87ad4fc58a2804dc4d79c53f6d2cf5a6eb9"},
-    {file = "librt-0.9.0-cp314-cp314-win_amd64.whl", hash = "sha256:b8bd70d5d816566a580d193326912f4a76ec2d28a97dc4cd4cc831c0af8e330e"},
-    {file = "librt-0.9.0-cp314-cp314-win_arm64.whl", hash = "sha256:fc5758e2b7a56532dc33e3c544d78cbaa9ecf0a0f2a2da2df882c1d6b99a317f"},
-    {file = "librt-0.9.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:f24b90b0e0c8cc9491fb1693ae91fe17cb7963153a1946395acdbdd5818429a4"},
-    {file = "librt-0.9.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:3fe56e80badb66fdcde06bef81bbaa5bfcf6fbd7aefb86222d9e369c38c6b228"},
-    {file = "librt-0.9.0-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:527b5b820b47a09e09829051452bb0d1dd2122261254e2a6f674d12f1d793d54"},
-    {file = "librt-0.9.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7d429bdd4ac0ab17c8e4a8af0ed2a7440b16eba474909ab357131018fe8c7e71"},
-    {file = "librt-0.9.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7202bdcac47d3a708271c4304a474a8605a4a9a4a709e954bf2d3241140aa938"},
-    {file = "librt-0.9.0-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c0d620e74897f8c2613b3c4e2e9c1e422eb46d2ddd07df540784d44117836af3"},
-    {file = "librt-0.9.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:d69fc39e627908f4c03297d5a88d9284b73f4d90b424461e32e8c2485e21c283"},
-    {file = "librt-0.9.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:c2640e23d2b7c98796f123ffd95cf2022c7777aa8a4a3b98b36c570d37e85eee"},
-    {file = "librt-0.9.0-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:451daa98463b7695b0a30aa56bf637831ea559e7b8101ac2ef6382e8eb15e29c"},
-    {file = "librt-0.9.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:928bd06eca2c2bbf4349e5b817f837509b0604342e65a502de1d50a7570afd15"},
-    {file = "librt-0.9.0-cp314-cp314t-win32.whl", hash = "sha256:a9c63e04d003bc0fb6a03b348018b9a3002f98268200e22cc80f146beac5dc40"},
-    {file = "librt-0.9.0-cp314-cp314t-win_amd64.whl", hash = "sha256:f162af66a2ed3f7d1d161a82ca584efd15acd9c1cff190a373458c32f7d42118"},
-    {file = "librt-0.9.0-cp314-cp314t-win_arm64.whl", hash = "sha256:a4b25c6c25cac5d0d9d6d6da855195b254e0021e513e0249f0e3b444dc6e0e61"},
-    {file = "librt-0.9.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:5112c2fb7c2eefefaeaf5c97fec81343ef44ee86a30dcfaa8223822fba6467b4"},
-    {file = "librt-0.9.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:a81eea9b999b985e4bacc650c4312805ea7008fd5e45e1bf221310176a7bcb3a"},
-    {file = "librt-0.9.0-cp39-cp39-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:eea1b54943475f51698f85fa230c65ccac769f1e603b981be060ac5763d90927"},
-    {file = "librt-0.9.0-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:81107843ed1836874b46b310f9b1816abcb89912af627868522461c3b7333c0f"},
-    {file = "librt-0.9.0-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:aa95738a68cedd3a6f5492feddc513e2e166b50602958139e47bbdd82da0f5a7"},
-    {file = "librt-0.9.0-cp39-cp39-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:6788207daa0c19955d2b668f3294a368d19f67d9b5f274553fd073c1260cbb9f"},
-    {file = "librt-0.9.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:f48c963a76d71b9d7927eb817b543d0dccd52ab6648b99d37bd54f4cd475d856"},
-    {file = "librt-0.9.0-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:42ff8a962554c350d4a83cf47d9b7b78b0e6ff7943e87df7cdfc97c07f3c016f"},
-    {file = "librt-0.9.0-cp39-cp39-musllinux_1_2_riscv64.whl", hash = "sha256:657f8ba7b9eaaa82759a104137aed2a3ef7bc46ccfd43e0d89b04005b3e0a4cc"},
-    {file = "librt-0.9.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:2d03fa4fd277a7974c1978c92c374c57f44edeee163d147b477b143446ad1bf6"},
-    {file = "librt-0.9.0-cp39-cp39-win32.whl", hash = "sha256:d9da80e5b04acce03ced8ba6479a71c2a2edf535c2acc0d09c80d2f80f3bad15"},
-    {file = "librt-0.9.0-cp39-cp39-win_amd64.whl", hash = "sha256:54d412e47c21b85865676ed0724e37a89e9593c2eee1e7367adf85bfad56ffb1"},
-    {file = "librt-0.9.0.tar.gz", hash = "sha256:a0951822531e7aee6e0dfb556b30d5ee36bbe234faf60c20a16c01be3530869d"},
+    {file = "librt-0.13.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:34e47058fcc69a313293d6dee94216a4f30c929ae6f2476e58c5ba635aa639d5"},
+    {file = "librt-0.13.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:dbdd5b6509d0c2a8fe72cf494c299a61dbd58142a90a4190664ae159e4a7b547"},
+    {file = "librt-0.13.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2e56ea4ee4df77585a6b5c138f6538680886024fa559f5b55bd14b12e98e67b2"},
+    {file = "librt-0.13.0-cp310-cp310-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:f1f9cc4d09a46d9cb3c2063ae100629d3f52a6517c3c08c2f4c9828261883929"},
+    {file = "librt-0.13.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f125f5d46b20f89dc5587a55cc416b4ba2a5b2ffda36d048ee120e17598a653a"},
+    {file = "librt-0.13.0-cp310-cp310-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:2608d3b39f9e0b4a66a130d9150c615cba40a5090d25eeeaa225e0e46de8c0ac"},
+    {file = "librt-0.13.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:9fd35e95ab5e45c3901d37110263c7db85a961110f5460588fe37f8c131f88a7"},
+    {file = "librt-0.13.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:5f31b0aa13c9b04370d4da6be1ab7779776b3a075cceb6747a39a4be85fe1e40"},
+    {file = "librt-0.13.0-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:0b795f5fc70fbbb787ceaf79bb3a0d627bcc33c53de51741755263ec406b775a"},
+    {file = "librt-0.13.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:36b306a623aaad96fe4b378692b54f9c0789fccd833b9851753d5fbf6138cfde"},
+    {file = "librt-0.13.0-cp310-cp310-win32.whl", hash = "sha256:a3762e75fcac8c9e4dacaaf438bffd9003e2ca2c531b756f3c0035deefa674c8"},
+    {file = "librt-0.13.0-cp310-cp310-win_amd64.whl", hash = "sha256:d63bae12a8aeb51380be3438e4dc4bd27354d0f8e19166b2f44e3e94d6f552dc"},
+    {file = "librt-0.13.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:1b5a7bbff495baedbd9b916c367d66854008f8f3b575908ded477c499dc60082"},
+    {file = "librt-0.13.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:34bc7938b9fdf14fe32a406c19c71faf894c5cee7e7474bd0be2f17200b82d14"},
+    {file = "librt-0.13.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f40e56b61b41be5f7dec938cfeffd660668cf4b5e72c78e7bd671d66b7bc2c79"},
+    {file = "librt-0.13.0-cp311-cp311-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:9c5d02b89de5acd0379a51ec44a89476fb03df6145442e1c8ecd6bee2f91b176"},
+    {file = "librt-0.13.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7db9a3ff32ef5f7d1703d93831a3316cdf0b537de6a1cc03cc8fdd09b9194e89"},
+    {file = "librt-0.13.0-cp311-cp311-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3dbb2a31882456cadc7053378e81ad7ed7693db4ac9f98ab5f81ef034aa8ec9f"},
+    {file = "librt-0.13.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:c6014e3c80f9c1fe268ef8b0e0ef113bac672cc032f2f93866e7ddad4f3e663d"},
+    {file = "librt-0.13.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:091b60a4d2174fc1ec5c34cdc0b72efb6224753d76b7da61ebeab7a191aec8bd"},
+    {file = "librt-0.13.0-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:66cb1138f384a191a6d75f986064841fcfdc0cea98f7bd9c9ab9b38049917588"},
+    {file = "librt-0.13.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:17221a7569f8f292aa0014226e48aa25b8c2b08da18088cd230953d0ea0f9cd1"},
+    {file = "librt-0.13.0-cp311-cp311-win32.whl", hash = "sha256:fc67741da44c6eaa90e01eafb586bbba9b51eb5b6ed381ee6f5ae72eb3316d21"},
+    {file = "librt-0.13.0-cp311-cp311-win_amd64.whl", hash = "sha256:cc99dfb62b23c9207c33d0be8a2e2af7a42e21e6ea388b380a0c948c7b88953b"},
+    {file = "librt-0.13.0-cp311-cp311-win_arm64.whl", hash = "sha256:40ccd13c252d3fe473ffc8a57be7565abc8b64cf1b108344c859d5164f7f3e0c"},
+    {file = "librt-0.13.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:30536798f4504c0fad0885b1d371b0539abb081e4570c9d7c641cb51141b49f0"},
+    {file = "librt-0.13.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:93d24ebb82aa4420b1409c389e7857bc35bd0b668007ac8172427d5c73cc8cc5"},
+    {file = "librt-0.13.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cb8a1adce42d8b75485a5d56a9623a50bcab995b6079f1dac59fc44034dd93d9"},
+    {file = "librt-0.13.0-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:0763ca2ab66058174f9dee426dc64f5e0a89c24a7df8d3fe3f1836c04e25de4b"},
+    {file = "librt-0.13.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b222493da6e7b6199db9bd79502436cf5a27da3c1f7fa83c7e285444fc93fd03"},
+    {file = "librt-0.13.0-cp312-cp312-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:fadc63331f4388c3dc90090448f682a7e9feafc11481391c1e94f2f907a3976e"},
+    {file = "librt-0.13.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:70d9c62a4cffd9f23396cd5ef93fc5d11b31596b9b7d6306074abe3d5fcf09bd"},
+    {file = "librt-0.13.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:66c0e7e6b02a155576df2c77ec933a70b72da726e248c494abf690923e624348"},
+    {file = "librt-0.13.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:ac04bcd3328eb91d99dfedf6a60d9c1f15d3434e6f6daf922f0420f7d90b85c7"},
+    {file = "librt-0.13.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:db327e7271e653c32040b85ae6188059c924b57d7e1e29f935523fa017cd4e82"},
+    {file = "librt-0.13.0-cp312-cp312-win32.whl", hash = "sha256:860bd1d8ba48456ce08feaf8d343a8aaeb2fa086f2bcaa2a923fa3f7a3ff9aa3"},
+    {file = "librt-0.13.0-cp312-cp312-win_amd64.whl", hash = "sha256:e54a315caf843c8d77e388cadc56ea9ded569935ee2d2347d7ea94992e5aa6fa"},
+    {file = "librt-0.13.0-cp312-cp312-win_arm64.whl", hash = "sha256:c718e99a0992127af84385378460db624103b559ab260435abcfe77a4e4ed1c1"},
+    {file = "librt-0.13.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:a468951af16155824e88bdd8326ebe5bdb371f3ec0ac04642994b98201d914f3"},
+    {file = "librt-0.13.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:ae01d8512cc17079e53425635327dbf3f7ff57a42c00dec348bf79791c56444c"},
+    {file = "librt-0.13.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:32c26893cd085c1efe83219e78d866da23fb20a066101b8f68210004361d224c"},
+    {file = "librt-0.13.0-cp313-cp313-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:5929da1981a46bcf4b28b1b9499905f0ff58e2419da402a048234e9783acbc4b"},
+    {file = "librt-0.13.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:94b85d664d777bab6c0d709416cb42938251fda9e221b79e3a2215d85df5f4f9"},
+    {file = "librt-0.13.0-cp313-cp313-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:531b2df3e9fe96b1fcf73a6d165921e4656be5f58d631d384ebce344298368db"},
+    {file = "librt-0.13.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:109b84a9edf69ad89dc1f66358659e14a031baca95e3e5b0060bd903ede8efd6"},
+    {file = "librt-0.13.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:1304368a3e7ffc3e9db986796cc5326fdb5943a3567ecc137cff318e4240c0e7"},
+    {file = "librt-0.13.0-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:e4f9b472e7d308d94b62c801982065661158c6ed02790d6c7ddb4337cea0f9c1"},
+    {file = "librt-0.13.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9f836c37478f167a81200d8c8b2c920a22224564bed2c23d7aeec760965c367a"},
+    {file = "librt-0.13.0-cp313-cp313-pyemscripten_2025_0_wasm32.whl", hash = "sha256:4000d961ff9598ac6ea603c6c836a5ed49bc205ade5fc378b998dfe1e2c36628"},
+    {file = "librt-0.13.0-cp313-cp313-win32.whl", hash = "sha256:79e44cff71750d299d61a678e49995b0d5935a9cda238c2574daeca3ba536927"},
+    {file = "librt-0.13.0-cp313-cp313-win_amd64.whl", hash = "sha256:54dab44a847d5ad1acd05c8a83fe518ae685516ecf4d3f7cc6e3df2a66767650"},
+    {file = "librt-0.13.0-cp313-cp313-win_arm64.whl", hash = "sha256:d4cb6fbfdf874340ab5e51450753c0f817b6958a3621125ee695bbc3de866566"},
+    {file = "librt-0.13.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:25218d94b1d2cbc0ba1d8a3f9dc9af578d9646e5ed16443a70cde1dfdcce6d71"},
+    {file = "librt-0.13.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:f26629539d4893c2957a16c41bb058e1e135c1f150f6a2e25ed047f64cf3f5c6"},
+    {file = "librt-0.13.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a4517d47b2b8af26975a406fba7d314de9696d864252e0257c6ea90238cfe27f"},
+    {file = "librt-0.13.0-cp314-cp314-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:f19e181de5b3a1148bb3420b8c4b0b0ea0fce6950099724ad151d6cea5acc180"},
+    {file = "librt-0.13.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:22034924f5b42d5a56371cf271771bfeaabf235a7a8b6264bef2d20013f786c6"},
+    {file = "librt-0.13.0-cp314-cp314-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c7897db4e95e22468bdda33d8e012ceacd0182abf001e6389d763f0def6286b9"},
+    {file = "librt-0.13.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:1ce61b3746545029d4f5c17d6bd74b676254ad98433086c846ffb5e8fa73f007"},
+    {file = "librt-0.13.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:46c330e82565962c761dbce7941be2cff7db674ee807455a8d0cadc5f9b759b0"},
+    {file = "librt-0.13.0-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:375f5af8f99cbaa99dd293af986e3d57caabc9ba81a5d3f021603764854197a1"},
+    {file = "librt-0.13.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:9320d34c3376ae204b2cd176e8d4883a013934e0aef822f1aed9c536490c275d"},
+    {file = "librt-0.13.0-cp314-cp314-pyemscripten_2026_0_wasm32.whl", hash = "sha256:9af313c66157a69dc69ea0059a66961692250e0dc95af9c385a48ffb770a0d16"},
+    {file = "librt-0.13.0-cp314-cp314-win32.whl", hash = "sha256:f2a7253458e34f33543551394ae4fe104b497ec2a65ac266074de64c1df82e37"},
+    {file = "librt-0.13.0-cp314-cp314-win_amd64.whl", hash = "sha256:a3dfe4edf10e8ed7e55b026a8bfc2c2a8704218b659cd4bffdf604fab966dc39"},
+    {file = "librt-0.13.0-cp314-cp314-win_arm64.whl", hash = "sha256:68a5faee4bba381cb93b5961f684a514cf0053cb92308ff9c792c2fea0b174c6"},
+    {file = "librt-0.13.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:a38fb81d8376dfa2f8963b265fec07637802b0d01e2a127c19c66cb070fb24f5"},
+    {file = "librt-0.13.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:d4c8d9bd5abce34b2e75edb3bf37ab0f34e49b1f915a40ae8468eb7c85bc5b46"},
+    {file = "librt-0.13.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:387e2f1d27e89bffe0d3f520f0da0662c973fd607ca16c1808f8a5085419485e"},
+    {file = "librt-0.13.0-cp314-cp314t-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:4f6db193d2e5e0ed60359b9a5a682cd67205d0d3b1e459a867dd4b5c4e7eaa7a"},
+    {file = "librt-0.13.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0d38604854e8d22faadf683ec6c02bb0f886e2ba56ef981a1c36ee275f21ea22"},
+    {file = "librt-0.13.0-cp314-cp314t-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:371f7ce73026815dafd51c50ce38416e91428b28c4b2ec97cd39271164b0045c"},
+    {file = "librt-0.13.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:3aaedf52171bee90860704c560bc798fe83b76247df47568e0197e9b13c735a0"},
+    {file = "librt-0.13.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:96bad8725a4f196a798366c25ce075d1f7543a4ec045ffc13e6a7ec095cdab04"},
+    {file = "librt-0.13.0-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:6bf6a559ffe4a93bbea6cf31ddf01a7fd9ba342ef51f27beb178e318b74acd61"},
+    {file = "librt-0.13.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:301067672387902c55f94b51d5022304b36c966ea9fe1f21caab99a9bef487c9"},
+    {file = "librt-0.13.0-cp314-cp314t-win32.whl", hash = "sha256:5fdcf34f86de8fb66d7dc7589f96ba91c4aa46671200d400e6fd6f109a483f18"},
+    {file = "librt-0.13.0-cp314-cp314t-win_amd64.whl", hash = "sha256:260c33e92263fa629b4f6d3c51967a1c2158fe6c33237aaa3ebeac586b085259"},
+    {file = "librt-0.13.0-cp314-cp314t-win_arm64.whl", hash = "sha256:2f281549a4c52ac7bb97997f14353f8bd0e53a34ca0dad1c905cfd0b4a58ae99"},
+    {file = "librt-0.13.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:f442e3954b1addc759faae22a7c9a3f1e16d7d1db3f484279dc27d62e06968fa"},
+    {file = "librt-0.13.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:9e786428f291dd2d2f1cbfc0e0caa45a2e395fab0ad3e2c9314daa8873414390"},
+    {file = "librt-0.13.0-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:21b7ac084f701a9cdff6139745a6620579d65a9379ac2d9d50a86368b109e63c"},
+    {file = "librt-0.13.0-cp39-cp39-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:a6e556d6aba31c93dd97ce661d66614d2429c0a3923f9dc8f0af7e8df10223a4"},
+    {file = "librt-0.13.0-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3657346f867469e962549435aa05fd15330b1d6a92829f8e27988e194382d005"},
+    {file = "librt-0.13.0-cp39-cp39-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:791aa18a373b90da8ac3c44fc77544f33fdf53ae403acdce9b39f1c26b4a3b94"},
+    {file = "librt-0.13.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:d6fb0eaa108814581c4d3bfbd068c3fb6757812a81415008d1bae08267cca360"},
+    {file = "librt-0.13.0-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:a001519c315d5db40710f2665d32c4791f1d4779fc96a9423fd18d92c8b9ac7b"},
+    {file = "librt-0.13.0-cp39-cp39-musllinux_1_2_riscv64.whl", hash = "sha256:d9188caac26e47671b52836a5e2a49873a7fc11c673b0c122d22515f98bc14e1"},
+    {file = "librt-0.13.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:05d96b80b95d3a2721b619f8982b8558848b04875bb4772fd54842b59f61dd97"},
+    {file = "librt-0.13.0-cp39-cp39-win32.whl", hash = "sha256:c3cd253cf32fe4f4662960d6bf7d55cb8be0c31a5d644a4d48aeafebaff3409a"},
+    {file = "librt-0.13.0-cp39-cp39-win_amd64.whl", hash = "sha256:b15e26cc0fe622d0c67e98bee6ef6bc8f792e20ee3006aa12627a00463d9399f"},
+    {file = "librt-0.13.0.tar.gz", hash = "sha256:1d2a610c14ac0d0750ee0a3ab8548e83155258387891caaca04def4bf7289781"},
 ]
 
 [[package]]
@@ -478,14 +509,14 @@ testing = ["coverage", "pyyaml"]
 
 [[package]]
 name = "markdown-it-py"
-version = "4.0.0"
+version = "4.2.0"
 description = "Python port of markdown-it. Markdown parsing, done right!"
 optional = false
 python-versions = ">=3.10"
 groups = ["dev"]
 files = [
-    {file = "markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147"},
-    {file = "markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3"},
+    {file = "markdown_it_py-4.2.0-py3-none-any.whl", hash = "sha256:9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a"},
+    {file = "markdown_it_py-4.2.0.tar.gz", hash = "sha256:04a21681d6fbb623de53f6f364d352309d4094dd4194040a10fd51833e418d49"},
 ]
 
 [package.dependencies]
@@ -498,7 +529,7 @@ linkify = ["linkify-it-py (>=1,<3)"]
 plugins = ["mdit-py-plugins (>=0.5.0)"]
 profiling = ["gprof2dot"]
 rtd = ["ipykernel", "jupyter_sphinx", "mdit-py-plugins (>=0.5.0)", "myst-parser", "pyyaml", "sphinx", "sphinx-book-theme (>=1.0,<2.0)", "sphinx-copybutton", "sphinx-design"]
-testing = ["coverage", "pytest", "pytest-cov", "pytest-regressions", "requests"]
+testing = ["coverage", "pytest", "pytest-cov", "pytest-regressions", "pytest-timeout", "requests"]
 
 [[package]]
 name = "markupsafe"
@@ -702,14 +733,14 @@ pyyaml = ">=5.1"
 
 [[package]]
 name = "mkdocs-include-markdown-plugin"
-version = "7.2.2"
+version = "7.3.0"
 description = "Mkdocs Markdown includer plugin."
 optional = false
 python-versions = ">=3.9"
 groups = ["dev"]
 files = [
-    {file = "mkdocs_include_markdown_plugin-7.2.2-py3-none-any.whl", hash = "sha256:f2ec4487cf32d3e33ca528f9366f20fb9280ded9c8d1630eb2bbda244962dcd1"},
-    {file = "mkdocs_include_markdown_plugin-7.2.2.tar.gz", hash = "sha256:f052ccb741eccf498116b826c1d78a2d761c56747372594709441cee0963fbc9"},
+    {file = "mkdocs_include_markdown_plugin-7.3.0-py3-none-any.whl", hash = "sha256:5b5c99b5d3c9b9ce0114a9e60353bbafb6be53a26c2d3b74ec6b767a7a8e55ca"},
+    {file = "mkdocs_include_markdown_plugin-7.3.0.tar.gz", hash = "sha256:2800126746452e31c2e321bbd43c8190b356e0de353e20cbc16a34a3c3d6796c"},
 ]
 
 [package.dependencies]
@@ -721,14 +752,14 @@ cache = ["platformdirs"]
 
 [[package]]
 name = "mkdocstrings"
-version = "1.0.4"
+version = "1.0.6"
 description = "Automatic documentation from sources, for MkDocs."
 optional = false
 python-versions = ">=3.10"
 groups = ["dev"]
 files = [
-    {file = "mkdocstrings-1.0.4-py3-none-any.whl", hash = "sha256:63464b4b29053514f32a1dbbf604e52876d5e638111b0c295ab7ed3cac73ca9b"},
-    {file = "mkdocstrings-1.0.4.tar.gz", hash = "sha256:3969a6515b77db65fd097b53c1b7aa4ae840bd71a2ee62a6a3e89503446d7172"},
+    {file = "mkdocstrings-1.0.6-py3-none-any.whl", hash = "sha256:2703708697487d1b6d6d7b412e176fa436edf120c1bf81dc9e126b12d00893c7"},
+    {file = "mkdocstrings-1.0.6.tar.gz", hash = "sha256:a0b8c2bdd29a6416c80d717aa369bbf7831946bd9f23c2a66db1b1dbe7693dbd"},
 ]
 
 [package.dependencies]
@@ -747,14 +778,14 @@ python-legacy = ["mkdocstrings-python-legacy (>=0.2.1)"]
 
 [[package]]
 name = "mkdocstrings-python"
-version = "2.0.3"
+version = "2.0.5"
 description = "A Python handler for mkdocstrings."
 optional = false
 python-versions = ">=3.10"
 groups = ["dev"]
 files = [
-    {file = "mkdocstrings_python-2.0.3-py3-none-any.whl", hash = "sha256:0b83513478bdfd803ff05aa43e9b1fca9dd22bcd9471f09ca6257f009bc5ee12"},
-    {file = "mkdocstrings_python-2.0.3.tar.gz", hash = "sha256:c518632751cc869439b31c9d3177678ad2bfa5c21b79b863956ad68fc92c13b8"},
+    {file = "mkdocstrings_python-2.0.5-py3-none-any.whl", hash = "sha256:30c837bbff016549f659fcba6539ac351303f0fd7e713c89a040611072236e9d"},
+    {file = "mkdocstrings_python-2.0.5.tar.gz", hash = "sha256:3a4d92556ad39637e88af94a5374213af9a8e3040c3824ceaed04b486c017594"},
 ]
 
 [package.dependencies]
@@ -765,60 +796,62 @@ typing-extensions = {version = ">=4.0", markers = "python_version < \"3.11\""}
 
 [[package]]
 name = "mypy"
-version = "1.20.2"
+version = "2.3.0"
 description = "Optional static typing for Python"
 optional = false
 python-versions = ">=3.10"
 groups = ["dev"]
 files = [
-    {file = "mypy-1.20.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:cf5a4db6dca263010e2c7bff081c89383c72d187ba2cf4c44759aac970e2f0c4"},
-    {file = "mypy-1.20.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:7b0e817b518bff7facd7f85ea05b643ad8bdcce684cf29784987b0a7c8e1f997"},
-    {file = "mypy-1.20.2-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:97d7b9a485b40f8ca425460e89bf1da2814625b2da627c0dcc6aa46c92631d14"},
-    {file = "mypy-1.20.2-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1e1c12f6d2db3d78b909b5f77513c11eb7f2dd2782b96a3ab6dffc7d44575c99"},
-    {file = "mypy-1.20.2-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:89dce27e142d25ffbc154c1819383b69f2e9234dc4ed4766f42e0e8cb264ab5c"},
-    {file = "mypy-1.20.2-cp310-cp310-win_amd64.whl", hash = "sha256:f376e37f9bf2a946872fc5fd1199c99310748e3c26c7a26683f13f8bdb756cbd"},
-    {file = "mypy-1.20.2-cp310-cp310-win_arm64.whl", hash = "sha256:6e2b469efd811707bc530fd1effef0f5d6eebcb7fe376affae69025da4b979a2"},
-    {file = "mypy-1.20.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:4077797a273e56e8843d001e9dfe4ba10e33323d6ade647ff260e5cd97d9758c"},
-    {file = "mypy-1.20.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:cdecf62abcc4292500d7858aeae87a1f8f1150f4c4dd08fb0b336ee79b2a6df3"},
-    {file = "mypy-1.20.2-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c566c3a88b6ece59b3d70f65bedef17304f48eb52ff040a6a18214e1917b3254"},
-    {file = "mypy-1.20.2-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0deb80d062b2479f2c87ae568f89845afc71d11bc41b04179e58165fd9f31e98"},
-    {file = "mypy-1.20.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:bba9ad231e92a3e424b3e56b65aa17704993425bba97e302c832f9466bb85bac"},
-    {file = "mypy-1.20.2-cp311-cp311-win_amd64.whl", hash = "sha256:baf593f2765fa3a6b1ef95807dbaa3d25b594f6a52adcc506a6b9cb115e1be67"},
-    {file = "mypy-1.20.2-cp311-cp311-win_arm64.whl", hash = "sha256:20175a1c0f49863946ec20b7f63255768058ac4f07d2b9ded6a6b46cfb5a9100"},
-    {file = "mypy-1.20.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:4dbfcf869f6b0517f70cf0030ba6ea1d6645e132337a7d5204a18d8d5636c02b"},
-    {file = "mypy-1.20.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:4b6481b228d072315b053210b01ac320e1be243dc17f9e5887ef167f23f5fae4"},
-    {file = "mypy-1.20.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:34397cdced6b90b836e38182076049fdb41424322e0b0728c946b0939ebdf9f6"},
-    {file = "mypy-1.20.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a5da6976f20cae27059ea8d0c86e7cef3de720e04c4bb9ee18e3690fdb792066"},
-    {file = "mypy-1.20.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:56908d7e08318d39f85b1f0c6cfd47b0cac1a130da677630dac0de3e0623e102"},
-    {file = "mypy-1.20.2-cp312-cp312-win_amd64.whl", hash = "sha256:d52ad8d78522da1d308789df651ee5379088e77c76cb1994858d40a426b343b9"},
-    {file = "mypy-1.20.2-cp312-cp312-win_arm64.whl", hash = "sha256:785b08db19c9f214dc37d65f7c165d19a30fcecb48abfa30f31b01b5acaabb58"},
-    {file = "mypy-1.20.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:edfbfca868cdd6bd8d974a60f8a3682f5565d3f5c99b327640cedd24c4264026"},
-    {file = "mypy-1.20.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e2877a02380adfcdbc69071a0f74d6e9dbbf593c0dc9d174e1f223ffd5281943"},
-    {file = "mypy-1.20.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7488448de6007cd5177c6cea0517ac33b4c0f5ee9b5e9f2be51ce75511a85517"},
-    {file = "mypy-1.20.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bb9c2fa06887e21d6a3a868762acb82aec34e2c6fd0174064f27c93ede68ad15"},
-    {file = "mypy-1.20.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9d56a78b646f2e3daa865bc70cd5ec5a46c50045801ca8ff17a0c43abc97e3ee"},
-    {file = "mypy-1.20.2-cp313-cp313-win_amd64.whl", hash = "sha256:2a4102b03bb7481d9a91a6da8d174740c9c8c4401024684b9ca3b7cc5e49852f"},
-    {file = "mypy-1.20.2-cp313-cp313-win_arm64.whl", hash = "sha256:a95a9248b0c6fd933a442c03c3b113c3b61320086b88e2c444676d3fd1ca3330"},
-    {file = "mypy-1.20.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:419413398fe250aae057fd2fe50166b61077083c9b82754c341cf4fd73038f30"},
-    {file = "mypy-1.20.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:e73c07f23009962885c197ccb9b41356a30cc0e5a1d0c2ea8fd8fb1362d7f924"},
-    {file = "mypy-1.20.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0c64e5973df366b747646fc98da921f9d6eba9716d57d1db94a83c026a08e0fb"},
-    {file = "mypy-1.20.2-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5a65aa591af023864fd08a97da9974e919452cfe19cb146c8a5dc692626445dc"},
-    {file = "mypy-1.20.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:4fef51b01e638974a6e69885687e9bd40c8d1e09a6cd291cca0619625cf1f558"},
-    {file = "mypy-1.20.2-cp314-cp314-win_amd64.whl", hash = "sha256:913485a03f1bcf5d279409a9d2b9ed565c151f61c09f29991e5faa14033da4c8"},
-    {file = "mypy-1.20.2-cp314-cp314-win_arm64.whl", hash = "sha256:c3bae4f855d965b5453784300c12ffc63a548304ac7f99e55d4dc7c898673aa3"},
-    {file = "mypy-1.20.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:2de3dcea53babc1c3237a19002bc3d228ce1833278f093b8d619e06e7cc79609"},
-    {file = "mypy-1.20.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:52b176444e2e5054dfcbcb8c75b0b719865c96247b37407184bbfca5c353f2c2"},
-    {file = "mypy-1.20.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:688c3312e5dadb573a2c69c82af3a298d43ecf9e6d264e0f95df960b5f6ac19c"},
-    {file = "mypy-1.20.2-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:29752dbbf8cc53f89f6ac096d363314333045c257c9c75cbd189ca2de0455744"},
-    {file = "mypy-1.20.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:803203d2b6ea644982c644895c2f78b28d0e208bba7b27d9b921e0ec5eb207c6"},
-    {file = "mypy-1.20.2-cp314-cp314t-win_amd64.whl", hash = "sha256:9bcb8aa397ff0093c824182fd76a935a9ba7ad097fcbef80ae89bf6c1731d8ec"},
-    {file = "mypy-1.20.2-cp314-cp314t-win_arm64.whl", hash = "sha256:e061b58443f1736f8a37c48978d7ab581636d6ab03e3d4f99e3fa90463bb9382"},
-    {file = "mypy-1.20.2-py3-none-any.whl", hash = "sha256:a94c5a76ab46c5e6257c7972b6c8cff0574201ca7dc05647e33e795d78680563"},
-    {file = "mypy-1.20.2.tar.gz", hash = "sha256:e8222c26daaafd9e8626dec58ae36029f82585890589576f769a650dd20fd665"},
+    {file = "mypy-2.3.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:1fa8d916ac3b705af733c4c1e6c9ebe38fd0d52beb15b105c3e8355b55e6ecdc"},
+    {file = "mypy-2.3.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:28e1e2af8cd8fff551fd30f2fe4b03fb76764ac8b1ba6c6a1bd00ad32b412db3"},
+    {file = "mypy-2.3.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3e77244df3843048c3f927182916730e40c124cbaa43905c1fb86cb382aa0805"},
+    {file = "mypy-2.3.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9559ab18a9c9957dfa3004ab57cd4bac5f26a724329a9584e583367f0c2e1117"},
+    {file = "mypy-2.3.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:09abd66d8685e73f8f7d17b847c3e104d9a7b164a8706ea87d6c96a3d45816d5"},
+    {file = "mypy-2.3.0-cp310-cp310-win_amd64.whl", hash = "sha256:5e91adad1ca81742ac7ef9893959911df867752206b37135185e88dfb3c89494"},
+    {file = "mypy-2.3.0-cp310-cp310-win_arm64.whl", hash = "sha256:6f99ec626e3c3a2f7c0b22c5b90ddb5dabb1c18729c971e9bdaca1f1766d2cee"},
+    {file = "mypy-2.3.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:3419d00717afbc5265b50dd14b1278f29ea4884dd398ab67873489ac093fd329"},
+    {file = "mypy-2.3.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:cfca8ee88544090f86b6dcce05ec55d66eb48a762412ac2507810ba4bd793b6f"},
+    {file = "mypy-2.3.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:75cbb4b9ef04a0c84a957f07abc4504fbf64b8dcc145675101f2d3a78a4b1d6a"},
+    {file = "mypy-2.3.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:982e3d53dd23d0a4cef67dd66791fdbede0cf38f9eb617bf47663554c51e1e36"},
+    {file = "mypy-2.3.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:85c5385b93012ffa3b31479ab579aef5415f4f3a32c6cf1ae07a984d2a0ff461"},
+    {file = "mypy-2.3.0-cp311-cp311-win_amd64.whl", hash = "sha256:13b1b16e2fa39f3b2e33fb1c468abc7a69369fa2e886b4b87b5afc81472325cd"},
+    {file = "mypy-2.3.0-cp311-cp311-win_arm64.whl", hash = "sha256:b5cd2f027a972a4a5f2278a11fac9747f5f81a53a30b714d74950b6807e55568"},
+    {file = "mypy-2.3.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2d53fc67b9d28a43c6199077f49fea0f05839e36cf6158500331c9549225e5a5"},
+    {file = "mypy-2.3.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fbc00cee7bdbb9291979ddc9d08034a29dfcda4932628c9bbc28c1edd589df0c"},
+    {file = "mypy-2.3.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:04e617030eca5221909c8b7d8d7fd1c637948199aa2100b2ad9813feb07e1491"},
+    {file = "mypy-2.3.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:56c184d2c20ca6b6378d58d1960270a767f41f5e44acbbd27f05effef4f4e1d7"},
+    {file = "mypy-2.3.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3961a4a34b05f7c74b0f05aa51fbfe99a2d1e126038df40318d15c8f558b7ef3"},
+    {file = "mypy-2.3.0-cp312-cp312-win_amd64.whl", hash = "sha256:b1942b9314d4c784b8ea1dbab4972603290e5dd5630f06675f13aec97526bc4c"},
+    {file = "mypy-2.3.0-cp312-cp312-win_arm64.whl", hash = "sha256:be51653d7669d7d7955d613b8d0bb57d5b652eaf71a873ddf65ac87254dd2595"},
+    {file = "mypy-2.3.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:91ad22a52ae2c7e621c2f67c94d5a17f66b3209a4cff5cf8a573579835c69e97"},
+    {file = "mypy-2.3.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:99ac767cc5d3b64c8d0ae226ead10c96694f94e4e7da1668642225dcd4e75aac"},
+    {file = "mypy-2.3.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:de6d2c484742a4d7b0ed6d07b143375624d3b899c5749c7b3c947f56261f48a6"},
+    {file = "mypy-2.3.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7da939dd335cfd2ad788bdfd081c9f4e47634ab995e5a45eb15fd1e5bc052f8b"},
+    {file = "mypy-2.3.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:7247eb2824f996722a949530183394921ca71deb9680052a338cf53cff7925c2"},
+    {file = "mypy-2.3.0-cp313-cp313-win_amd64.whl", hash = "sha256:75b0984bb3cbd76bb5c9291a8671f7ae66ca3b51c7584c358fc2e923259f0757"},
+    {file = "mypy-2.3.0-cp313-cp313-win_arm64.whl", hash = "sha256:d78fcf900b59cb7e82cb7e3a235e31b462d9333d92285bd1e4952d355b8ffba1"},
+    {file = "mypy-2.3.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:ea317b060ce83e26050f8f9e4d7d6bf44ed7597c8ff9990bccffbb9d1d8522db"},
+    {file = "mypy-2.3.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:094af99f92638aa92852326188b85a89e50f4a472f44827c03362228482f0762"},
+    {file = "mypy-2.3.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:de121747278144fc9ae7caa2e978cf5df12aebc82933182f5b3b86081a30baef"},
+    {file = "mypy-2.3.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:37fa4de896a84e2dc9200d91e614c22563b43d1a266789d4bbac7b22ebe6192b"},
+    {file = "mypy-2.3.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:f1b3a98dfd21058bc759bb3337d5d1f61d0fdf9f3cf9c00f4291790fb5427bff"},
+    {file = "mypy-2.3.0-cp314-cp314-pyemscripten_2026_0_wasm32.whl", hash = "sha256:944c665d984157cb96a679dfb7a4a81dd1d36b24b9c284b699514e6e626b82d4"},
+    {file = "mypy-2.3.0-cp314-cp314-win_amd64.whl", hash = "sha256:4359424140d985192c778c1ce2c114a10c1ca58a381ed79cfa70d37df94b299f"},
+    {file = "mypy-2.3.0-cp314-cp314-win_arm64.whl", hash = "sha256:3dd0bed92c4bdec57c42505b96416fb9e6a5aa7be84d2809bcd5f2ecec2860d7"},
+    {file = "mypy-2.3.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:691fdc37132b1ae628d834f672e74de83462d9fb4aff621835767fb43a8dd373"},
+    {file = "mypy-2.3.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:aec15d465d477558fd842757b487849007311cf3897849cdda0e3162ac0ac556"},
+    {file = "mypy-2.3.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b352b7e49f5e6576009e8df730e1ff4f915cb565b851b396d2ffe2f5a6f5da88"},
+    {file = "mypy-2.3.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1c6c6bf687b17f90dbfcad95b960d32eaa0154c00da45f03ab50bf8952e047fe"},
+    {file = "mypy-2.3.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:f4ed18f111bfe2d599bca7468e7f9251042c1c2118f762c8de2766a56d773c60"},
+    {file = "mypy-2.3.0-cp314-cp314t-win_amd64.whl", hash = "sha256:0b025a93cffb9781d231f232be07a17912f35f10a313c24f301c81e842870654"},
+    {file = "mypy-2.3.0-cp314-cp314t-win_arm64.whl", hash = "sha256:adebc76aab4f3495a88b41d48aa4aff0c03f2822501da76625afcca5975f19e5"},
+    {file = "mypy-2.3.0-py3-none-any.whl", hash = "sha256:6b1cdb579446b60432432b2b2403a6201b4b475a004d7f488511c9ba177c9e88"},
+    {file = "mypy-2.3.0.tar.gz", hash = "sha256:465965d41cd9a2726694e983e8ce7113259327bec798115d1e1dfa2a52fb666e"},
 ]
 
 [package.dependencies]
-librt = {version = ">=0.8.0", markers = "platform_python_implementation != \"PyPy\""}
+ast-serialize = ">=0.6.0,<1.0.0"
+librt = {version = ">=0.13.0", markers = "platform_python_implementation != \"PyPy\""}
 mypy_extensions = ">=1.0.0"
 pathspec = ">=1.0.0"
 tomli = {version = ">=1.1.0", markers = "python_version < \"3.11\""}
@@ -832,7 +865,6 @@ dmypy = ["psutil (>=4.0)"]
 faster-cache = ["orjson"]
 install-types = ["pip"]
 mypyc = ["setuptools (>=50)"]
-native-parser = ["ast-serialize (>=0.1.1,<1.0.0)"]
 reports = ["lxml"]
 
 [[package]]
@@ -890,14 +922,14 @@ re2 = ["google-re2 (>=1.1)"]
 
 [[package]]
 name = "platformdirs"
-version = "4.9.6"
+version = "4.10.1"
 description = "A small Python package for determining appropriate platform-specific dirs, e.g. a `user data dir`."
 optional = false
 python-versions = ">=3.10"
 groups = ["dev"]
 files = [
-    {file = "platformdirs-4.9.6-py3-none-any.whl", hash = "sha256:e61adb1d5e5cb3441b4b7710bea7e4c12250ca49439228cc1021c00dcfac0917"},
-    {file = "platformdirs-4.9.6.tar.gz", hash = "sha256:3bfa75b0ad0db84096ae777218481852c0ebc6c727b3168c1b9e0118e458cf0a"},
+    {file = "platformdirs-4.10.1-py3-none-any.whl", hash = "sha256:0e4eff26be2d75293977f7cddc153fd9b8eaa7fb0c7b64ffe4076cb443117443"},
+    {file = "platformdirs-4.10.1.tar.gz", hash = "sha256:ceab4084426fe6319ce18e86deada8ab1b7487c7aee7040c55e277c9ae793695"},
 ]
 
 [[package]]
@@ -918,19 +950,19 @@ testing = ["coverage", "pytest", "pytest-benchmark"]
 
 [[package]]
 name = "pydantic"
-version = "2.13.3"
+version = "2.13.4"
 description = "Data validation using Python type hints"
 optional = false
 python-versions = ">=3.9"
 groups = ["main", "dev"]
 files = [
-    {file = "pydantic-2.13.3-py3-none-any.whl", hash = "sha256:6db14ac8dfc9a1e57f87ea2c0de670c251240f43cb0c30a5130e9720dc612927"},
-    {file = "pydantic-2.13.3.tar.gz", hash = "sha256:af09e9d1d09f4e7fe37145c1f577e1d61ceb9a41924bf0094a36506285d0a84d"},
+    {file = "pydantic-2.13.4-py3-none-any.whl", hash = "sha256:45a282cde31d808236fd7ea9d919b128653c8b38b393d1c4ab335c62924d9aba"},
+    {file = "pydantic-2.13.4.tar.gz", hash = "sha256:c40756b57adaa8b1efeeced5c196f3f3b7c435f90e84ea7f443901bec8099ef6"},
 ]
 
 [package.dependencies]
 annotated-types = ">=0.6.0"
-pydantic-core = "2.46.3"
+pydantic-core = "2.46.4"
 typing-extensions = ">=4.14.1"
 typing-inspection = ">=0.4.2"
 
@@ -940,132 +972,132 @@ timezone = ["tzdata ; python_version >= \"3.9\" and platform_system == \"Windows
 
 [[package]]
 name = "pydantic-core"
-version = "2.46.3"
+version = "2.46.4"
 description = "Core functionality for Pydantic validation and serialization"
 optional = false
 python-versions = ">=3.9"
 groups = ["main", "dev"]
 files = [
-    {file = "pydantic_core-2.46.3-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:1da3786b8018e60349680720158cc19161cc3b4bdd815beb0a321cd5ce1ad5b1"},
-    {file = "pydantic_core-2.46.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:cc0988cb29d21bf4a9d5cf2ef970b5c0e38d8d8e107a493278c05dc6c1dda69f"},
-    {file = "pydantic_core-2.46.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:27f9067c3bfadd04c55484b89c0d267981b2f3512850f6f66e1e74204a4e4ce3"},
-    {file = "pydantic_core-2.46.3-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a642ac886ecf6402d9882d10c405dcf4b902abeb2972cd5fb4a48c83cd59279a"},
-    {file = "pydantic_core-2.46.3-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:79f561438481f28681584b89e2effb22855e2179880314bcddbf5968e935e807"},
-    {file = "pydantic_core-2.46.3-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:57a973eae4665352a47cf1a99b4ee864620f2fe663a217d7a8da68a1f3a5bfda"},
-    {file = "pydantic_core-2.46.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:83d002b97072a53ea150d63e0a3adfae5670cef5aa8a6e490240e482d3b22e57"},
-    {file = "pydantic_core-2.46.3-cp310-cp310-manylinux_2_31_riscv64.whl", hash = "sha256:b40ddd51e7c44b28cfaef746c9d3c506d658885e0a46f9eeef2ee815cbf8e045"},
-    {file = "pydantic_core-2.46.3-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:ac5ec7fb9b87f04ee839af2d53bcadea57ded7d229719f56c0ed895bff987943"},
-    {file = "pydantic_core-2.46.3-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:a3b11c812f61b3129c4905781a2601dfdfdea5fe1e6c1cfb696b55d14e9c054f"},
-    {file = "pydantic_core-2.46.3-cp310-cp310-musllinux_1_1_armv7l.whl", hash = "sha256:1108da631e602e5b3c38d6d04fe5bb3bfa54349e6918e3ca6cf570b2e2b2f9d4"},
-    {file = "pydantic_core-2.46.3-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:de885175515bcfa98ae618c1df7a072f13d179f81376c8007112af20567fd08a"},
-    {file = "pydantic_core-2.46.3-cp310-cp310-win32.whl", hash = "sha256:d11058e3201527d41bc6b545c79187c9e4bf85e15a236a6007f0e991518882b7"},
-    {file = "pydantic_core-2.46.3-cp310-cp310-win_amd64.whl", hash = "sha256:3612edf65c8ea67ac13616c4d23af12faef1ae435a8a93e5934c2a0cbbdd1fd6"},
-    {file = "pydantic_core-2.46.3-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:ab124d49d0459b2373ecf54118a45c28a1e6d4192a533fbc915e70f556feb8e5"},
-    {file = "pydantic_core-2.46.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:cca67d52a5c7a16aed2b3999e719c4bcf644074eac304a5d3d62dd70ae7d4b2c"},
-    {file = "pydantic_core-2.46.3-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5c024e08c0ba23e6fd68c771a521e9d6a792f2ebb0fa734296b36394dc30390e"},
-    {file = "pydantic_core-2.46.3-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:6645ce7eec4928e29a1e3b3d5c946621d105d3e79f0c9cddf07c2a9770949287"},
-    {file = "pydantic_core-2.46.3-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a712c7118e6c5ea96562f7b488435172abb94a3c53c22c9efc1412264a45cbbe"},
-    {file = "pydantic_core-2.46.3-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:69a868ef3ff206343579021c40faf3b1edc64b1cc508ff243a28b0a514ccb050"},
-    {file = "pydantic_core-2.46.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cc7e8c32db809aa0f6ea1d6869ebc8518a65d5150fdfad8bcae6a49ae32a22e2"},
-    {file = "pydantic_core-2.46.3-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:3481bd1341dc85779ee506bc8e1196a277ace359d89d28588a9468c3ecbe63fa"},
-    {file = "pydantic_core-2.46.3-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:8690eba565c6d68ffd3a8655525cbdd5246510b44a637ee2c6c03a7ebfe64d3c"},
-    {file = "pydantic_core-2.46.3-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:4de88889d7e88d50d40ee5b39d5dac0bcaef9ba91f7e536ac064e6b2834ecccf"},
-    {file = "pydantic_core-2.46.3-cp311-cp311-musllinux_1_1_armv7l.whl", hash = "sha256:e480080975c1ef7f780b8f99ed72337e7cc5efea2e518a20a692e8e7b278eb8b"},
-    {file = "pydantic_core-2.46.3-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:de3a5c376f8cd94da9a1b8fd3dd1c16c7a7b216ed31dc8ce9fd7a22bf13b836e"},
-    {file = "pydantic_core-2.46.3-cp311-cp311-win32.whl", hash = "sha256:fc331a5314ffddd5385b9ee9d0d2fee0b13c27e0e02dad71b1ae5d6561f51eeb"},
-    {file = "pydantic_core-2.46.3-cp311-cp311-win_amd64.whl", hash = "sha256:b5b9c6cf08a8a5e502698f5e153056d12c34b8fb30317e0c5fd06f45162a6346"},
-    {file = "pydantic_core-2.46.3-cp311-cp311-win_arm64.whl", hash = "sha256:5dfd51cf457482f04ec49491811a2b8fd5b843b64b11eecd2d7a1ee596ea78a6"},
-    {file = "pydantic_core-2.46.3-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:b11b59b3eee90a80a36701ddb4576d9ae31f93f05cb9e277ceaa09e6bf074a67"},
-    {file = "pydantic_core-2.46.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:af8653713055ea18a3abc1537fe2ebc42f5b0bbb768d1eb79fd74eb47c0ac089"},
-    {file = "pydantic_core-2.46.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:75a519dab6d63c514f3a81053e5266c549679e4aa88f6ec57f2b7b854aceb1b0"},
-    {file = "pydantic_core-2.46.3-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a6cd87cb1575b1ad05ba98894c5b5c96411ef678fa2f6ed2576607095b8d9789"},
-    {file = "pydantic_core-2.46.3-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f80a55484b8d843c8ada81ebf70a682f3f00a3d40e378c06cf17ecb44d280d7d"},
-    {file = "pydantic_core-2.46.3-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3861f1731b90c50a3266316b9044f5c9b405eecb8e299b0a7120596334e4fe9c"},
-    {file = "pydantic_core-2.46.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fb528e295ed31570ac3dcc9bfdd6e0150bc11ce6168ac87a8082055cf1a67395"},
-    {file = "pydantic_core-2.46.3-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:367508faa4973b992b271ba1494acaab36eb7e8739d1e47be5035fb1ea225396"},
-    {file = "pydantic_core-2.46.3-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5ad3c826fe523e4becf4fe39baa44286cff85ef137c729a2c5e269afbfd0905d"},
-    {file = "pydantic_core-2.46.3-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:ec638c5d194ef8af27db69f16c954a09797c0dc25015ad6123eb2c73a4d271ca"},
-    {file = "pydantic_core-2.46.3-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:28ed528c45446062ee66edb1d33df5d88828ae167de76e773a3c7f64bd14e976"},
-    {file = "pydantic_core-2.46.3-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:aed19d0c783886d5bd86d80ae5030006b45e28464218747dcf83dabfdd092c7b"},
-    {file = "pydantic_core-2.46.3-cp312-cp312-win32.whl", hash = "sha256:06d5d8820cbbdb4147578c1fe7ffcd5b83f34508cb9f9ab76e807be7db6ff0a4"},
-    {file = "pydantic_core-2.46.3-cp312-cp312-win_amd64.whl", hash = "sha256:c3212fda0ee959c1dd04c60b601ec31097aaa893573a3a1abd0a47bcac2968c1"},
-    {file = "pydantic_core-2.46.3-cp312-cp312-win_arm64.whl", hash = "sha256:f1f8338dd7a7f31761f1f1a3c47503a9a3b34eea3c8b01fa6ee96408affb5e72"},
-    {file = "pydantic_core-2.46.3-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:12bc98de041458b80c86c56b24df1d23832f3e166cbaff011f25d187f5c62c37"},
-    {file = "pydantic_core-2.46.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:85348b8f89d2c3508b65b16c3c33a4da22b8215138d8b996912bb1532868885f"},
-    {file = "pydantic_core-2.46.3-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1105677a6df914b1fb71a81b96c8cce7726857e1717d86001f29be06a25ee6f8"},
-    {file = "pydantic_core-2.46.3-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:87082cd65669a33adeba5470769e9704c7cf026cc30afb9cc77fd865578ebaad"},
-    {file = "pydantic_core-2.46.3-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:60e5f66e12c4f5212d08522963380eaaeac5ebd795826cfd19b2dfb0c7a52b9c"},
-    {file = "pydantic_core-2.46.3-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b6cdf19bf84128d5e7c37e8a73a0c5c10d51103a650ac585d42dd6ae233f2b7f"},
-    {file = "pydantic_core-2.46.3-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:031bb17f4885a43773c8c763089499f242aee2ea85cf17154168775dccdecf35"},
-    {file = "pydantic_core-2.46.3-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:bcf2a8b2982a6673693eae7348ef3d8cf3979c1d63b54fca7c397a635cc68687"},
-    {file = "pydantic_core-2.46.3-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:28e8cf2f52d72ced402a137145923a762cbb5081e48b34312f7a0c8f55928ec3"},
-    {file = "pydantic_core-2.46.3-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:17eaface65d9fc5abb940003020309c1bf7a211f5f608d7870297c367e6f9022"},
-    {file = "pydantic_core-2.46.3-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:93fd339f23408a07e98950a89644f92c54d8729719a40b30c0a30bb9ebc55d23"},
-    {file = "pydantic_core-2.46.3-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:23cbdb3aaa74dfe0837975dbf69b469753bbde8eacace524519ffdb6b6e89eb7"},
-    {file = "pydantic_core-2.46.3-cp313-cp313-win32.whl", hash = "sha256:610eda2e3838f401105e6326ca304f5da1e15393ae25dacae5c5c63f2c275b13"},
-    {file = "pydantic_core-2.46.3-cp313-cp313-win_amd64.whl", hash = "sha256:68cc7866ed863db34351294187f9b729964c371ba33e31c26f478471c52e1ed0"},
-    {file = "pydantic_core-2.46.3-cp313-cp313-win_arm64.whl", hash = "sha256:f64b5537ac62b231572879cd08ec05600308636a5d63bcbdb15063a466977bec"},
-    {file = "pydantic_core-2.46.3-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:afa3aa644f74e290cdede48a7b0bee37d1c35e71b05105f6b340d484af536d9b"},
-    {file = "pydantic_core-2.46.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:ced3310e51aa425f7f77da8bbbb5212616655bedbe82c70944320bc1dbe5e018"},
-    {file = "pydantic_core-2.46.3-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e29908922ce9da1a30b4da490bd1d3d82c01dcfdf864d2a74aacee674d0bfa34"},
-    {file = "pydantic_core-2.46.3-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0c9ff69140423eea8ed2d5477df3ba037f671f5e897d206d921bc9fdc39613e7"},
-    {file = "pydantic_core-2.46.3-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b675ab0a0d5b1c8fdb81195dc5bcefea3f3c240871cdd7ff9a2de8aa50772eb2"},
-    {file = "pydantic_core-2.46.3-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0087084960f209a9a4af50ecd1fb063d9ad3658c07bb81a7a53f452dacbfb2ba"},
-    {file = "pydantic_core-2.46.3-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ed42e6cc8e1b0e2b9b96e2276bad70ae625d10d6d524aed0c93de974ae029f9f"},
-    {file = "pydantic_core-2.46.3-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:f1771ce258afb3e4201e67d154edbbae712a76a6081079fe247c2f53c6322c22"},
-    {file = "pydantic_core-2.46.3-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a7610b6a5242a6c736d8ad47fd5fff87fcfe8f833b281b1c409c3d6835d9227f"},
-    {file = "pydantic_core-2.46.3-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:ff5e7783bcc5476e1db448bf268f11cb257b1c276d3e89f00b5727be86dd0127"},
-    {file = "pydantic_core-2.46.3-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:9d2e32edcc143bc01e95300671915d9ca052d4f745aa0a49c48d4803f8a85f2c"},
-    {file = "pydantic_core-2.46.3-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:6e42d83d1c6b87fa56b521479cff237e626a292f3b31b6345c15a99121b454c1"},
-    {file = "pydantic_core-2.46.3-cp314-cp314-win32.whl", hash = "sha256:07bc6d2a28c3adb4f7c6ae46aa4f2d2929af127f587ed44057af50bf1ce0f505"},
-    {file = "pydantic_core-2.46.3-cp314-cp314-win_amd64.whl", hash = "sha256:8940562319bc621da30714617e6a7eaa6b98c84e8c685bcdc02d7ed5e7c7c44e"},
-    {file = "pydantic_core-2.46.3-cp314-cp314-win_arm64.whl", hash = "sha256:5dcbbcf4d22210ced8f837c96db941bdb078f419543472aca5d9a0bb7cddc7df"},
-    {file = "pydantic_core-2.46.3-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:d0fe3dce1e836e418f912c1ad91c73357d03e556a4d286f441bf34fed2dbeecf"},
-    {file = "pydantic_core-2.46.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:9ce92e58abc722dac1bf835a6798a60b294e48eb0e625ec9fd994b932ac5feee"},
-    {file = "pydantic_core-2.46.3-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a03e6467f0f5ab796a486146d1b887b2dc5e5f9b3288898c1b1c3ad974e53e4a"},
-    {file = "pydantic_core-2.46.3-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:2798b6ba041b9d70acfb9071a2ea13c8456dd1e6a5555798e41ba7b0790e329c"},
-    {file = "pydantic_core-2.46.3-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9be3e221bdc6d69abf294dcf7aff6af19c31a5cdcc8f0aa3b14be29df4bd03b1"},
-    {file = "pydantic_core-2.46.3-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f13936129ce841f2a5ddf6f126fea3c43cd128807b5a59588c37cf10178c2e64"},
-    {file = "pydantic_core-2.46.3-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:28b5f2ef03416facccb1c6ef744c69793175fd27e44ef15669201601cf423acb"},
-    {file = "pydantic_core-2.46.3-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:830d1247d77ad23852314f069e9d7ddafeec5f684baf9d7e7065ed46a049c4e6"},
-    {file = "pydantic_core-2.46.3-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d0793c90c1a3c74966e7975eaef3ed30ebdff3260a0f815a62a22adc17e4c01c"},
-    {file = "pydantic_core-2.46.3-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:d2d0aead851b66f5245ec0c4fb2612ef457f8bbafefdf65a2bf9d6bac6140f47"},
-    {file = "pydantic_core-2.46.3-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:2f40e4246676beb31c5ce77c38a55ca4e465c6b38d11ea1bd935420568e0b1ab"},
-    {file = "pydantic_core-2.46.3-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:cf489cf8986c543939aeee17a09c04d6ffb43bfef8ca16fcbcc5cfdcbed24dba"},
-    {file = "pydantic_core-2.46.3-cp314-cp314t-win32.whl", hash = "sha256:ffe0883b56cfc05798bf994164d2b2ff03efe2d22022a2bb080f3b626176dd56"},
-    {file = "pydantic_core-2.46.3-cp314-cp314t-win_amd64.whl", hash = "sha256:706d9d0ce9cf4593d07270d8e9f53b161f90c57d315aeec4fb4fd7a8b10240d8"},
-    {file = "pydantic_core-2.46.3-cp314-cp314t-win_arm64.whl", hash = "sha256:77706aeb41df6a76568434701e0917da10692da28cb69d5fb6919ce5fdb07374"},
-    {file = "pydantic_core-2.46.3-cp39-cp39-macosx_10_12_x86_64.whl", hash = "sha256:fa3eb7c2995aa443687a825bc30395c8521b7c6ec201966e55debfd1128bcceb"},
-    {file = "pydantic_core-2.46.3-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:3d08782c4045f90724b44c95d35ebec0d67edb8a957a2ac81d5a8e4b8a200495"},
-    {file = "pydantic_core-2.46.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:831eb19aa789a97356979e94c981e5667759301fb708d1c0d5adf1bc0098b873"},
-    {file = "pydantic_core-2.46.3-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:4335e87c7afa436a0dfa899e138d57a72f8aad542e2cf19c36fb428461caabd0"},
-    {file = "pydantic_core-2.46.3-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:99421e7684a60f7f3550a1d159ade5fdff1954baedb6bdd407cba6a307c9f27d"},
-    {file = "pydantic_core-2.46.3-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:dd81f6907932ebac3abbe41378dac64b2380db1287e2aa64d8d88f78d170f51a"},
-    {file = "pydantic_core-2.46.3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9f247596366f4221af52beddd65af1218797771d6989bc891a0b86ccaa019168"},
-    {file = "pydantic_core-2.46.3-cp39-cp39-manylinux_2_31_riscv64.whl", hash = "sha256:6dff8cc884679df229ebc6d8eb2321ea6f8e091bc7d4886d4dc2e0e71452843c"},
-    {file = "pydantic_core-2.46.3-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:68ef2f623dda6d5a9067ac014e406c020c780b2a358930a7e5c1b73702900720"},
-    {file = "pydantic_core-2.46.3-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:d56bdb4af1767cc15b0386b3c581fdfe659bb9ee4a4f776e92c1cd9d074000d6"},
-    {file = "pydantic_core-2.46.3-cp39-cp39-musllinux_1_1_armv7l.whl", hash = "sha256:91249bcb7c165c2fb2a2f852dbc5c91636e2e218e75d96dfdd517e4078e173dd"},
-    {file = "pydantic_core-2.46.3-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:4b068543bdb707f5d935dab765d99227aa2545ef2820935f2e5dd801795c7dbd"},
-    {file = "pydantic_core-2.46.3-cp39-cp39-win32.whl", hash = "sha256:dcda6583921c05a40533f982321532f2d8db29326c7b95c4026941fa5074bd79"},
-    {file = "pydantic_core-2.46.3-cp39-cp39-win_amd64.whl", hash = "sha256:a35cc284c8dd7edae8a31533713b4d2467dfe7c4f1b5587dd4031f28f90d1d13"},
-    {file = "pydantic_core-2.46.3-graalpy311-graalpy242_311_native-macosx_10_12_x86_64.whl", hash = "sha256:9715525891ed524a0a1eb6d053c74d4d4ad5017677fb00af0b7c2644a31bae46"},
-    {file = "pydantic_core-2.46.3-graalpy311-graalpy242_311_native-macosx_11_0_arm64.whl", hash = "sha256:9d2f400712a99a013aff420ef1eb9be077f8189a36c1e3ef87660b4e1088a874"},
-    {file = "pydantic_core-2.46.3-graalpy311-graalpy242_311_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bd2aab0e2e9dc2daf36bd2686c982535d5e7b1d930a1344a7bb6e82baab42a76"},
-    {file = "pydantic_core-2.46.3-graalpy311-graalpy242_311_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4e9d76736da5f362fabfeea6a69b13b7f2be405c6d6966f06b2f6bfff7e64531"},
-    {file = "pydantic_core-2.46.3-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:b12dd51f1187c2eb489af8e20f880362db98e954b54ab792fa5d92e8bcc6b803"},
-    {file = "pydantic_core-2.46.3-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:f00a0961b125f1a47af7bcc17f00782e12f4cd056f83416006b30111d941dfa3"},
-    {file = "pydantic_core-2.46.3-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:57697d7c056aca4bbb680200f96563e841a6386ac1129370a0102592f4dddff5"},
-    {file = "pydantic_core-2.46.3-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fd35aa21299def8db7ef4fe5c4ff862941a9a158ca7b63d61e66fe67d30416b4"},
-    {file = "pydantic_core-2.46.3-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:13afdd885f3d71280cf286b13b310ee0f7ccfefd1dbbb661514a474b726e2f25"},
-    {file = "pydantic_core-2.46.3-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:f91c0aff3e3ee0928edd1232c57f643a7a003e6edf1860bc3afcdc749cb513f3"},
-    {file = "pydantic_core-2.46.3-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6529d1d128321a58d30afcc97b49e98836542f68dd41b33c2e972bb9e5290536"},
-    {file = "pydantic_core-2.46.3-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:975c267cff4f7e7272eacbe50f6cc03ca9a3da4c4fbd66fffd89c94c1e311aa1"},
-    {file = "pydantic_core-2.46.3-pp311-pypy311_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:2b8e4f2bbdf71415c544b4b1138b8060db7b6611bc927e8064c769f64bed651c"},
-    {file = "pydantic_core-2.46.3-pp311-pypy311_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:e61ea8e9fff9606d09178f577ff8ccdd7206ff73d6552bcec18e1033c4254b85"},
-    {file = "pydantic_core-2.46.3-pp311-pypy311_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:b504bda01bafc69b6d3c7a0c7f039dcf60f47fab70e06fe23f57b5c75bdc82b8"},
-    {file = "pydantic_core-2.46.3-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:b00b76f7142fc60c762ce579bd29c8fa44aaa56592dd3c54fab3928d0d4ca6ff"},
-    {file = "pydantic_core-2.46.3.tar.gz", hash = "sha256:41c178f65b8c29807239d47e6050262eb6bf84eb695e41101e62e38df4a5bc2c"},
+    {file = "pydantic_core-2.46.4-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:a396dcc17e5a0b164dbe026896245a4fa9ff402edca1dff0be3d53a517f74de4"},
+    {file = "pydantic_core-2.46.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:da4b951fe36dc7c3a1ccb4e3cd1747c3542b8c9ceede8fc86cae054e764485f5"},
+    {file = "pydantic_core-2.46.4-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bb63e0198ca18aad131c089b9204c23079c3afa95487e561f4c522d519e55aba"},
+    {file = "pydantic_core-2.46.4-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f47286a97f0bc9b8859519809077b91b2cefe4ae47fcbf5e466a009c1c5d742b"},
+    {file = "pydantic_core-2.46.4-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:905a0ed8ea6f2d61c1738835f99b699348d7857379083e5fc497fa0c967a407c"},
+    {file = "pydantic_core-2.46.4-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ea793e075b70290d89d8142074262885d3f7da19634845135751bd6344f73b50"},
+    {file = "pydantic_core-2.46.4-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:395aebd9183f9d112f569aeb5b2214d1a10a33bec8456447f7fbdfa51d38d4cd"},
+    {file = "pydantic_core-2.46.4-cp310-cp310-manylinux_2_31_riscv64.whl", hash = "sha256:b078afbc25f3a1436c7a1d2cd3e322497ee99615ba97c563566fdf46aff1ee01"},
+    {file = "pydantic_core-2.46.4-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:f747929cf940cddb5b3668a390056ddd5ba2e5010615ea2dcf4f9c4f3ab8791d"},
+    {file = "pydantic_core-2.46.4-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:daa27d92c36f24388fe3ad306b174781c747627f134452e4f128ea00ce1fe8c4"},
+    {file = "pydantic_core-2.46.4-cp310-cp310-musllinux_1_1_armv7l.whl", hash = "sha256:19e51f073cd3df251856a8a4189fbdf1de4012c3ebacfb1884f94f1eb406079f"},
+    {file = "pydantic_core-2.46.4-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:c1747f85cee84c26985853c6f3d9bd3e75da5212912443fa111c113b9c246f39"},
+    {file = "pydantic_core-2.46.4-cp310-cp310-win32.whl", hash = "sha256:2f84c03c8607173d16b5a854ec68a2f9079ae03237a54fb506d13af47e1d018d"},
+    {file = "pydantic_core-2.46.4-cp310-cp310-win_amd64.whl", hash = "sha256:8358a950c8909158e3df31538a7e4edc2d7265a7c54b47f0864d9e5bae9dcebf"},
+    {file = "pydantic_core-2.46.4-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:0e96592440881c74a213e5ad528e2b24d3d4f940de2766bed9010ab1d9e51594"},
+    {file = "pydantic_core-2.46.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:e0d65b8c354be7fb5f720c3caa8bc940bc2d20ce749c8e06135f07f8ed95dd7c"},
+    {file = "pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7bfb192b3f4b9e8a89b6277b6ce787564f62cfd272055f6e685726b111dc7826"},
+    {file = "pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:9037063db01f09b09e237c282b6792bd4da634b5402c4e7f0c61effed7701a04"},
+    {file = "pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:fc010ab034c8c7452522748bf937df58020d256ccae0874463d1f4d01758af8e"},
+    {file = "pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8c5dac79fa1614d1e06ca695109c6105923bd9c7d1d6c918d4e637b7e6b32fd3"},
+    {file = "pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f9fa868638bf362d3d138ea55829cefb3d5f4b0d7f142234382a15e2485dbec4"},
+    {file = "pydantic_core-2.46.4-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:17299feefe090f2caa5b8e37222bb5f663e4935a8bfa6931d4102e5df1a9f398"},
+    {file = "pydantic_core-2.46.4-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:4c63ebc82684aa89d9a3bcbd13d515b3be44250dc68dd3bd81526c1cb31286c3"},
+    {file = "pydantic_core-2.46.4-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:aaa2a54443eff1950ba5ddc6b6ccda0d9c84a364276a62f969bdf2a390650848"},
+    {file = "pydantic_core-2.46.4-cp311-cp311-musllinux_1_1_armv7l.whl", hash = "sha256:18e5ceec2ab67e6d5f1a9085e5a24c9c4e2ac4545730bfe668680bca05e555f3"},
+    {file = "pydantic_core-2.46.4-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:a0f62d0a58f4e7da165457e995725421e0064f2255d8eccebc49f41bbc23b109"},
+    {file = "pydantic_core-2.46.4-cp311-cp311-win32.whl", hash = "sha256:041bde0a48fd37cf71cab1c9d56d3e8625a3793fef1f7dd232b3ff37e978ecda"},
+    {file = "pydantic_core-2.46.4-cp311-cp311-win_amd64.whl", hash = "sha256:6f2eeda33a839975441c86a4119e1383c50b47faf0cbb5176985565c6bb02c33"},
+    {file = "pydantic_core-2.46.4-cp311-cp311-win_arm64.whl", hash = "sha256:14f4c5d6db102bd796a627bbb3a17b4cf4574b9ae861d8b7c9a9661c6dd3362d"},
+    {file = "pydantic_core-2.46.4-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:3245406455a5d98187ec35530fd772b1d799b26667980872c8d4614991e2c4a2"},
+    {file = "pydantic_core-2.46.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:962ccbab7b642487b1d8b7df90ef677e03134cf1fd8880bf698649b22a69371f"},
+    {file = "pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8233f2947cf85404441fd7e0085f53b10c93e0ee78611099b5c7237e36aacbf7"},
+    {file = "pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3a233125ac121aa3ffba9a2b59edfc4a985a76092dc8279586ab4b71390875e7"},
+    {file = "pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5b712b53160b79a5850310b912a5ef8e57e56947c8ad690c227f5c9d7e561712"},
+    {file = "pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9401557acd873c3a7f3eb9383edef8ac4968f9510e340f4808d427e75667e7b4"},
+    {file = "pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:926c9541b14b12b1681dca8a0b75feb510b06c6341b70a8e500c2fdcff837cce"},
+    {file = "pydantic_core-2.46.4-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:56cb4851bcaf3d117eddcef4fe66afd750a50274b0da8e22be256d10e5611987"},
+    {file = "pydantic_core-2.46.4-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c68fcd102d71ea85c5b2dfac3f4f8476eff42a9e078fd5faefff6d145063536b"},
+    {file = "pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:b2f69dec1725e79a012d920df1707de5caf7ed5e08f3be4435e25803efc47458"},
+    {file = "pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:8d0820e8192167f80d88d64038e609c31452eeca865b4e1d9950a27a4609b00b"},
+    {file = "pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:fbdb89b3e1c94a30cc5edfce477c6e6a5dc4d8f84665b455c27582f211a1c72c"},
+    {file = "pydantic_core-2.46.4-cp312-cp312-win32.whl", hash = "sha256:9aa768456404a8bf48a4406685ac2bec8e72b62c69313734fa3b73cf33b3a894"},
+    {file = "pydantic_core-2.46.4-cp312-cp312-win_amd64.whl", hash = "sha256:e9c26f834c65f5752f3f06cb08cb86a913ceb7274d0db6e267808a708b46bc89"},
+    {file = "pydantic_core-2.46.4-cp312-cp312-win_arm64.whl", hash = "sha256:4fc73cb559bdb54b1134a706a2802a4cddd27a0633f5abb7e53056268751ac6a"},
+    {file = "pydantic_core-2.46.4-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:5d5902252db0d3cedf8d4a1bc68f70eeb430f7e4c7104c8c476753519b423008"},
+    {file = "pydantic_core-2.46.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c94f0688e7b8d0a67abf40e57a7eaaecd17cc9586706a31b76c031f63df052b4"},
+    {file = "pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f027324c56cd5406ca49c124b0db10e56c69064fec039acc571c29020cc87c76"},
+    {file = "pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e739fee756ba1010f8bcccb534252e85a35fe45ae92c295a06059ce58b74ccd3"},
+    {file = "pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9d56801be94b86a9da183e5f3766e6310752b99ff647e38b09a9500d88e46e76"},
+    {file = "pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2412e734dcb48da14d4e4006b82b46b74f2518b8a26ee7e58c6844a6cd6d03c4"},
+    {file = "pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9551187363ffc0de2a00b2e47c25aeaeb1020b69b668762966df15fc5659dd5a"},
+    {file = "pydantic_core-2.46.4-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:0186750b482eefa11d7f435892b09c5c606193ef3375bcf94aa00ae6bfb66262"},
+    {file = "pydantic_core-2.46.4-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5855698a4856556d86e8e6cd8434bc3ac0314ee8e12089ae0e143f64c6256e4e"},
+    {file = "pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:cbaf13819775b7f769bf4a1f066cb6df7a28d4480081a589828ef190226881cd"},
+    {file = "pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:633147d34cf4550417f12e2b1a0383973bdf5cdfde212cb09e9a581cf10820be"},
+    {file = "pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:82cf5301172168103724d49a1444d3378cb20cdee30b116a1bd6031236298a5d"},
+    {file = "pydantic_core-2.46.4-cp313-cp313-win32.whl", hash = "sha256:9fa8ae11da9e2b3126c6426f147e0fba88d96d65921799bb30c6abd1cb2c97fb"},
+    {file = "pydantic_core-2.46.4-cp313-cp313-win_amd64.whl", hash = "sha256:6b3ace8194b0e5204818c92802dcdca7fc6d88aabbb799d7c795540d9cd6d292"},
+    {file = "pydantic_core-2.46.4-cp313-cp313-win_arm64.whl", hash = "sha256:184c081504d17f1c1066e430e117142b2c77d9448a97f7b65c6ac9fd9aee238d"},
+    {file = "pydantic_core-2.46.4-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:428e04521a40150c85216fc8b85e8d39fece235a9cf5e383761238c7fa9b96fb"},
+    {file = "pydantic_core-2.46.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:23ace664830ee0bfe014a0c7bc248b1f7f25ed7ad103852c317624a1083af462"},
+    {file = "pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce5c1d2a8b27468f433ca974829c44060b8097eedc39933e3c206a90ee49c4a9"},
+    {file = "pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7283d57845ecf5a163403eb0702dfc220cc4fbdd18919cb5ccea4f95ee1cdab4"},
+    {file = "pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8daafc69c93ee8a0204506a3b6b30f586ef54028f52aeeeb5c4cfc5184fd5914"},
+    {file = "pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cd2213145bcc2ba85884d0ac63d222fece9209678f77b9b4d76f054c561adb28"},
+    {file = "pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7a5f930472650a82629163023e630d160863fce524c616f4e5186e5de9d9a49b"},
+    {file = "pydantic_core-2.46.4-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:c1b3f518abeca3aa13c712fd202306e145abf59a18b094a6bafb2d2bbf59192c"},
+    {file = "pydantic_core-2.46.4-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1a7dd0b3ee80d90150e3495a3a13ac34dbcbfd4f012996a6a1d8900e91b5c0fb"},
+    {file = "pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:3fb702cd90b0446a3a1c5e470bfa0dd23c0233b676a9099ddcc964fa6ca13898"},
+    {file = "pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:b8458003118a712e66286df6a707db01c52c0f52f7db8e4a38f0da1d3b94fc4e"},
+    {file = "pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:372429a130e469c9cd698925ce5fc50940b7a1336b0d82038e63d5bbc4edc519"},
+    {file = "pydantic_core-2.46.4-cp314-cp314-win32.whl", hash = "sha256:85bb3611ff1802f3ee7fdd7dbff26b56f343fb432d57a4728fdd49b6ef35e2f4"},
+    {file = "pydantic_core-2.46.4-cp314-cp314-win_amd64.whl", hash = "sha256:811ff8e9c313ab425368bcbb36e5c4ebd7108c2bbf4e4089cfbb0b01eff63fac"},
+    {file = "pydantic_core-2.46.4-cp314-cp314-win_arm64.whl", hash = "sha256:bfec22eab3c8cc2ceec0248aec886624116dc079afa027ecc8ad4a7e62010f8a"},
+    {file = "pydantic_core-2.46.4-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:af8244b2bef6aaad6d92cda81372de7f8c8d36c9f0c3ea36e827c60e7d9467a0"},
+    {file = "pydantic_core-2.46.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5a4330cdbc57162e4b3aa303f588ba752257694c9c9be3e7ebb11b4aca659b5d"},
+    {file = "pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:29c61fc04a3d840155ff08e475a04809278972fe6aef51e2720554e96367e34b"},
+    {file = "pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c50f2528cf200c5eed56faf3f4e22fcd5f38c157a8b78576e6ba3168ec35f000"},
+    {file = "pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0cbe8b01f948de4286c74cdd6c667aceb38f5c1e26f0693b3983d9d74887c65e"},
+    {file = "pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:617d7e2ca7dcb8c5cf6bcb8c59b8832c94b36196bbf1cbd1bfb56ed341905edd"},
+    {file = "pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7027560ee92211647d0d34e3f7cd6f50da56399d26a9c8ad0da286d3869a53f3"},
+    {file = "pydantic_core-2.46.4-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:f99626688942fb746e545232e7726926f3be91b5975f8b55327665fafda991c7"},
+    {file = "pydantic_core-2.46.4-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fc3e9034a63de20e15e8ade85358bc6efc614008cab72898b4b4952bea0509ff"},
+    {file = "pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:97e7cf2be5c77b7d1a9713a05605d49460d02c6078d38d8bef3cbe323c548424"},
+    {file = "pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:3bf92c5d0e00fefaab325a4d27828fe6b6e2a21848686b5b60d2d9eeb09d76c6"},
+    {file = "pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:3ecbc122d18468d06ca279dc26a8c2e2d5acb10943bb35e36ae92096dc3b5565"},
+    {file = "pydantic_core-2.46.4-cp314-cp314t-win32.whl", hash = "sha256:e846ae7835bf0703ae43f534ab79a867146dadd59dc9ca5c8b53d5c8f7c9ef02"},
+    {file = "pydantic_core-2.46.4-cp314-cp314t-win_amd64.whl", hash = "sha256:2108ba5c1c1eca18030634489dc544844144ee36357f2f9f780b93e7ddbb44b5"},
+    {file = "pydantic_core-2.46.4-cp314-cp314t-win_arm64.whl", hash = "sha256:4fcbe087dbc2068af7eda3aa87634eba216dbda64d1ae73c8684b621d33f6596"},
+    {file = "pydantic_core-2.46.4-cp39-cp39-macosx_10_12_x86_64.whl", hash = "sha256:fd8b3d9fd264be37976686c7f65cd52a83f5e84f4bfd2adf9c1d469676bbb6ae"},
+    {file = "pydantic_core-2.46.4-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:9f444c499b3eefd3a92e348059471ea0c3a6e303d9c1cec09fa748fd9f895201"},
+    {file = "pydantic_core-2.46.4-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3447661d99f75a3683a4cf5c87da72f2161964611864dbbeac7fbb118bb4bfc0"},
+    {file = "pydantic_core-2.46.4-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8b9bab013d1c7a79d3501ff86d0bc9c31bf587db4551677b96bec07df78c6b15"},
+    {file = "pydantic_core-2.46.4-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d995260fdf4e1db774581b4900e0f832abe3c7c84996726bbc161b19c8f29e76"},
+    {file = "pydantic_core-2.46.4-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f13a646d65d09fbf1bc6b3a9635d30095c8e7e5cc419ff35ecc563c5fd04cd49"},
+    {file = "pydantic_core-2.46.4-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:432c179df7874eeb73307aad2df0755e1ae0efa61ff0ea89b93e194411ae3928"},
+    {file = "pydantic_core-2.46.4-cp39-cp39-manylinux_2_31_riscv64.whl", hash = "sha256:e68b7a074f65a2fd746c52a7ce6142ab7006074ac269ace0c25cd8ba171f8066"},
+    {file = "pydantic_core-2.46.4-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:4a05d69cba51d852c5c3e92758653245a50c0b646ced0cf05bd793ed592839d6"},
+    {file = "pydantic_core-2.46.4-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:228ee9bae8bef5b1e97ec58302f80357c37199e0d0a99174e138d28e6957b9d9"},
+    {file = "pydantic_core-2.46.4-cp39-cp39-musllinux_1_1_armv7l.whl", hash = "sha256:10e17cbb10a330363733efc4d7c4d0dd827ac0909b8f6a6542298fed1ea62f29"},
+    {file = "pydantic_core-2.46.4-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:91a06d2e259ecfbd8c901d70c3c507900458498142b3026a296b7de4d1322cc9"},
+    {file = "pydantic_core-2.46.4-cp39-cp39-win32.whl", hash = "sha256:d80ee3d731373b24cebbc10d689ca4ee1875caf0d5703a245db18efd4dd37fc1"},
+    {file = "pydantic_core-2.46.4-cp39-cp39-win_amd64.whl", hash = "sha256:3be77f45df024d789a672ae34f8b06fb346c4f9f46ea714956660ea4862e89ac"},
+    {file = "pydantic_core-2.46.4-graalpy311-graalpy242_311_native-macosx_10_12_x86_64.whl", hash = "sha256:14d4edf427bdcf950a8a02d7cb44a08614388dd6e1bdcbf4f67504fa7887da9c"},
+    {file = "pydantic_core-2.46.4-graalpy311-graalpy242_311_native-macosx_11_0_arm64.whl", hash = "sha256:0ce40cd7b21210e99342afafbd4d0f76d784eb5b1d60f3bdc566be4983c6c73b"},
+    {file = "pydantic_core-2.46.4-graalpy311-graalpy242_311_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:90884113d8b48f760e9587002789ddd741e76ab9f89518cd1e43b1f1a52ec44b"},
+    {file = "pydantic_core-2.46.4-graalpy311-graalpy242_311_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:66ce7632c22d837c95301830e111ad0128a32b8207533b60896a96c4915192ea"},
+    {file = "pydantic_core-2.46.4-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:1d8ba486450b14f3b1d63bc521d410ec7565e52f887b9fb671791886436a42f7"},
+    {file = "pydantic_core-2.46.4-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:3009f12e4e90b7f88b4f9adb1b0c4a3d58fe7820f3238c190047209d148026df"},
+    {file = "pydantic_core-2.46.4-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ad785e92e6dc634c21555edc8bd6b64957ab844541bcb96a1366c202951ae526"},
+    {file = "pydantic_core-2.46.4-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:00c603d540afdd6b80eb39f078f33ebd46211f02f33e34a32d9f053bba711de0"},
+    {file = "pydantic_core-2.46.4-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:0c563b08bca408dc7f65f700633d8442fffb2421fc47b8101377e9fd65051ff0"},
+    {file = "pydantic_core-2.46.4-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:db06ffe51636ffe9ca531fe9023dd64bdd794be8754cb5df57c5498ae5b518a7"},
+    {file = "pydantic_core-2.46.4-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:133878133d271ade3d41d1bfb2a45ec38dbdbda40bc065921c6b04e4630127e2"},
+    {file = "pydantic_core-2.46.4-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:9bc519fbf2b7578398853d815009ae5e4d4603d12f4e3f91da8c06852d3da3e9"},
+    {file = "pydantic_core-2.46.4-pp311-pypy311_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:c7a7bd4e39e8e4c12c39cd480356842b6a8a06e41b23a55a5e3e191718838ddf"},
+    {file = "pydantic_core-2.46.4-pp311-pypy311_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:d396ec2b979760aaf3218e76c24e65bd0aca24983298653b3a9d7a45f9e47b30"},
+    {file = "pydantic_core-2.46.4-pp311-pypy311_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:86e1a4418c6cd97d60c95c71164158eaf7324fae7b0923264016baa993eba6fc"},
+    {file = "pydantic_core-2.46.4-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:d51026d73fcfd93610abc7b27789c26b313920fcfb20e27462d74a7f8b06e983"},
+    {file = "pydantic_core-2.46.4.tar.gz", hash = "sha256:62f875393d7f270851f20523dd2e29f082bcc82292d66db2b64ea71f64b6e1c1"},
 ]
 
 [package.dependencies]
@@ -1088,14 +1120,14 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pylint"
-version = "4.0.5"
+version = "4.0.6"
 description = "python code static checker"
 optional = false
 python-versions = ">=3.10.0"
 groups = ["dev"]
 files = [
-    {file = "pylint-4.0.5-py3-none-any.whl", hash = "sha256:00f51c9b14a3b3ae08cff6b2cdd43f28165c78b165b628692e428fb1f8dc2cf2"},
-    {file = "pylint-4.0.5.tar.gz", hash = "sha256:8cd6a618df75deb013bd7eb98327a95f02a6fb839205a6bbf5456ef96afb317c"},
+    {file = "pylint-4.0.6-py3-none-any.whl", hash = "sha256:d11a0e1fdb7b1cd46ec5d6fc78fee8b95f28695b2d6140e5809925f61e32ea54"},
+    {file = "pylint-4.0.6.tar.gz", hash = "sha256:52f19191bee08bf103f9705ad1a0ece4aa5a0a4ef2bdcbd969375a1e6f6579d5"},
 ]
 
 [package.dependencies]
@@ -1149,14 +1181,14 @@ pylint-plugin-utils = "*"
 
 [[package]]
 name = "pymdown-extensions"
-version = "10.21.2"
+version = "11.0.1"
 description = "Extension pack for Python Markdown."
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 groups = ["dev"]
 files = [
-    {file = "pymdown_extensions-10.21.2-py3-none-any.whl", hash = "sha256:5c0fd2a2bea14eb39af8ff284f1066d898ab2187d81b889b75d46d4348c01638"},
-    {file = "pymdown_extensions-10.21.2.tar.gz", hash = "sha256:c3f55a5b8a1d0edf6699e35dcbea71d978d34ff3fa79f3d807b8a5b3fa90fbdc"},
+    {file = "pymdown_extensions-11.0.1-py3-none-any.whl", hash = "sha256:db3943a62bab7e03af1364f0c4083e64b91fb097675a4b6cceccfbe9a77e5eb2"},
+    {file = "pymdown_extensions-11.0.1.tar.gz", hash = "sha256:dd2905ae6fc5b75582fafb139a1266ffc754705efa902aa50067fa7ff4f94ec0"},
 ]
 
 [package.dependencies]
@@ -1168,14 +1200,14 @@ extra = ["pygments (>=2.19.1)"]
 
 [[package]]
 name = "pyright"
-version = "1.1.409"
+version = "1.1.411"
 description = "Command line wrapper for pyright"
 optional = false
 python-versions = ">=3.7"
 groups = ["dev"]
 files = [
-    {file = "pyright-1.1.409-py3-none-any.whl", hash = "sha256:aa3ea228cab90c845c7a60d28db7a844c04315356392aa09fafcee98c8c22fb3"},
-    {file = "pyright-1.1.409.tar.gz", hash = "sha256:986ee05beca9e077c165758ad123667c679e050059a2546aa02473930394bc93"},
+    {file = "pyright-1.1.411-py3-none-any.whl", hash = "sha256:dc7c72a8e2700c55baa127554040e067041ea53ccfd50bf96308cc4291c7d5d9"},
+    {file = "pyright-1.1.411.tar.gz", hash = "sha256:d885a0551f2e763b089a02702174e7f4ba77548cddabc972ab86d1f7f1b0f998"},
 ]
 
 [package.dependencies]
@@ -1189,14 +1221,14 @@ nodejs = ["nodejs-wheel-binaries"]
 
 [[package]]
 name = "pytest"
-version = "9.0.3"
+version = "9.1.1"
 description = "pytest: simple powerful testing with Python"
 optional = false
 python-versions = ">=3.10"
 groups = ["dev"]
 files = [
-    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
-    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
+    {file = "pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c"},
+    {file = "pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313"},
 ]
 
 [package.dependencies]
@@ -1419,30 +1451,30 @@ jupyter = ["ipywidgets (>=7.5.1,<9)"]
 
 [[package]]
 name = "ruff"
-version = "0.15.12"
+version = "0.15.22"
 description = "An extremely fast Python linter and code formatter, written in Rust."
 optional = false
 python-versions = ">=3.7"
 groups = ["dev"]
 files = [
-    {file = "ruff-0.15.12-py3-none-linux_armv6l.whl", hash = "sha256:f86f176e188e94d6bdbc09f09bfd9dc729059ad93d0e7390b5a73efe19f8861c"},
-    {file = "ruff-0.15.12-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:e3bcd123364c3770b8e1b7baaf343cc99a35f197c5c6e8af79015c666c423a6c"},
-    {file = "ruff-0.15.12-py3-none-macosx_11_0_arm64.whl", hash = "sha256:fe87510d000220aa1ed530d4448a7c696a0cae1213e5ec30e5874287b66557b5"},
-    {file = "ruff-0.15.12-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:84a1630093121375a3e2a95b4a6dc7b59e2b4ee76216e32d81aae550a832d002"},
-    {file = "ruff-0.15.12-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:fb129f40f114f089ebe0ca56c0d251cf2061b17651d464bb6478dc01e69f11f5"},
-    {file = "ruff-0.15.12-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b0c862b172d695db7598426b8af465e7e9ac00a3ea2a3630ee67eb82e366aaa6"},
-    {file = "ruff-0.15.12-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2849ea9f3484c3aca43a82f484210370319e7170df4dfe4843395ddf6c57bc33"},
-    {file = "ruff-0.15.12-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9e77c7e51c07fe396826d5969a5b846d9cd4c402535835fb6e21ce8b28fef847"},
-    {file = "ruff-0.15.12-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:83b2f4f2f3b1026b5fb449b467d9264bf22067b600f7b6f41fc5958909f449d0"},
-    {file = "ruff-0.15.12-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:9ba3b8f1afd7e2e43d8943e55f249e13f9682fde09711644a6e7290eb4f3e339"},
-    {file = "ruff-0.15.12-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:e852ba9fdc890655e1d78f2df1499efbe0e54126bd405362154a75e2bde159c5"},
-    {file = "ruff-0.15.12-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:dd8aed930da53780d22fc70bdf84452c843cf64f8cb4eb38984319c24c5cd5fd"},
-    {file = "ruff-0.15.12-py3-none-musllinux_1_2_i686.whl", hash = "sha256:01da3988d225628b709493d7dc67c3b9b12c0210016b08690ef9bd27970b262b"},
-    {file = "ruff-0.15.12-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:9cae0f92bd5700d1213188b31cd3bdd2b315361296d10b96b8e2337d3d11f53e"},
-    {file = "ruff-0.15.12-py3-none-win32.whl", hash = "sha256:d0185894e038d7043ba8fd6aee7499ece6462dc0ea9f1e260c7451807c714c20"},
-    {file = "ruff-0.15.12-py3-none-win_amd64.whl", hash = "sha256:c87a162d61ab3adca47c03f7f717c68672edec7d1b5499e652331780fe74950d"},
-    {file = "ruff-0.15.12-py3-none-win_arm64.whl", hash = "sha256:a538f7a82d061cee7be55542aca1d86d1393d55d81d4fcc314370f4340930d4f"},
-    {file = "ruff-0.15.12.tar.gz", hash = "sha256:ecea26adb26b4232c0c2ca19ccbc0083a68344180bba2a600605538ce51a40a6"},
+    {file = "ruff-0.15.22-py3-none-linux_armv6l.whl", hash = "sha256:44423e73493737f5e7c5b41d475483898ff37afcdae38bc3da5085e29af1c2d8"},
+    {file = "ruff-0.15.22-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:b82c6482946e9eda7ff2e091d25b8bad3f718684e1916d41bd56873cee05b697"},
+    {file = "ruff-0.15.22-py3-none-macosx_11_0_arm64.whl", hash = "sha256:11c1c715af53a09f714e011106bffc419751ec8232fcb5da42173284ea3fec6f"},
+    {file = "ruff-0.15.22-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:742a29cf29bddb7c8327895d6a10e0e6c5b38a96dd407af9b5d0857f809c0576"},
+    {file = "ruff-0.15.22-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:72af58b951b0ae395935ae79763dc349bc0eb706319d28f7a33ad2cfb3cfc178"},
+    {file = "ruff-0.15.22-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:62d425005c1835eb24e2ee4161cb90e8db263415f4a71c8c72c33abaa6c0c224"},
+    {file = "ruff-0.15.22-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e8b9b3f8779a4f08c969defc3c8c35abffaa757e601ed5ae66d6d1db6519969a"},
+    {file = "ruff-0.15.22-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:1e0dd1b2e4d3d585f897a0d137cbf4eaf6223bef4e8ce34d6bb12556c5f9249e"},
+    {file = "ruff-0.15.22-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:365523eb91d9224e1bcb03b022fbf0facb8f9e23792a2c53d9d4b3924bdbdebb"},
+    {file = "ruff-0.15.22-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:fabfd168afdf29fee5be98b831efa9683c94d7c5a3b58b9ce5a2e38444589a74"},
+    {file = "ruff-0.15.22-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:225dbf095a87f1d9f90f5fd7924d2613ee452a75a4308c63a8f50f761787aa7c"},
+    {file = "ruff-0.15.22-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:1877d63b9d24ed278744f1523fd11b85540566d54641f97c566d7d9dc5ca5296"},
+    {file = "ruff-0.15.22-py3-none-musllinux_1_2_i686.whl", hash = "sha256:a1606c510bd7215680d32efab38965f7cdec3ef69f5170a3f4791404ffdd5262"},
+    {file = "ruff-0.15.22-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:630479b18625f5ffc373f77603a22a9f8ac0acd7ff0501178b5db28ec71e9c64"},
+    {file = "ruff-0.15.22-py3-none-win32.whl", hash = "sha256:e5ba0e4a13fd14abbed2a77b517a3911290c6c6c59ef67784328d1668fab76cf"},
+    {file = "ruff-0.15.22-py3-none-win_amd64.whl", hash = "sha256:9be63ba1eb936acd2d1342fb8337c356353706fce233b2a15a09a97037e6acde"},
+    {file = "ruff-0.15.22-py3-none-win_arm64.whl", hash = "sha256:e1168075b72158510839f250027659cdd78476f40507dd517892304c41318661"},
+    {file = "ruff-0.15.22.tar.gz", hash = "sha256:3f15175b1fb580126f58285a5dae6b2ea89000136d980c64499211f116b54809"},
 ]
 
 [[package]]
@@ -1529,56 +1561,56 @@ files = [
 
 [[package]]
 name = "tomlkit"
-version = "0.14.0"
+version = "0.15.1"
 description = "Style preserving TOML library"
 optional = false
 python-versions = ">=3.9"
 groups = ["dev"]
 files = [
-    {file = "tomlkit-0.14.0-py3-none-any.whl", hash = "sha256:592064ed85b40fa213469f81ac584f67a4f2992509a7c3ea2d632208623a3680"},
-    {file = "tomlkit-0.14.0.tar.gz", hash = "sha256:cf00efca415dbd57575befb1f6634c4f42d2d87dbba376128adb42c121b87064"},
+    {file = "tomlkit-0.15.1-py3-none-any.whl", hash = "sha256:177a05aece5a8ca5266fd3c448abb47b8d352f09d477d3ca8332db4d89b24304"},
+    {file = "tomlkit-0.15.1.tar.gz", hash = "sha256:e25bbf38843005246210a12982776f27f99cb9be67160e14434d0c0d21ee1e97"},
 ]
 
 [[package]]
 name = "typer"
-version = "0.25.1"
+version = "0.27.0"
 description = "Typer, build great CLIs. Easy to code. Based on Python type hints."
 optional = false
 python-versions = ">=3.10"
 groups = ["dev"]
 files = [
-    {file = "typer-0.25.1-py3-none-any.whl", hash = "sha256:75caa44ed46a03fb2dab8808753ffacdbfea88495e74c85a28c5eefcf5f39c89"},
-    {file = "typer-0.25.1.tar.gz", hash = "sha256:9616eb8853a09ffeabab1698952f33c6f29ffdbceb4eaeecf571880e8d7664cc"},
+    {file = "typer-0.27.0-py3-none-any.whl", hash = "sha256:6f4b27631e47f077871b7dc30e933ec0131c1390fbe0e387ea5574b5bac9ccf1"},
+    {file = "typer-0.27.0.tar.gz", hash = "sha256:629bd12ea5d13a17148125d9a264f949eb171fb3f120f9b04d85873cab054fa5"},
 ]
 
 [package.dependencies]
 annotated-doc = ">=0.0.2"
-click = ">=8.2.1"
+colorama = {version = "*", markers = "platform_system == \"Windows\""}
 rich = ">=13.8.0"
 shellingham = ">=1.3.0"
 
 [[package]]
 name = "types-pyyaml"
-version = "6.0.12.20260408"
+version = "6.0.12.20260518"
 description = "Typing stubs for PyYAML"
 optional = false
 python-versions = ">=3.10"
 groups = ["dev"]
 files = [
-    {file = "types_pyyaml-6.0.12.20260408-py3-none-any.whl", hash = "sha256:fbc42037d12159d9c801ebfcc79ebd28335a7c13b08a4cfbc6916df78fee9384"},
-    {file = "types_pyyaml-6.0.12.20260408.tar.gz", hash = "sha256:92a73f2b8d7f39ef392a38131f76b970f8c66e4c42b3125ae872b7c93b556307"},
+    {file = "types_pyyaml-6.0.12.20260518-py3-none-any.whl", hash = "sha256:d2150f75a231c9fe9c7463bd29487d93e60bac90400287351384bc2284eba7cd"},
+    {file = "types_pyyaml-6.0.12.20260518.tar.gz", hash = "sha256:d917f83fb38462550338c1297faedd860b3ec83912b96b1e3d73255f7473e466"},
 ]
 
 [[package]]
 name = "typing-extensions"
-version = "4.15.0"
+version = "4.16.0"
 description = "Backported and Experimental Type Hints for Python 3.9+"
 optional = false
 python-versions = ">=3.9"
 groups = ["main", "dev"]
 files = [
-    {file = "typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548"},
-    {file = "typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466"},
+    {file = "typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8"},
+    {file = "typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5"},
 ]
 
 [[package]]
@@ -1641,18 +1673,18 @@ watchmedo = ["PyYAML (>=3.10)"]
 
 [[package]]
 name = "wcmatch"
-version = "10.1"
+version = "11.0"
 description = "Wildcard/glob file name matcher."
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 groups = ["dev"]
 files = [
-    {file = "wcmatch-10.1-py3-none-any.whl", hash = "sha256:5848ace7dbb0476e5e55ab63c6bbd529745089343427caa5537f230cc01beb8a"},
-    {file = "wcmatch-10.1.tar.gz", hash = "sha256:f11f94208c8c8484a16f4f48638a85d771d9513f4ab3f37595978801cb9465af"},
+    {file = "wcmatch-11.0-py3-none-any.whl", hash = "sha256:3a5977ace27e075eef67eb03d539563f1a19018b62881949a42932cf66926934"},
+    {file = "wcmatch-11.0.tar.gz", hash = "sha256:55d95c2447789712774b198ceec72939e88b5618f1f8f0a9b605bf7740b63b96"},
 ]
 
 [package.dependencies]
-bracex = ">=2.1.1"
+bracex = ">=3.0"
 
 [[package]]
 name = "yamllint"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hier-config"
-version = "3.6.2"
+version = "4.0.0b1"
 description = "A network configuration query and comparison library, used to build remediation configurations."
 packages = [
     { include="hier_config", from="."},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -150,6 +150,9 @@ parametrize-values-type = "tuple"
 [tool.ruff.lint.per-file-ignores]
 "**/tests/*" = ["PLC2701", "S101"]
 "tests/test_benchmarks.py" = ["T201", "PLR6301", "PERF401"]
+# HConfig's classmethod constructors defer their loader imports to call time
+# to avoid a circular import with constructors.py.
+"hier_config/root.py" = ["PLC0415"]
 
 [tool.pytest.ini_options]
 markers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,7 @@ load-plugins = [
 ]
 disable = [
     "consider-alternative-union-syntax",
+    "cyclic-import",  # Only lazy (function-level) cycles remain: HConfig classmethod constructors defer their loader imports to call time
     "duplicate-code",  # Enable this at some point in the future
     "fixme",  # Covered by ruff FIX002
     "import-outside-toplevel", # Covered by ruff PLC0415

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import os
-import subprocess  # noqa: S404
+import subprocess  # ruff:ignore[suspicious-subprocess-import]
 import sys
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from functools import cache
@@ -207,17 +207,17 @@ def _run_commands_threaded(commands: tuple[str, ...]) -> NoReturn:
         ):
             command, return_code, output = future.result()
             if return_code:
-                print(output)  # noqa: T201
+                print(output)  # ruff:ignore[print]
             return_codes[command] = return_code
 
     error_found = False
     for command, return_code in return_codes.items():
         if return_code != 0:
-            print(f"{command.split()[0]} -> {return_code}")  # noqa: T201
+            print(f"{command.split()[0]} -> {return_code}")  # ruff:ignore[print]
             error_found = True
     if error_found:
         sys.exit(1)
-    print("No issues found")  # noqa: T201
+    print("No issues found")  # ruff:ignore[print]
     sys.exit()
 
 
@@ -227,19 +227,19 @@ def _run(
     check: bool = True,
     environment: dict[str, str] | None = None,
 ) -> int:
-    print(f"\n======== {command} ========\n")  # noqa: T201
+    print(f"\n======== {command} ========\n")  # ruff:ignore[print]
     my_env = os.environ.copy()
     if environment:
         my_env.update(environment)
-    result = subprocess.run(command.split(), check=False, env=my_env)  # noqa: S603
+    result = subprocess.run(command.split(), check=False, env=my_env)  # ruff:ignore[subprocess-without-shell-equals-true]
     if check:
         sys.exit(result.returncode)
     return result.returncode
 
 
 def _run_for_thread(command: str) -> tuple[str, int, str]:
-    print(f"Running: {command}")  # noqa: T201
-    result = subprocess.run(  # noqa: S603
+    print(f"Running: {command}")  # ruff:ignore[print]
+    result = subprocess.run(  # ruff:ignore[subprocess-without-shell-equals-true]
         command.split(),
         check=False,
         capture_output=True,

--- a/tests/benchmarks/test_benchmarks.py
+++ b/tests/benchmarks/test_benchmarks.py
@@ -4,12 +4,12 @@ These tests are skipped by default. Run with:
     poetry run pytest -m benchmark -v
 """
 
-from hier_config import HConfig
 import time
 from collections.abc import Callable
 
 import pytest
 
+from hier_config import HConfig
 from hier_config.models import Platform
 
 pytestmark = pytest.mark.benchmark

--- a/tests/benchmarks/test_benchmarks.py
+++ b/tests/benchmarks/test_benchmarks.py
@@ -4,12 +4,12 @@ These tests are skipped by default. Run with:
     poetry run pytest -m benchmark -v
 """
 
+from hier_config import HConfig
 import time
 from collections.abc import Callable
 
 import pytest
 
-from hier_config import get_hconfig, get_hconfig_fast_load
 from hier_config.models import Platform
 
 pytestmark = pytest.mark.benchmark
@@ -153,7 +153,7 @@ class TestParsingBenchmarks:
     def test_parse_large_ios_config() -> None:
         """Parse a ~10k line IOS config via get_hconfig."""
         config_text = _generate_large_ios_config()
-        elapsed = _time_fn(lambda: get_hconfig(Platform.CISCO_IOS, config_text))
+        elapsed = _time_fn(lambda: HConfig.from_text(Platform.CISCO_IOS, config_text))
         line_count = config_text.count("\n")
         print(f"\nget_hconfig: {line_count} lines in {elapsed:.4f}s")  # noqa: T201
         assert elapsed < 5.0, f"Parsing took {elapsed:.2f}s, expected < 5s"
@@ -162,7 +162,7 @@ class TestParsingBenchmarks:
     def test_parse_large_xr_config() -> None:
         """Parse a ~10k line XR config via get_hconfig."""
         config_text = _generate_large_xr_config()
-        elapsed = _time_fn(lambda: get_hconfig(Platform.CISCO_XR, config_text))
+        elapsed = _time_fn(lambda: HConfig.from_text(Platform.CISCO_XR, config_text))
         line_count = config_text.count("\n")
         print(f"\nget_hconfig (XR): {line_count} lines in {elapsed:.4f}s")  # noqa: T201
         assert elapsed < 5.0, f"Parsing took {elapsed:.2f}s, expected < 5s"
@@ -173,7 +173,7 @@ class TestParsingBenchmarks:
         config_text = _generate_large_ios_config()
         config_lines = tuple(config_text.splitlines())
         elapsed = _time_fn(
-            lambda: get_hconfig_fast_load(Platform.CISCO_IOS, config_lines),
+            lambda: HConfig.from_lines(Platform.CISCO_IOS, config_lines),
         )
         print(f"\nget_hconfig_fast_load: {len(config_lines)} lines in {elapsed:.4f}s")  # noqa: T201
         assert elapsed < 5.0, f"Fast load took {elapsed:.2f}s, expected < 5s"
@@ -184,9 +184,9 @@ class TestParsingBenchmarks:
         config_text = _generate_large_ios_config()
         config_lines = tuple(config_text.splitlines())
 
-        time_full = _time_fn(lambda: get_hconfig(Platform.CISCO_IOS, config_text))
+        time_full = _time_fn(lambda: HConfig.from_text(Platform.CISCO_IOS, config_text))
         time_fast = _time_fn(
-            lambda: get_hconfig_fast_load(Platform.CISCO_IOS, config_lines),
+            lambda: HConfig.from_lines(Platform.CISCO_IOS, config_lines),
         )
         ratio = time_full / time_fast if time_fast > 0 else float("inf")
         print(  # noqa: T201
@@ -207,13 +207,13 @@ class TestRemediationBenchmarks:
     def test_remediation_small_diff() -> None:
         """Remediation with ~5% of interfaces changed."""
         running_text = _generate_large_ios_config()
-        running = get_hconfig(Platform.CISCO_IOS, running_text)
+        running = HConfig.from_text(Platform.CISCO_IOS, running_text)
 
         # Modify 50 interfaces in generated config
         generated_text = running_text.replace(
             " ip ospf cost 100", " ip ospf cost 200", 50
         )
-        generated = get_hconfig(Platform.CISCO_IOS, generated_text)
+        generated = HConfig.from_text(Platform.CISCO_IOS, generated_text)
 
         elapsed = _time_fn(lambda: running.remediation(generated))
         print(f"\nRemediation (10% diff): {elapsed:.4f}s")  # noqa: T201
@@ -222,11 +222,11 @@ class TestRemediationBenchmarks:
     @staticmethod
     def test_remediation_large_diff() -> None:
         """Remediation with ~100% of interfaces changed."""
-        running = get_hconfig(Platform.CISCO_IOS, _generate_large_ios_config())
+        running = HConfig.from_text(Platform.CISCO_IOS, _generate_large_ios_config())
         generated_text = _generate_large_ios_config().replace(
             " ip ospf cost 100", " ip ospf cost 200"
         )
-        generated = get_hconfig(Platform.CISCO_IOS, generated_text)
+        generated = HConfig.from_text(Platform.CISCO_IOS, generated_text)
 
         elapsed = _time_fn(lambda: running.remediation(generated))
         print(f"\nRemediation (100% diff): {elapsed:.4f}s")  # noqa: T201
@@ -235,7 +235,7 @@ class TestRemediationBenchmarks:
     @staticmethod
     def test_remediation_completely_different() -> None:
         """Remediation between two entirely different configs."""
-        running = get_hconfig(Platform.CISCO_IOS, _generate_large_ios_config(500))
+        running = HConfig.from_text(Platform.CISCO_IOS, _generate_large_ios_config(500))
         # Generate a completely different config
         lines = ["hostname OTHER-ROUTER"]
         for i in range(500):
@@ -246,7 +246,7 @@ class TestRemediationBenchmarks:
                     f" ip address 192.168.{i // 256}.{i % 256} 255.255.255.255",
                 ]
             )
-        generated = get_hconfig(Platform.CISCO_IOS, "\n".join(lines))
+        generated = HConfig.from_text(Platform.CISCO_IOS, "\n".join(lines))
 
         elapsed = _time_fn(lambda: running.remediation(generated))
         print(f"\nRemediation (completely different): {elapsed:.4f}s")  # noqa: T201
@@ -259,7 +259,7 @@ class TestIterationBenchmarks:
     @staticmethod
     def test_all_children_sorted() -> None:
         """Iterate all_children_sorted on a large config."""
-        config = get_hconfig(Platform.CISCO_IOS, _generate_large_ios_config())
+        config = HConfig.from_text(Platform.CISCO_IOS, _generate_large_ios_config())
 
         elapsed = _time_fn(lambda: list(config.all_children_sorted()))
         child_count = len(list(config.all_children()))
@@ -269,7 +269,7 @@ class TestIterationBenchmarks:
     @staticmethod
     def test_to_lines() -> None:
         """Dump a large config to simple text."""
-        config = get_hconfig(Platform.CISCO_IOS, _generate_large_ios_config())
+        config = HConfig.from_text(Platform.CISCO_IOS, _generate_large_ios_config())
 
         elapsed = _time_fn(config.to_lines)
         line_count = len(config.to_lines())
@@ -279,7 +279,7 @@ class TestIterationBenchmarks:
     @staticmethod
     def test_deep_copy() -> None:
         """Deep copy a large config tree."""
-        config = get_hconfig(Platform.CISCO_IOS, _generate_large_ios_config())
+        config = HConfig.from_text(Platform.CISCO_IOS, _generate_large_ios_config())
 
         elapsed = _time_fn(config.deep_copy)
         print(f"\ndeep_copy: {elapsed:.4f}s")  # noqa: T201

--- a/tests/benchmarks/test_benchmarks.py
+++ b/tests/benchmarks/test_benchmarks.py
@@ -155,7 +155,7 @@ class TestParsingBenchmarks:
         config_text = _generate_large_ios_config()
         elapsed = _time_fn(lambda: HConfig.from_text(Platform.CISCO_IOS, config_text))
         line_count = config_text.count("\n")
-        print(f"\nget_hconfig: {line_count} lines in {elapsed:.4f}s")  # noqa: T201
+        print(f"\nget_hconfig: {line_count} lines in {elapsed:.4f}s")  # ruff:ignore[print]
         assert elapsed < 5.0, f"Parsing took {elapsed:.2f}s, expected < 5s"
 
     @staticmethod
@@ -164,7 +164,7 @@ class TestParsingBenchmarks:
         config_text = _generate_large_xr_config()
         elapsed = _time_fn(lambda: HConfig.from_text(Platform.CISCO_XR, config_text))
         line_count = config_text.count("\n")
-        print(f"\nget_hconfig (XR): {line_count} lines in {elapsed:.4f}s")  # noqa: T201
+        print(f"\nget_hconfig (XR): {line_count} lines in {elapsed:.4f}s")  # ruff:ignore[print]
         assert elapsed < 5.0, f"Parsing took {elapsed:.2f}s, expected < 5s"
 
     @staticmethod
@@ -175,7 +175,7 @@ class TestParsingBenchmarks:
         elapsed = _time_fn(
             lambda: HConfig.from_lines(Platform.CISCO_IOS, config_lines),
         )
-        print(f"\nget_hconfig_fast_load: {len(config_lines)} lines in {elapsed:.4f}s")  # noqa: T201
+        print(f"\nget_hconfig_fast_load: {len(config_lines)} lines in {elapsed:.4f}s")  # ruff:ignore[print]
         assert elapsed < 5.0, f"Fast load took {elapsed:.2f}s, expected < 5s"
 
     @staticmethod
@@ -189,7 +189,7 @@ class TestParsingBenchmarks:
             lambda: HConfig.from_lines(Platform.CISCO_IOS, config_lines),
         )
         ratio = time_full / time_fast if time_fast > 0 else float("inf")
-        print(  # noqa: T201
+        print(  # ruff:ignore[print]
             f"\nget_hconfig: {time_full:.4f}s, "
             f"fast_load: {time_fast:.4f}s, "
             f"ratio: {ratio:.1f}x"
@@ -216,7 +216,7 @@ class TestRemediationBenchmarks:
         generated = HConfig.from_text(Platform.CISCO_IOS, generated_text)
 
         elapsed = _time_fn(lambda: running.remediation(generated))
-        print(f"\nRemediation (10% diff): {elapsed:.4f}s")  # noqa: T201
+        print(f"\nRemediation (10% diff): {elapsed:.4f}s")  # ruff:ignore[print]
         assert elapsed < 5.0, f"Remediation took {elapsed:.2f}s, expected < 5s"
 
     @staticmethod
@@ -229,7 +229,7 @@ class TestRemediationBenchmarks:
         generated = HConfig.from_text(Platform.CISCO_IOS, generated_text)
 
         elapsed = _time_fn(lambda: running.remediation(generated))
-        print(f"\nRemediation (100% diff): {elapsed:.4f}s")  # noqa: T201
+        print(f"\nRemediation (100% diff): {elapsed:.4f}s")  # ruff:ignore[print]
         assert elapsed < 10.0, f"Remediation took {elapsed:.2f}s, expected < 10s"
 
     @staticmethod
@@ -249,7 +249,7 @@ class TestRemediationBenchmarks:
         generated = HConfig.from_text(Platform.CISCO_IOS, "\n".join(lines))
 
         elapsed = _time_fn(lambda: running.remediation(generated))
-        print(f"\nRemediation (completely different): {elapsed:.4f}s")  # noqa: T201
+        print(f"\nRemediation (completely different): {elapsed:.4f}s")  # ruff:ignore[print]
         assert elapsed < 10.0, f"Remediation took {elapsed:.2f}s, expected < 10s"
 
 
@@ -263,7 +263,7 @@ class TestIterationBenchmarks:
 
         elapsed = _time_fn(lambda: list(config.all_children_sorted()))
         child_count = len(list(config.all_children()))
-        print(f"\nall_children_sorted: {child_count} nodes in {elapsed:.4f}s")  # noqa: T201
+        print(f"\nall_children_sorted: {child_count} nodes in {elapsed:.4f}s")  # ruff:ignore[print]
         assert elapsed < 2.0, f"Iteration took {elapsed:.2f}s, expected < 2s"
 
     @staticmethod
@@ -273,7 +273,7 @@ class TestIterationBenchmarks:
 
         elapsed = _time_fn(config.to_lines)
         line_count = len(config.to_lines())
-        print(f"\nto_lines: {line_count} lines in {elapsed:.4f}s")  # noqa: T201
+        print(f"\nto_lines: {line_count} lines in {elapsed:.4f}s")  # ruff:ignore[print]
         assert elapsed < 2.0, f"to_lines took {elapsed:.2f}s, expected < 2s"
 
     @staticmethod
@@ -282,5 +282,5 @@ class TestIterationBenchmarks:
         config = HConfig.from_text(Platform.CISCO_IOS, _generate_large_ios_config())
 
         elapsed = _time_fn(config.deep_copy)
-        print(f"\ndeep_copy: {elapsed:.4f}s")  # noqa: T201
+        print(f"\ndeep_copy: {elapsed:.4f}s")  # ruff:ignore[print]
         assert elapsed < 5.0, f"deep_copy took {elapsed:.2f}s, expected < 5s"

--- a/tests/integration/test_circular_workflows.py
+++ b/tests/integration/test_circular_workflows.py
@@ -35,7 +35,7 @@ class TestConfigWorkflows:  # pylint: disable=too-few-public-methods
             (Platform.HP_PROCURVE, "procurve"),
         ),
     )
-    def test_circular_workflow(  # pylint: disable=too-many-locals  # noqa: PLR0914,PLR6301
+    def test_circular_workflow(  # pylint: disable=too-many-locals  # ruff:ignore[too-many-locals, no-self-use]
         self,
         platform: Platform,
         fixture_prefix: str,

--- a/tests/integration/test_circular_workflows.py
+++ b/tests/integration/test_circular_workflows.py
@@ -14,7 +14,7 @@ generating features by validating a circular workflow:
 
 import pytest
 
-from hier_config import WorkflowRemediation, get_hconfig
+from hier_config import HConfig, WorkflowRemediation
 from hier_config.models import Platform
 
 
@@ -66,7 +66,7 @@ class TestConfigWorkflows:  # pylint: disable=too-few-public-methods
         )
 
         # Step 1: Load running config and assert it matches the file
-        running_config = get_hconfig(platform, running_config_text)
+        running_config = HConfig.from_text(platform, running_config_text)
         assert running_config is not None
         assert running_config.children
         loaded_running_text = "\n".join(
@@ -77,7 +77,7 @@ class TestConfigWorkflows:  # pylint: disable=too-few-public-methods
         )
 
         # Step 2: Load generated config and assert it matches the file
-        generated_config = get_hconfig(platform, generated_config_text)
+        generated_config = HConfig.from_text(platform, generated_config_text)
         assert generated_config is not None
         assert generated_config.children
         loaded_generated_text = "\n".join(

--- a/tests/integration/test_cisco_ios.py
+++ b/tests/integration/test_cisco_ios.py
@@ -1,12 +1,11 @@
-from hier_config import get_hconfig_fast_load
-from hier_config.constructors import get_hconfig
+from hier_config import HConfig
 from hier_config.models import Platform
 
 
 def test_logging_console_emergencies_scenario_1() -> None:
     platform = Platform.CISCO_IOS
-    running_config = get_hconfig_fast_load(platform, ("no logging console",))
-    generated_config = get_hconfig_fast_load(platform, ("logging console emergencies",))
+    running_config = HConfig.from_lines(platform, ("no logging console",))
+    generated_config = HConfig.from_lines(platform, ("logging console emergencies",))
     remediation_config = running_config.remediation(generated_config)
     assert remediation_config.to_lines() == ("logging console emergencies",)
     future_config = running_config.future(remediation_config)
@@ -20,8 +19,8 @@ def test_logging_console_emergencies_scenario_1() -> None:
 
 def test_logging_console_emergencies_scenario_2() -> None:
     platform = Platform.CISCO_IOS
-    running_config = get_hconfig_fast_load(platform, ("logging console",))
-    generated_config = get_hconfig_fast_load(platform, ("logging console emergencies",))
+    running_config = HConfig.from_lines(platform, ("logging console",))
+    generated_config = HConfig.from_lines(platform, ("logging console emergencies",))
     remediation_config = running_config.remediation(generated_config)
     assert remediation_config.to_lines() == ("logging console emergencies",)
     future_config = running_config.future(remediation_config)
@@ -35,8 +34,8 @@ def test_logging_console_emergencies_scenario_2() -> None:
 
 def test_logging_console_emergencies_scenario_3() -> None:
     platform = Platform.CISCO_IOS
-    running_config = get_hconfig(platform)
-    generated_config = get_hconfig_fast_load(platform, ("logging console emergencies",))
+    running_config = HConfig.from_text(platform)
+    generated_config = HConfig.from_lines(platform, ("logging console emergencies",))
     remediation_config = running_config.remediation(generated_config)
     assert remediation_config.to_lines() == ("logging console emergencies",)
     future_config = running_config.future(remediation_config)
@@ -50,7 +49,7 @@ def test_logging_console_emergencies_scenario_3() -> None:
 
 def test_duplicate_child_router() -> None:
     platform = Platform.CISCO_IOS
-    running_config = get_hconfig_fast_load(
+    running_config = HConfig.from_lines(
         platform,
         (
             "router eigrp EIGRP_INSTANCE",
@@ -72,7 +71,7 @@ def test_duplicate_child_router() -> None:
             " exit-address-family",
         ),
     )
-    generated_config = get_hconfig_fast_load(
+    generated_config = HConfig.from_lines(
         platform,
         (
             "router eigrp EIGRP_INSTANCE",
@@ -106,7 +105,7 @@ def test_duplicate_child_router() -> None:
 
 def test_vlan_id_list_split_on_load() -> None:
     """The post-load callback expands 'vlan 69,381' into one block per VLAN id."""
-    config = get_hconfig(Platform.CISCO_IOS, "vlan 69,381\n")
+    config = HConfig.from_text(Platform.CISCO_IOS, "vlan 69,381\n")
     assert config.get_child(equals="vlan 69") is not None
     assert config.get_child(equals="vlan 381") is not None
     assert config.get_child(equals="vlan 69,381") is None
@@ -114,13 +113,13 @@ def test_vlan_id_list_split_on_load() -> None:
 
 def test_vlan_id_range_split_on_load() -> None:
     """The post-load callback expands ranges into individual VLAN ids."""
-    config = get_hconfig(Platform.CISCO_IOS, "vlan 10-12\n")
+    config = HConfig.from_text(Platform.CISCO_IOS, "vlan 10-12\n")
     assert [c.text for c in config.children] == ["vlan 10", "vlan 11", "vlan 12"]
 
 
 def test_single_vlan_not_split_on_load() -> None:
     """A single VLAN id is left untouched (no comma/range separator)."""
-    config = get_hconfig(Platform.CISCO_IOS, "vlan 44\n name servers\n")
+    config = HConfig.from_text(Platform.CISCO_IOS, "vlan 44\n name servers\n")
     vlan = config.get_child(equals="vlan 44")
     assert vlan is not None
     assert vlan.get_child(equals="name servers") is not None
@@ -129,7 +128,7 @@ def test_single_vlan_not_split_on_load() -> None:
 def test_non_vlan_id_line_not_split_on_load() -> None:
     """Lines like 'vlan internal allocation policy ...' are not VLAN id lists."""
     text = "vlan internal allocation policy ascending\n"
-    config = get_hconfig(Platform.CISCO_IOS, text)
+    config = HConfig.from_text(Platform.CISCO_IOS, text)
     assert (
         config.get_child(equals="vlan internal allocation policy ascending") is not None
     )
@@ -137,8 +136,8 @@ def test_non_vlan_id_line_not_split_on_load() -> None:
 
 def test_vlan_id_list_rename_is_not_destructive() -> None:
     """Renaming one VLAN in a collapsed list must not negate the whole list."""
-    running_config = get_hconfig(Platform.CISCO_IOS, "vlan 69,381\n")
-    generated_config = get_hconfig(
+    running_config = HConfig.from_text(Platform.CISCO_IOS, "vlan 69,381\n")
+    generated_config = HConfig.from_text(
         Platform.CISCO_IOS, "vlan 69\n name newname\nvlan 381\n"
     )
     remediation = running_config.remediation(generated_config).to_lines()
@@ -148,8 +147,8 @@ def test_vlan_id_list_rename_is_not_destructive() -> None:
 
 def test_vlan_id_list_naming_middle_vlan_regroups_cleanly() -> None:
     """Naming a VLAN regroups IOS commas (69,70,71 -> 69,71 + 70); diff stays surgical."""
-    running_config = get_hconfig(Platform.CISCO_IOS, "vlan 69,70,71\n")
-    generated_config = get_hconfig(
+    running_config = HConfig.from_text(Platform.CISCO_IOS, "vlan 69,70,71\n")
+    generated_config = HConfig.from_text(
         Platform.CISCO_IOS, "vlan 69,71\nvlan 70\n name MIDDLE\n"
     )
     remediation = running_config.remediation(generated_config).to_lines()
@@ -159,23 +158,23 @@ def test_vlan_id_list_naming_middle_vlan_regroups_cleanly() -> None:
 
 def test_vlan_id_list_partial_removal_is_surgical() -> None:
     """Removing only some VLANs from a collapsed list negates just those ids."""
-    running_config = get_hconfig(Platform.CISCO_IOS, "vlan 69,381,400\n")
-    generated_config = get_hconfig(Platform.CISCO_IOS, "vlan 69\nvlan 381\n")
+    running_config = HConfig.from_text(Platform.CISCO_IOS, "vlan 69,381,400\n")
+    generated_config = HConfig.from_text(Platform.CISCO_IOS, "vlan 69\nvlan 381\n")
     remediation = running_config.remediation(generated_config).to_lines()
     assert remediation == ("no vlan 400",)
 
 
 def test_vlan_id_list_pure_add_emits_one_line_per_vlan() -> None:
     """Adding a collapsed VLAN list emits one (non-destructive) line per VLAN."""
-    running_config = get_hconfig(Platform.CISCO_IOS, "")
-    generated_config = get_hconfig(Platform.CISCO_IOS, "vlan 10-12,20\n")
+    running_config = HConfig.from_text(Platform.CISCO_IOS, "")
+    generated_config = HConfig.from_text(Platform.CISCO_IOS, "vlan 10-12,20\n")
     remediation = running_config.remediation(generated_config).to_lines()
     assert remediation == ("vlan 10", "vlan 11", "vlan 12", "vlan 20")
 
 
 def test_vlan_id_list_no_change_is_idempotent() -> None:
     """Identical collapsed VLAN lists produce no remediation."""
-    running_config = get_hconfig(Platform.CISCO_IOS, "vlan 69,381\n")
-    generated_config = get_hconfig(Platform.CISCO_IOS, "vlan 69,381\n")
+    running_config = HConfig.from_text(Platform.CISCO_IOS, "vlan 69,381\n")
+    generated_config = HConfig.from_text(Platform.CISCO_IOS, "vlan 69,381\n")
     remediation = running_config.remediation(generated_config).to_lines()
     assert remediation == ()

--- a/tests/integration/test_cisco_nxos.py
+++ b/tests/integration/test_cisco_nxos.py
@@ -1,4 +1,4 @@
-from hier_config import get_hconfig_fast_load
+from hier_config import HConfig
 from hier_config.models import Platform
 from hier_config.utils import load_driver_rules
 
@@ -31,7 +31,7 @@ def test_line_console_terminal_settings_negation_negate_with() -> None:
         Platform.CISCO_NXOS,
     )
 
-    running_config = get_hconfig_fast_load(
+    running_config = HConfig.from_lines(
         driver,
         (
             "line console",
@@ -40,7 +40,7 @@ def test_line_console_terminal_settings_negation_negate_with() -> None:
             "  terminal width 160",
         ),
     )
-    generated_config = get_hconfig_fast_load(
+    generated_config = HConfig.from_lines(
         driver,
         (
             "line console",

--- a/tests/integration/test_cisco_xr.py
+++ b/tests/integration/test_cisco_xr.py
@@ -1,11 +1,11 @@
-from hier_config import get_hconfig, get_hconfig_fast_load
+from hier_config import HConfig
 from hier_config.models import Platform
 
 
 def test_multiple_groups_remediation() -> None:
     """Test remediation between configs with multiple group blocks."""
     platform = Platform.CISCO_XR
-    running_config = get_hconfig_fast_load(
+    running_config = HConfig.from_lines(
         platform,
         (
             "hostname router1",
@@ -21,7 +21,7 @@ def test_multiple_groups_remediation() -> None:
             "end-group",
         ),
     )
-    generated_config = get_hconfig_fast_load(
+    generated_config = HConfig.from_lines(
         platform,
         (
             "hostname router1",
@@ -38,7 +38,7 @@ def test_multiple_groups_remediation() -> None:
 
 def test_duplicate_child_route_policy() -> None:
     platform = Platform.CISCO_XR
-    running_config = get_hconfig_fast_load(
+    running_config = HConfig.from_lines(
         platform,
         (
             "route-policy SET_COMMUNITY_AND_PERMIT",
@@ -60,7 +60,7 @@ def test_duplicate_child_route_policy() -> None:
             "end-policy",
         ),
     )
-    generated_config = get_hconfig_fast_load(
+    generated_config = HConfig.from_lines(
         platform,
         (
             "route-policy SET_COMMUNITY_AND_PERMIT",
@@ -83,7 +83,7 @@ def test_duplicate_child_route_policy() -> None:
 def test_nested_if_endif_route_policy() -> None:
     """Test nested if/endif blocks in route-policy don't raise DuplicateChildError."""
     platform = Platform.CISCO_XR
-    running_config = get_hconfig_fast_load(
+    running_config = HConfig.from_lines(
         platform,
         (
             "route-policy EXAMPLE-POLICY",
@@ -100,7 +100,7 @@ def test_nested_if_endif_route_policy() -> None:
             "end-policy",
         ),
     )
-    generated_config = get_hconfig_fast_load(
+    generated_config = HConfig.from_lines(
         platform,
         (
             "route-policy EXAMPLE-POLICY",
@@ -140,7 +140,7 @@ def test_nested_if_endif_route_policy() -> None:
 def test_flow_exporter_template_indent_adjust() -> None:
     """Test that 'template timeout' inside flow exporter-map doesn't corrupt indentation."""
     platform = Platform.CISCO_XR
-    running_config = get_hconfig_fast_load(
+    running_config = HConfig.from_lines(
         platform,
         (
             "flow exporter-map EXPORTER1",
@@ -160,7 +160,7 @@ def test_flow_exporter_template_indent_adjust() -> None:
             "end-policy",
         ),
     )
-    generated_config = get_hconfig_fast_load(
+    generated_config = HConfig.from_lines(
         platform,
         (
             "flow exporter-map EXPORTER1",
@@ -205,7 +205,7 @@ def test_flow_exporter_template_data_options_timeout_indent_adjust() -> None:
     arriving, every subsequent line in the config was nested under them.
     """
     platform = Platform.CISCO_XR
-    running_config = get_hconfig_fast_load(
+    running_config = HConfig.from_lines(
         platform,
         (
             "flow exporter-map EXPORTER1",
@@ -236,7 +236,7 @@ def test_flow_exporter_template_data_options_timeout_indent_adjust() -> None:
     assert version.get_child(equals="template data timeout 15") is not None
     assert version.get_child(equals="template options timeout 15") is not None
 
-    generated_config = get_hconfig_fast_load(
+    generated_config = HConfig.from_lines(
         platform,
         (
             "flow exporter-map EXPORTER1",
@@ -270,7 +270,7 @@ def test_flow_exporter_template_data_options_timeout_indent_adjust() -> None:
 def test_template_block_indent_adjust() -> None:
     """Test that template blocks still parse correctly with the indent_adjust rule."""
     platform = Platform.CISCO_XR
-    running_config = get_hconfig_fast_load(
+    running_config = HConfig.from_lines(
         platform,
         (
             "template ACCESS-PORT",
@@ -296,7 +296,7 @@ def test_template_block_indent_adjust() -> None:
             "!",
         ),
     )
-    generated_config = get_hconfig_fast_load(
+    generated_config = HConfig.from_lines(
         platform,
         (
             "template ACCESS-PORT",
@@ -343,7 +343,7 @@ def test_template_block_indent_adjust() -> None:
 def test_ipv4_acl_sequence_number_idempotent() -> None:
     """Test IPv4 ACL sequence number idempotency (covers lines 25-31)."""
     platform = Platform.CISCO_XR
-    running_config = get_hconfig_fast_load(
+    running_config = HConfig.from_lines(
         platform,
         (
             "ipv4 access-list TEST_ACL",
@@ -352,7 +352,7 @@ def test_ipv4_acl_sequence_number_idempotent() -> None:
             " 30 deny ipv4 any any",
         ),
     )
-    generated_config = get_hconfig_fast_load(
+    generated_config = HConfig.from_lines(
         platform,
         (
             "ipv4 access-list TEST_ACL",
@@ -372,7 +372,7 @@ def test_ipv4_acl_sequence_number_idempotent() -> None:
 def test_ipv6_acl_sequence_number_idempotent() -> None:
     """Test IPv6 ACL sequence number idempotency (covers lines 25-31)."""
     platform = Platform.CISCO_XR
-    running_config = get_hconfig_fast_load(
+    running_config = HConfig.from_lines(
         platform,
         (
             "ipv6 access-list TEST_IPV6_ACL",
@@ -380,7 +380,7 @@ def test_ipv6_acl_sequence_number_idempotent() -> None:
             " 20 deny ipv6 any any",
         ),
     )
-    generated_config = get_hconfig_fast_load(
+    generated_config = HConfig.from_lines(
         platform,
         (
             "ipv6 access-list TEST_IPV6_ACL",
@@ -399,7 +399,7 @@ def test_ipv6_acl_sequence_number_idempotent() -> None:
 def test_ipv4_acl_sequence_number_addition() -> None:
     """Test adding new IPv4 ACL entries with sequence numbers."""
     platform = Platform.CISCO_XR
-    running_config = get_hconfig_fast_load(
+    running_config = HConfig.from_lines(
         platform,
         (
             "ipv4 access-list TEST_ACL",
@@ -407,7 +407,7 @@ def test_ipv4_acl_sequence_number_addition() -> None:
             " 30 deny ipv4 any any",
         ),
     )
-    generated_config = get_hconfig_fast_load(
+    generated_config = HConfig.from_lines(
         platform,
         (
             "ipv4 access-list TEST_ACL",
@@ -427,7 +427,7 @@ def test_ipv4_acl_sequence_number_addition() -> None:
 def test_running_with_bang_separators_intended_without_no_remediation() -> None:
     """Running config with indented ! separators and intended without produces no remediation."""
     platform = Platform.CISCO_XR
-    running = get_hconfig(
+    running = HConfig.from_text(
         platform,
         """\
 telemetry model-driven
@@ -445,7 +445,7 @@ telemetry model-driven
  !
 """,
     )
-    intended = get_hconfig(
+    intended = HConfig.from_text(
         platform,
         """\
 telemetry model-driven
@@ -465,7 +465,7 @@ telemetry model-driven
 def test_intended_with_bang_comments_running_without_no_remediation() -> None:
     """Intended config with ! comment lines and running without produces no remediation."""
     platform = Platform.CISCO_XR
-    running = get_hconfig(
+    running = HConfig.from_text(
         platform,
         """\
 telemetry model-driven
@@ -479,7 +479,7 @@ telemetry model-driven
    protocol tcp
 """,
     )
-    intended = get_hconfig(
+    intended = HConfig.from_text(
         platform,
         """\
 telemetry model-driven
@@ -501,7 +501,7 @@ telemetry model-driven
 def test_differing_bang_comment_text_produces_no_remediation() -> None:
     """Differing ! comment text between running and intended produces no remediation."""
     platform = Platform.CISCO_XR
-    running = get_hconfig(
+    running = HConfig.from_text(
         platform,
         """\
 router isis backbone
@@ -509,7 +509,7 @@ router isis backbone
  net 49.0001.1921.2022.0222.00
 """,
     )
-    intended = get_hconfig(
+    intended = HConfig.from_text(
         platform,
         """\
 router isis backbone

--- a/tests/integration/test_fortinet_fortios.py
+++ b/tests/integration/test_fortinet_fortios.py
@@ -1,11 +1,10 @@
-from hier_config import get_hconfig_fast_load
-from hier_config.constructors import get_hconfig
+from hier_config import HConfig
 from hier_config.models import Platform
 
 
 def test_swap_negation() -> None:
     platform = Platform.FORTINET_FORTIOS
-    running_config = get_hconfig_fast_load(
+    running_config = HConfig.from_lines(
         platform,
         (
             "config system interface",
@@ -20,7 +19,7 @@ def test_swap_negation() -> None:
             "end",
         ),
     )
-    generated_config = get_hconfig_fast_load(
+    generated_config = HConfig.from_lines(
         platform,
         (
             "config system interface",
@@ -48,7 +47,7 @@ def test_swap_negation() -> None:
 
 def test_idempotent_for() -> None:
     platform = Platform.FORTINET_FORTIOS
-    running_config = get_hconfig_fast_load(
+    running_config = HConfig.from_lines(
         platform,
         (
             "config system interface",
@@ -63,7 +62,7 @@ def test_idempotent_for() -> None:
             "end",
         ),
     )
-    generated_config = get_hconfig_fast_load(
+    generated_config = HConfig.from_lines(
         platform,
         (
             "config system interface",
@@ -93,8 +92,8 @@ def test_idempotent_for() -> None:
 
 def test_future() -> None:
     platform = Platform.FORTINET_FORTIOS
-    running_config = get_hconfig(platform)
-    remediation_config = get_hconfig_fast_load(
+    running_config = HConfig.from_text(platform)
+    remediation_config = HConfig.from_lines(
         platform,
         (
             "config system interface",

--- a/tests/integration/test_generic.py
+++ b/tests/integration/test_generic.py
@@ -1,6 +1,5 @@
 import pytest
 
-from hier_config import get_hconfig_fast_load
 from hier_config.exceptions import DuplicateChildError
 from hier_config.models import Platform
 from hier_config.root import HConfig
@@ -9,8 +8,8 @@ from hier_config.utils import load_driver_rules
 
 def test_generic_snmp_scenario_1() -> None:
     platform = Platform.GENERIC
-    running_config = get_hconfig_fast_load(platform, ("snmp-server community public",))
-    generated_config = get_hconfig_fast_load(
+    running_config = HConfig.from_lines(platform, ("snmp-server community public",))
+    generated_config = HConfig.from_lines(
         platform,
         (
             "snmp-server community examplekey1",
@@ -42,7 +41,7 @@ def test_generic_snmp_scenario_2() -> None:
         platform,
     )
     with pytest.raises(DuplicateChildError):
-        get_hconfig_fast_load(
+        HConfig.from_lines(
             driver,
             (
                 "snmp-server community <credentials_removed>",
@@ -56,7 +55,7 @@ def test_generic_snmp_scenario_2() -> None:
 
 def test_generic_aaa_scenario_1() -> None:
     platform = Platform.GENERIC
-    running_config = get_hconfig_fast_load(
+    running_config = HConfig.from_lines(
         platform,
         (
             "aaa group server tacacs TACACS_GROUP1",
@@ -66,7 +65,7 @@ def test_generic_aaa_scenario_1() -> None:
             "  server 192.2.0.121",
         ),
     )
-    generated_config = get_hconfig_fast_load(
+    generated_config = HConfig.from_lines(
         platform,
         (
             "aaa group server tacacs TACACS_GROUP2",
@@ -90,7 +89,7 @@ def test_generic_aaa_scenario_1() -> None:
 
 def test_generic_aaa_scenario_2() -> None:
     platform = Platform.GENERIC
-    running_config = get_hconfig_fast_load(
+    running_config = HConfig.from_lines(
         platform,
         (
             "aaa group server tacacs TACACS_GROUP1",
@@ -100,7 +99,7 @@ def test_generic_aaa_scenario_2() -> None:
             "  server 192.2.0.121",
         ),
     )
-    generated_config = get_hconfig_fast_load(
+    generated_config = HConfig.from_lines(
         platform,
         (
             "aaa group server tacacs TACACS_GROUP2",

--- a/tests/integration/test_hp_procurve.py
+++ b/tests/integration/test_hp_procurve.py
@@ -1,11 +1,10 @@
-from hier_config import get_hconfig_fast_load
-from hier_config.constructors import get_hconfig
+from hier_config import HConfig
 from hier_config.models import Platform
 
 
 def test_negate_with() -> None:
     platform = Platform.HP_PROCURVE
-    running_config = get_hconfig_fast_load(
+    running_config = HConfig.from_lines(
         platform,
         (
             "aaa port-access authenticator 1/1 tx-period 3",
@@ -16,7 +15,7 @@ def test_negate_with() -> None:
             'aaa port-access 1/1 critical-auth user-role "allowall"',
         ),
     )
-    generated_config = get_hconfig(platform)
+    generated_config = HConfig.from_text(platform)
     remediation_config = running_config.remediation(generated_config)
     assert remediation_config.to_lines() == (
         "aaa port-access authenticator 1/1 tx-period 30",
@@ -30,7 +29,7 @@ def test_negate_with() -> None:
 
 def test_idempotent_for() -> None:
     platform = Platform.HP_PROCURVE
-    running_config = get_hconfig_fast_load(
+    running_config = HConfig.from_lines(
         platform,
         (
             "aaa port-access authenticator 1/1 tx-period 3",
@@ -41,7 +40,7 @@ def test_idempotent_for() -> None:
             'aaa port-access 1/1 critical-auth user-role "allowall"',
         ),
     )
-    generated_config = get_hconfig_fast_load(
+    generated_config = HConfig.from_lines(
         platform,
         (
             "aaa port-access authenticator 1/1 tx-period 4",
@@ -65,8 +64,8 @@ def test_idempotent_for() -> None:
 
 def test_future() -> None:
     platform = Platform.HP_PROCURVE
-    running_config = get_hconfig(platform)
-    remediation_config = get_hconfig_fast_load(
+    running_config = HConfig.from_text(platform)
+    remediation_config = HConfig.from_lines(
         platform,
         (
             "aaa port-access authenticator 3/34",
@@ -85,14 +84,14 @@ def test_future() -> None:
 def test_negate_with_child_config() -> None:
     """Test negate_with returns None for non-root config without special rule (covers line 166)."""
     platform = Platform.HP_PROCURVE
-    running_config = get_hconfig_fast_load(
+    running_config = HConfig.from_lines(
         platform,
         (
             "interface 1/1",
             "   speed-duplex auto",
         ),
     )
-    generated_config = get_hconfig_fast_load(
+    generated_config = HConfig.from_lines(
         platform,
         ("interface 1/1",),
     )
@@ -107,14 +106,14 @@ def test_negate_with_child_config() -> None:
 def test_negate_with_from_base_driver() -> None:
     """Test negate_with uses parent driver rule when applicable (covers line 163)."""
     platform = Platform.HP_PROCURVE
-    running_config = get_hconfig_fast_load(
+    running_config = HConfig.from_lines(
         platform,
         (
             "interface 1/1",
             "   disable",
         ),
     )
-    generated_config = get_hconfig_fast_load(
+    generated_config = HConfig.from_lines(
         platform,
         ("interface 1/1",),
     )

--- a/tests/integration/test_huawei_vrp.py
+++ b/tests/integration/test_huawei_vrp.py
@@ -1,14 +1,13 @@
-from hier_config import get_hconfig_fast_load
-from hier_config.constructors import get_hconfig
+from hier_config import HConfig
 from hier_config.models import Platform
 
 
 def test_merge_with_undo() -> None:
     platform = Platform.HUAWEI_VRP
-    running_config = get_hconfig_fast_load(
+    running_config = HConfig.from_lines(
         platform, ("test_for_undo", "undo test_for_redo")
     )
-    generated_config = get_hconfig_fast_load(
+    generated_config = HConfig.from_lines(
         platform, ("undo test_for_undo", "test_for_redo")
     )
     remediation_config = running_config.remediation(generated_config)
@@ -17,10 +16,10 @@ def test_merge_with_undo() -> None:
 
 def test_negate_description() -> None:
     platform = Platform.HUAWEI_VRP
-    running_config = get_hconfig_fast_load(
+    running_config = HConfig.from_lines(
         platform, ("interface GigabitEthernet0/0/0", " description some old blabla")
     )
-    generated_config = get_hconfig_fast_load(
+    generated_config = HConfig.from_lines(
         platform, ("interface GigabitEthernet0/0/0",)
     )
     remediation_config = running_config.remediation(generated_config)
@@ -32,10 +31,10 @@ def test_negate_description() -> None:
 
 def test_negate_remark() -> None:
     platform = Platform.HUAWEI_VRP
-    running_config = get_hconfig_fast_load(
+    running_config = HConfig.from_lines(
         platform, ("acl number 2000", " rule 5 remark some old remark")
     )
-    generated_config = get_hconfig_fast_load(platform, ("acl number 2000",))
+    generated_config = HConfig.from_lines(platform, ("acl number 2000",))
     remediation_config = running_config.remediation(generated_config)
     assert remediation_config.to_lines() == (
         "acl number 2000",
@@ -45,10 +44,10 @@ def test_negate_remark() -> None:
 
 def test_negate_alias() -> None:
     platform = Platform.HUAWEI_VRP
-    running_config = get_hconfig_fast_load(
+    running_config = HConfig.from_lines(
         platform, ("interface GigabitEthernet0/0/0", " alias some old alias")
     )
-    generated_config = get_hconfig_fast_load(
+    generated_config = HConfig.from_lines(
         platform, ("interface GigabitEthernet0/0/0",)
     )
     remediation_config = running_config.remediation(generated_config)
@@ -60,10 +59,10 @@ def test_negate_alias() -> None:
 
 def test_negate_snmp_agent_community() -> None:
     platform = Platform.HUAWEI_VRP
-    running_config = get_hconfig_fast_load(
+    running_config = HConfig.from_lines(
         platform, ("snmp-agent community read cipher %^%#blabla%^%# acl 2000",)
     )
-    generated_config = get_hconfig(platform)
+    generated_config = HConfig.from_text(platform)
     remediation_config = running_config.remediation(generated_config)
     assert remediation_config.to_lines() == (
         "undo snmp-agent community read cipher %^%#blabla%^%#",
@@ -72,7 +71,7 @@ def test_negate_snmp_agent_community() -> None:
 
 def test_comments_stripped() -> None:
     platform = Platform.HUAWEI_VRP
-    config = get_hconfig_fast_load(
+    config = HConfig.from_lines(
         platform,
         (
             "#",
@@ -91,7 +90,7 @@ def test_comments_stripped() -> None:
 
 def test_multiple_peer_public_keys_no_duplicate_child_error() -> None:
     platform = Platform.HUAWEI_VRP
-    config = get_hconfig(
+    config = HConfig.from_text(
         platform,
         "rsa peer-public-key user1 encoding-type openssh\n"
         " public-key-code begin\n"
@@ -124,7 +123,7 @@ def test_multiple_peer_public_keys_no_duplicate_child_error() -> None:
 
 def test_sectional_exit_is_quit() -> None:
     platform = Platform.HUAWEI_VRP
-    config = get_hconfig_fast_load(
+    config = HConfig.from_lines(
         platform,
         (
             "interface GigabitEthernet0/0/0",

--- a/tests/integration/test_huawei_vrp.py
+++ b/tests/integration/test_huawei_vrp.py
@@ -19,9 +19,7 @@ def test_negate_description() -> None:
     running_config = HConfig.from_lines(
         platform, ("interface GigabitEthernet0/0/0", " description some old blabla")
     )
-    generated_config = HConfig.from_lines(
-        platform, ("interface GigabitEthernet0/0/0",)
-    )
+    generated_config = HConfig.from_lines(platform, ("interface GigabitEthernet0/0/0",))
     remediation_config = running_config.remediation(generated_config)
     assert remediation_config.to_lines() == (
         "interface GigabitEthernet0/0/0",
@@ -47,9 +45,7 @@ def test_negate_alias() -> None:
     running_config = HConfig.from_lines(
         platform, ("interface GigabitEthernet0/0/0", " alias some old alias")
     )
-    generated_config = HConfig.from_lines(
-        platform, ("interface GigabitEthernet0/0/0",)
-    )
+    generated_config = HConfig.from_lines(platform, ("interface GigabitEthernet0/0/0",))
     remediation_config = running_config.remediation(generated_config)
     assert remediation_config.to_lines() == (
         "interface GigabitEthernet0/0/0",

--- a/tests/integration/test_idempotent_commands.py
+++ b/tests/integration/test_idempotent_commands.py
@@ -1,4 +1,4 @@
-from hier_config import get_hconfig_fast_load
+from hier_config import HConfig
 from hier_config.models import (
     IdempotentCommandsRule,
     MatchRule,
@@ -26,11 +26,11 @@ def test_parameterized_regex_same_key_is_idempotent() -> None:
             ),
         ],
     )
-    running = get_hconfig_fast_load(
+    running = HConfig.from_lines(
         driver,
         ("client 10.1.1.1 server-key KEY_OLD",),
     )
-    generated = get_hconfig_fast_load(
+    generated = HConfig.from_lines(
         driver,
         ("client 10.1.1.1 server-key KEY_NEW",),
     )
@@ -47,14 +47,14 @@ def test_parameterized_regex_different_key_not_idempotent() -> None:
             ),
         ],
     )
-    running = get_hconfig_fast_load(
+    running = HConfig.from_lines(
         driver,
         (
             "client 10.1.1.1 server-key KEY1",
             "client 10.2.2.2 server-key KEY2",
         ),
     )
-    generated = get_hconfig_fast_load(
+    generated = HConfig.from_lines(
         driver,
         ("client 10.1.1.1 server-key KEY1",),
     )
@@ -66,7 +66,7 @@ def test_parameterized_regex_different_key_not_idempotent() -> None:
 def test_bgp_neighbor_regex_idempotent() -> None:
     """BGP neighbor remote-as is idempotent per neighbor IP via regex capture group."""
     platform = Platform.CISCO_XR
-    running = get_hconfig_fast_load(
+    running = HConfig.from_lines(
         platform,
         (
             "router bgp 1001",
@@ -75,7 +75,7 @@ def test_bgp_neighbor_regex_idempotent() -> None:
             "  neighbor 40.0.0.8 remote-as 2002",
         ),
     )
-    generated = get_hconfig_fast_load(
+    generated = HConfig.from_lines(
         platform,
         (
             "router bgp 1001",
@@ -108,14 +108,14 @@ def test_startswith_rules_do_not_cross_contaminate() -> None:
             ),
         ],
     )
-    running = get_hconfig_fast_load(
+    running = HConfig.from_lines(
         driver,
         (
             "hardware access-list tcam region arp-ether 0",
             "hardware profile tcam region racl 0",
         ),
     )
-    generated = get_hconfig_fast_load(
+    generated = HConfig.from_lines(
         driver,
         (
             "hardware access-list tcam region arp-ether 256",

--- a/tests/integration/test_juniper_junos.py
+++ b/tests/integration/test_juniper_junos.py
@@ -1,4 +1,4 @@
-from hier_config import WorkflowRemediation, get_hconfig, get_hconfig_fast_load
+from hier_config import HConfig, WorkflowRemediation
 from hier_config.models import Platform
 
 
@@ -9,8 +9,8 @@ def test_junos_basic_remediation() -> None:
     remediation_str = "delete vlans switch_mgmt_10.0.2.0/24 vlan-id 2\nset vlans switch_mgmt_10.0.3.0/24 vlan-id 3"
 
     workflow_remediation = WorkflowRemediation(
-        get_hconfig_fast_load(platform, running_config_str),
-        get_hconfig_fast_load(platform, generated_config_str),
+        HConfig.from_lines(platform, running_config_str),
+        HConfig.from_lines(platform, generated_config_str),
     )
 
     assert workflow_remediation.remediation_config_filtered_text() == remediation_str
@@ -23,8 +23,8 @@ def test_junos_convert_to_set(
 ) -> None:
     platform = Platform.JUNIPER_JUNOS
     workflow_remediation = WorkflowRemediation(
-        get_hconfig(platform, running_config_junos),
-        get_hconfig(platform, generated_config_junos),
+        HConfig.from_text(platform, running_config_junos),
+        HConfig.from_text(platform, generated_config_junos),
     )
 
     assert (
@@ -40,8 +40,8 @@ def test_flat_junos_remediation(
 ) -> None:
     platform = Platform.JUNIPER_JUNOS
     workflow_remediation = WorkflowRemediation(
-        get_hconfig_fast_load(platform, running_config_flat_junos),
-        get_hconfig_fast_load(platform, generated_config_flat_junos),
+        HConfig.from_lines(platform, running_config_flat_junos),
+        HConfig.from_lines(platform, generated_config_flat_junos),
     )
 
     remediation_list = remediation_config_flat_junos.splitlines()
@@ -52,14 +52,14 @@ def test_flat_junos_remediation(
 def test_vlan_addition_scenario() -> None:
     """Test adding a new VLAN to the configuration."""
     platform = Platform.JUNIPER_JUNOS
-    running_config = get_hconfig_fast_load(
+    running_config = HConfig.from_lines(
         platform,
         (
             "set vlans switch_mgmt_10.0.2.0/24 vlan-id 2",
             "set vlans switch_mgmt_10.0.2.0/24 l3-interface irb.2",
         ),
     )
-    generated_config = get_hconfig_fast_load(
+    generated_config = HConfig.from_lines(
         platform,
         (
             "set vlans switch_mgmt_10.0.2.0/24 vlan-id 2",
@@ -78,7 +78,7 @@ def test_vlan_addition_scenario() -> None:
 def test_vlan_removal_scenario() -> None:
     """Test removing a VLAN from the configuration."""
     platform = Platform.JUNIPER_JUNOS
-    running_config = get_hconfig_fast_load(
+    running_config = HConfig.from_lines(
         platform,
         (
             "set vlans switch_mgmt_10.0.2.0/24 vlan-id 2",
@@ -87,7 +87,7 @@ def test_vlan_removal_scenario() -> None:
             "set vlans switch_mgmt_10.0.3.0/24 l3-interface irb.3",
         ),
     )
-    generated_config = get_hconfig_fast_load(
+    generated_config = HConfig.from_lines(
         platform,
         (
             "set vlans switch_mgmt_10.0.2.0/24 vlan-id 2",
@@ -104,11 +104,11 @@ def test_vlan_removal_scenario() -> None:
 def test_interface_unit_configuration_scenario() -> None:
     """Test configuring interface unit parameters."""
     platform = Platform.JUNIPER_JUNOS
-    running_config = get_hconfig_fast_load(
+    running_config = HConfig.from_lines(
         platform,
         ("set interfaces irb unit 2 family inet address 10.0.2.1/24",),
     )
-    generated_config = get_hconfig_fast_load(
+    generated_config = HConfig.from_lines(
         platform,
         (
             "set interfaces irb unit 2 family inet address 10.0.2.1/24",
@@ -128,11 +128,11 @@ def test_interface_unit_configuration_scenario() -> None:
 def test_interface_address_change_scenario() -> None:
     """Test changing an interface IP address."""
     platform = Platform.JUNIPER_JUNOS
-    running_config = get_hconfig_fast_load(
+    running_config = HConfig.from_lines(
         platform,
         ("set interfaces irb unit 3 family inet address 10.0.4.1/16",),
     )
-    generated_config = get_hconfig_fast_load(
+    generated_config = HConfig.from_lines(
         platform,
         ("set interfaces irb unit 3 family inet address 10.0.3.1/16",),
     )
@@ -146,14 +146,14 @@ def test_interface_address_change_scenario() -> None:
 def test_interface_disable_enable_scenario() -> None:
     """Test disabling and enabling an interface."""
     platform = Platform.JUNIPER_JUNOS
-    running_config = get_hconfig_fast_load(
+    running_config = HConfig.from_lines(
         platform,
         (
             "set interfaces irb unit 2 family inet address 10.0.2.1/24",
             "set interfaces irb unit 2 family inet disable",
         ),
     )
-    generated_config = get_hconfig_fast_load(
+    generated_config = HConfig.from_lines(
         platform,
         ("set interfaces irb unit 2 family inet address 10.0.2.1/24",),
     )
@@ -166,14 +166,14 @@ def test_interface_disable_enable_scenario() -> None:
 def test_firewall_filter_configuration_scenario() -> None:
     """Test configuring firewall filter rules."""
     platform = Platform.JUNIPER_JUNOS
-    running_config = get_hconfig_fast_load(
+    running_config = HConfig.from_lines(
         platform,
         (
             "set firewall family inet filter TEST term 1 from source-address 10.0.0.0/29",
             "set firewall family inet filter TEST term 1 then accept",
         ),
     )
-    generated_config = get_hconfig_fast_load(
+    generated_config = HConfig.from_lines(
         platform,
         (
             "set firewall family inet filter TEST term 1 from source-address 10.0.0.0/29",
@@ -192,8 +192,8 @@ def test_firewall_filter_configuration_scenario() -> None:
 def test_physical_interface_configuration_scenario() -> None:
     """Test configuring physical interface with multiple families."""
     platform = Platform.JUNIPER_JUNOS
-    running_config = get_hconfig(platform)
-    generated_config = get_hconfig_fast_load(
+    running_config = HConfig.from_text(platform)
+    generated_config = HConfig.from_lines(
         platform,
         (
             "set interfaces xe-0/0/0 description bb01.lax01:Ethernet2; ID:YT661812121",
@@ -227,11 +227,11 @@ def test_physical_interface_configuration_scenario() -> None:
 def test_system_hostname_change_scenario() -> None:
     """Test changing system hostname."""
     platform = Platform.JUNIPER_JUNOS
-    running_config = get_hconfig_fast_load(
+    running_config = HConfig.from_lines(
         platform,
         ("set system host-name old-router.example.com",),
     )
-    generated_config = get_hconfig_fast_load(
+    generated_config = HConfig.from_lines(
         platform,
         ("set system host-name new-router.example.com",),
     )

--- a/tests/integration/test_negate_with_undo.py
+++ b/tests/integration/test_negate_with_undo.py
@@ -4,12 +4,8 @@ from hier_config.models import Platform
 
 def test_merge_with_undo() -> None:
     platform = Platform.HP_COMWARE5
-    running_config = HConfig.from_lines(
-        platform, "test_for_undo\nundo test_for_redo"
-    )
-    generated_config = HConfig.from_lines(
-        platform, "undo test_for_undo\ntest_for_redo"
-    )
+    running_config = HConfig.from_lines(platform, "test_for_undo\nundo test_for_redo")
+    generated_config = HConfig.from_lines(platform, "undo test_for_undo\ntest_for_redo")
     expected_remediation_config = HConfig.from_lines(
         platform, "undo test_for_undo\ntest_for_redo"
     )

--- a/tests/integration/test_negate_with_undo.py
+++ b/tests/integration/test_negate_with_undo.py
@@ -1,16 +1,16 @@
-from hier_config import WorkflowRemediation, get_hconfig_fast_load
+from hier_config import HConfig, WorkflowRemediation
 from hier_config.models import Platform
 
 
 def test_merge_with_undo() -> None:
     platform = Platform.HP_COMWARE5
-    running_config = get_hconfig_fast_load(
+    running_config = HConfig.from_lines(
         platform, "test_for_undo\nundo test_for_redo"
     )
-    generated_config = get_hconfig_fast_load(
+    generated_config = HConfig.from_lines(
         platform, "undo test_for_undo\ntest_for_redo"
     )
-    expected_remediation_config = get_hconfig_fast_load(
+    expected_remediation_config = HConfig.from_lines(
         platform, "undo test_for_undo\ntest_for_redo"
     )
     workflow_remediation = WorkflowRemediation(running_config, generated_config)

--- a/tests/integration/test_negation_sub.py
+++ b/tests/integration/test_negation_sub.py
@@ -1,7 +1,8 @@
 from hier_config import HConfig
 from hier_config.models import (
     MatchRule,
-    NegationSubRule,
+    NegationRule,
+    NegationStrategy,
     Platform,
 )
 from hier_config.platforms.driver_base import HConfigDriverRules
@@ -10,11 +11,11 @@ from hier_config.utils import load_driver_rules
 
 
 def _make_driver(
-    rules: list[NegationSubRule],
+    rules: list[NegationRule],
 ) -> HConfigDriverGeneric:
     """Create a generic driver with custom negation_sub rules."""
     driver = HConfigDriverGeneric()
-    driver.rules = HConfigDriverRules(negation_sub=rules)
+    driver.rules = HConfigDriverRules(negation=rules)
     return driver
 
 
@@ -22,7 +23,8 @@ def test_negation_sub_truncates_snmp_user() -> None:
     """SNMP user negation is truncated after the username."""
     driver = _make_driver(
         [
-            NegationSubRule(
+            NegationRule(
+                strategy=NegationStrategy.REGEX_SUB,
                 match_rules=(MatchRule(startswith="snmp-server user "),),
                 search=r"(no snmp-server user \S+).*",
                 replace=r"\1",
@@ -42,7 +44,8 @@ def test_negation_sub_truncates_prefix_list() -> None:
     """Prefix-list negation is truncated after the sequence number."""
     driver = _make_driver(
         [
-            NegationSubRule(
+            NegationRule(
+                strategy=NegationStrategy.REGEX_SUB,
                 match_rules=(MatchRule(startswith="ipv6 prefix-list "),),
                 search=r"(no ipv6 prefix-list \S+ seq \d+).*",
                 replace=r"\1",
@@ -62,7 +65,8 @@ def test_negation_sub_no_match_uses_normal_negation() -> None:
     """Commands not matching any negation_sub rule get normal swap_negation."""
     driver = _make_driver(
         [
-            NegationSubRule(
+            NegationRule(
+                strategy=NegationStrategy.REGEX_SUB,
                 match_rules=(MatchRule(startswith="snmp-server user "),),
                 search=r"(no snmp-server user \S+).*",
                 replace=r"\1",
@@ -82,7 +86,8 @@ def test_negation_sub_full_remediation() -> None:
     """Full remediation: removed entry uses truncated negation, kept entry unchanged."""
     driver = _make_driver(
         [
-            NegationSubRule(
+            NegationRule(
+                strategy=NegationStrategy.REGEX_SUB,
                 match_rules=(MatchRule(startswith="snmp-server user "),),
                 search=r"(no snmp-server user \S+).*",
                 replace=r"\1",

--- a/tests/integration/test_negation_sub.py
+++ b/tests/integration/test_negation_sub.py
@@ -1,4 +1,4 @@
-from hier_config import get_hconfig_fast_load
+from hier_config import HConfig
 from hier_config.models import (
     MatchRule,
     NegationSubRule,
@@ -29,11 +29,11 @@ def test_negation_sub_truncates_snmp_user() -> None:
             ),
         ],
     )
-    running = get_hconfig_fast_load(
+    running = HConfig.from_lines(
         driver,
         ("snmp-server user admin auth sha secret",),
     )
-    generated = get_hconfig_fast_load(driver, ())
+    generated = HConfig.from_lines(driver, ())
     remediation = running.remediation(generated)
     assert remediation.to_lines() == ("no snmp-server user admin",)
 
@@ -49,11 +49,11 @@ def test_negation_sub_truncates_prefix_list() -> None:
             ),
         ],
     )
-    running = get_hconfig_fast_load(
+    running = HConfig.from_lines(
         driver,
         ("ipv6 prefix-list PL seq 1 permit 2801::/64 ge 65",),
     )
-    generated = get_hconfig_fast_load(driver, ())
+    generated = HConfig.from_lines(driver, ())
     remediation = running.remediation(generated)
     assert remediation.to_lines() == ("no ipv6 prefix-list PL seq 1",)
 
@@ -69,11 +69,11 @@ def test_negation_sub_no_match_uses_normal_negation() -> None:
             ),
         ],
     )
-    running = get_hconfig_fast_load(
+    running = HConfig.from_lines(
         driver,
         ("hostname router1",),
     )
-    generated = get_hconfig_fast_load(driver, ())
+    generated = HConfig.from_lines(driver, ())
     remediation = running.remediation(generated)
     assert remediation.to_lines() == ("no hostname router1",)
 
@@ -89,14 +89,14 @@ def test_negation_sub_full_remediation() -> None:
             ),
         ],
     )
-    running = get_hconfig_fast_load(
+    running = HConfig.from_lines(
         driver,
         (
             "snmp-server user admin auth sha secret",
             "snmp-server user monitor auth sha secret2",
         ),
     )
-    generated = get_hconfig_fast_load(
+    generated = HConfig.from_lines(
         driver,
         ("snmp-server user monitor auth sha secret2",),
     )
@@ -116,10 +116,10 @@ def test_negation_sub_via_load_driver_rules() -> None:
         ],
     }
     driver = load_driver_rules(options, Platform.GENERIC)
-    running = get_hconfig_fast_load(
+    running = HConfig.from_lines(
         driver,
         ("snmp-server user admin auth sha secret",),
     )
-    generated = get_hconfig_fast_load(driver, ())
+    generated = HConfig.from_lines(driver, ())
     remediation = running.remediation(generated)
     assert remediation.to_lines() == ("no snmp-server user admin",)

--- a/tests/integration/test_nokia_srl.py
+++ b/tests/integration/test_nokia_srl.py
@@ -1,4 +1,4 @@
-from hier_config import WorkflowRemediation, get_hconfig, get_hconfig_fast_load
+from hier_config import HConfig, WorkflowRemediation
 from hier_config.models import Platform
 
 
@@ -10,8 +10,8 @@ def test_nokia_srl_basic_remediation() -> None:
     remediation_str = "delete interface ethernet-1/1 subinterface 0 ipv4 admin-state enable address 192.168.1.1/24\nset interface ethernet-1/1 subinterface 0 ipv4 admin-state enable address 192.168.2.1/24"
 
     workflow_remediation = WorkflowRemediation(
-        get_hconfig_fast_load(platform, running_config_str),
-        get_hconfig_fast_load(platform, generated_config_str),
+        HConfig.from_lines(platform, running_config_str),
+        HConfig.from_lines(platform, generated_config_str),
     )
 
     assert workflow_remediation.remediation_config_filtered_text() == remediation_str
@@ -20,11 +20,11 @@ def test_nokia_srl_basic_remediation() -> None:
 def test_interface_address_addition() -> None:
     """Test adding an interface address."""
     platform = Platform.NOKIA_SRL
-    running_config = get_hconfig_fast_load(
+    running_config = HConfig.from_lines(
         platform,
         ("set interface ethernet-1/1 subinterface 0 ipv4 address 192.168.1.1/24",),
     )
-    generated_config = get_hconfig_fast_load(
+    generated_config = HConfig.from_lines(
         platform,
         (
             "set interface ethernet-1/1 subinterface 0 ipv4 address 192.168.1.1/24",
@@ -40,14 +40,14 @@ def test_interface_address_addition() -> None:
 def test_interface_description_modification() -> None:
     """Test modifying interface description."""
     platform = Platform.NOKIA_SRL
-    running_config = get_hconfig_fast_load(
+    running_config = HConfig.from_lines(
         platform,
         (
             "set interface ethernet-1/1 description Old Description",
             "set interface ethernet-1/1 subinterface 0 ipv4 address 192.168.1.1/24",
         ),
     )
-    generated_config = get_hconfig_fast_load(
+    generated_config = HConfig.from_lines(
         platform,
         (
             "set interface ethernet-1/1 description New Description",
@@ -64,14 +64,14 @@ def test_interface_description_modification() -> None:
 def test_interface_removal() -> None:
     """Test removing an interface configuration."""
     platform = Platform.NOKIA_SRL
-    running_config = get_hconfig_fast_load(
+    running_config = HConfig.from_lines(
         platform,
         (
             "set interface ethernet-1/1 subinterface 0 ipv4 address 192.168.1.1/24",
             "set interface ethernet-1/2 subinterface 0 ipv4 address 10.0.0.1/24",
         ),
     )
-    generated_config = get_hconfig_fast_load(
+    generated_config = HConfig.from_lines(
         platform,
         ("set interface ethernet-1/1 subinterface 0 ipv4 address 192.168.1.1/24",),
     )
@@ -84,14 +84,14 @@ def test_interface_removal() -> None:
 def test_network_instance_remediation() -> None:
     """Test network-instance (VRF) block handling."""
     platform = Platform.NOKIA_SRL
-    running_config = get_hconfig_fast_load(
+    running_config = HConfig.from_lines(
         platform,
         (
             "set network-instance default router-id 10.0.0.1",
             "set network-instance default interface ethernet-1/1.0",
         ),
     )
-    generated_config = get_hconfig_fast_load(
+    generated_config = HConfig.from_lines(
         platform,
         (
             "set network-instance default router-id 10.0.0.2",
@@ -110,14 +110,14 @@ def test_network_instance_remediation() -> None:
 def test_system_configuration() -> None:
     """Test system configuration changes."""
     platform = Platform.NOKIA_SRL
-    running_config = get_hconfig_fast_load(
+    running_config = HConfig.from_lines(
         platform,
         (
             "set system name host-name old-srl-router",
             "set system dns network-instance mgmt",
         ),
     )
-    generated_config = get_hconfig_fast_load(
+    generated_config = HConfig.from_lines(
         platform,
         (
             "set system name host-name new-srl-router",
@@ -136,8 +136,8 @@ def test_system_configuration() -> None:
 def test_empty_to_basic_config() -> None:
     """Test building configuration from empty state."""
     platform = Platform.NOKIA_SRL
-    running_config = get_hconfig(platform)
-    generated_config = get_hconfig_fast_load(
+    running_config = HConfig.from_text(platform)
+    generated_config = HConfig.from_lines(
         platform,
         (
             "set system name host-name srl-router",
@@ -159,11 +159,11 @@ def test_empty_to_basic_config() -> None:
 def test_routing_policy_configuration() -> None:
     """Test routing-policy configuration changes."""
     platform = Platform.NOKIA_SRL
-    running_config = get_hconfig_fast_load(
+    running_config = HConfig.from_lines(
         platform,
         ("set routing-policy policy accept-all default-action policy-result accept",),
     )
-    generated_config = get_hconfig_fast_load(
+    generated_config = HConfig.from_lines(
         platform,
         (
             "set routing-policy policy accept-all default-action policy-result accept",
@@ -179,11 +179,11 @@ def test_routing_policy_configuration() -> None:
 def test_ipv6_address_configuration() -> None:
     """Test configuring IPv6 addresses on interfaces."""
     platform = Platform.NOKIA_SRL
-    running_config = get_hconfig_fast_load(
+    running_config = HConfig.from_lines(
         platform,
         ("set interface ethernet-1/1 subinterface 0 ipv6 address 2001:db8:1::1/64",),
     )
-    generated_config = get_hconfig_fast_load(
+    generated_config = HConfig.from_lines(
         platform,
         ("set interface ethernet-1/1 subinterface 0 ipv6 address 2001:db8:2::1/64",),
     )

--- a/tests/integration/test_remediation.py
+++ b/tests/integration/test_remediation.py
@@ -524,3 +524,28 @@ def test_sectional_exit_text_parent_level_generic_platform() -> None:
     # Generic platform has no specific sectional_exiting rules with parent_level=True
     section = config.add_child("section test")
     assert section.sectional_exit_text_parent_level is False
+
+
+def test_remediation_does_not_mutate_inputs() -> None:
+    """remediation() must not modify the running or generated configs (#224)."""
+    running_text = (
+        "hostname old\n"
+        "interface GigabitEthernet0/0\n"
+        " description keep\n"
+        " shutdown\n"
+    )
+    generated_text = (
+        "hostname new\n"
+        "interface GigabitEthernet0/0\n"
+        " description keep\n"
+        " ip address 10.0.0.1 255.255.255.0\n"
+    )
+    running_config = HConfig.from_text(Platform.CISCO_IOS, running_text)
+    generated_config = HConfig.from_text(Platform.CISCO_IOS, generated_text)
+    running_before = running_config.to_lines()
+    generated_before = generated_config.to_lines()
+
+    running_config.remediation(generated_config)
+
+    assert running_config.to_lines() == running_before
+    assert generated_config.to_lines() == generated_before

--- a/tests/integration/test_remediation.py
+++ b/tests/integration/test_remediation.py
@@ -1,20 +1,19 @@
 """Integration tests for remediation, future, difference, and sectional overwrite."""
 
 from hier_config import (
+    HConfig,
     HConfigChild,
     WorkflowRemediation,
-    get_hconfig,
     get_hconfig_driver,
-    get_hconfig_fast_load,
 )
 from hier_config.models import Platform
 
 
 def test_remediation(platform_a: Platform) -> None:
-    running_config_hier = get_hconfig(platform_a)
+    running_config_hier = HConfig.from_text(platform_a)
     interface = running_config_hier.add_child("interface Vlan2")
     interface.add_child("ip address 192.168.1.1/24")
-    generated_config_hier = get_hconfig(platform_a)
+    generated_config_hier = HConfig.from_text(platform_a)
     generated_config_hier.add_child("interface Vlan3")
     remediation_config_hier = running_config_hier.remediation(
         generated_config_hier,
@@ -23,12 +22,12 @@ def test_remediation(platform_a: Platform) -> None:
 
 
 def test_remediation2(platform_a: Platform) -> None:
-    running_config_hier = get_hconfig(platform_a)
+    running_config_hier = HConfig.from_text(platform_a)
     running_config_hier.add_child("do not add me")
-    generated_config_hier = get_hconfig(platform_a)
+    generated_config_hier = HConfig.from_text(platform_a)
     generated_config_hier.add_child("do not add me")
     generated_config_hier.add_child("add me")
-    delta = get_hconfig(platform_a)
+    delta = HConfig.from_text(platform_a)
     running_config_hier.remediation(
         generated_config_hier,
         delta,
@@ -38,10 +37,10 @@ def test_remediation2(platform_a: Platform) -> None:
 
 
 def test_future_config(platform_a: Platform) -> None:
-    running_config = get_hconfig(platform_a)
+    running_config = HConfig.from_text(platform_a)
     running_config.add_children_deep(("a", "aa", "aaa", "aaaa"))
     running_config.add_children_deep(("a", "ab", "aba", "abaa"))
-    config = get_hconfig(platform_a)
+    config = HConfig.from_text(platform_a)
     config.add_children_deep(("a", "ac"))
     config.add_children_deep(("a", "no ab"))
     config.add_children_deep(("a", "no az"))
@@ -75,8 +74,8 @@ def test_future_preserves_bgp_neighbor_description() -> None:
   neighbor 3.3.3.3 remote-as 3
 """
 
-    running_config = get_hconfig(platform, running_raw)
-    change_config = get_hconfig(platform, change_raw)
+    running_config = HConfig.from_text(platform, running_raw)
+    change_config = HConfig.from_text(platform, change_raw)
 
     future_config = running_config.future(change_config)
     expected_future = (
@@ -101,8 +100,8 @@ def test_future_preserves_bgp_neighbor_description() -> None:
 
 def test_idempotent_commands() -> None:
     platform = Platform.HP_PROCURVE
-    config_a = get_hconfig(platform)
-    config_b = get_hconfig(platform)
+    config_a = HConfig.from_text(platform)
+    config_b = HConfig.from_text(platform)
     interface_name = "interface 1/1"
     config_a.add_children_deep((interface_name, "untagged vlan 1"))
     config_b.add_children_deep((interface_name, "untagged vlan 2"))
@@ -114,8 +113,8 @@ def test_idempotent_commands() -> None:
 
 def test_idempotent_commands2() -> None:
     platform = Platform.CISCO_IOS
-    config_a = get_hconfig(platform)
-    config_b = get_hconfig(platform)
+    config_a = HConfig.from_text(platform)
+    config_b = HConfig.from_text(platform)
     interface_name = "interface 1/1"
     config_a.add_children_deep((interface_name, "authentication host-mode multi-auth"))
     config_b.add_children_deep(
@@ -129,8 +128,8 @@ def test_idempotent_commands2() -> None:
 
 def test_future_config_no_command_in_source() -> None:
     platform = Platform.HP_PROCURVE
-    running_config = get_hconfig(platform)
-    generated_config = get_hconfig(platform)
+    running_config = HConfig.from_text(platform)
+    generated_config = HConfig.from_text(platform)
     generated_config.add_child("no service dhcp")
 
     remediation_config = running_config.remediation(generated_config)
@@ -149,9 +148,9 @@ def test_future_config_no_command_in_source() -> None:
 def test_sectional_overwrite() -> None:
     platform = Platform.CISCO_XR
     # There is a sectional_overwrite rules in the CISCO_XR driver for "template".
-    running_config = get_hconfig_fast_load(platform, "template test\n  a\n  b")
-    generated_config = get_hconfig_fast_load(platform, "template test\n  a")
-    expected_remediation_config = get_hconfig_fast_load(
+    running_config = HConfig.from_lines(platform, "template test\n  a\n  b")
+    generated_config = HConfig.from_lines(platform, "template test\n  a")
+    expected_remediation_config = HConfig.from_lines(
         platform, "no template test\ntemplate test\n  a"
     )
     workflow_remediation = WorkflowRemediation(running_config, generated_config)
@@ -161,9 +160,9 @@ def test_sectional_overwrite() -> None:
 
 def test_sectional_overwrite_no_negate() -> None:
     platform = Platform.CISCO_XR
-    running_config = get_hconfig_fast_load(platform, "as-path-set test\n  a\n  b")
-    generated_config = get_hconfig_fast_load(platform, "as-path-set test\n  a")
-    expected_remediation_config = get_hconfig_fast_load(
+    running_config = HConfig.from_lines(platform, "as-path-set test\n  a\n  b")
+    generated_config = HConfig.from_lines(platform, "as-path-set test\n  a")
+    expected_remediation_config = HConfig.from_lines(
         platform, "as-path-set test\n  a"
     )
     workflow_remediation = WorkflowRemediation(running_config, generated_config)
@@ -173,14 +172,14 @@ def test_sectional_overwrite_no_negate() -> None:
 
 def test_sectional_overwrite_no_negate2() -> None:
     platform = Platform.CISCO_XR
-    running_config = get_hconfig_fast_load(
+    running_config = HConfig.from_lines(
         platform,
         "route-policy test\n  duplicate\n  not_duplicate1\n  duplicate\n  not_duplicate2",
     )
-    generated_config = get_hconfig_fast_load(
+    generated_config = HConfig.from_lines(
         platform, "route-policy test\n  duplicate\n  not_duplicate1"
     )
-    expected_remediation_config = get_hconfig_fast_load(
+    expected_remediation_config = HConfig.from_lines(
         platform, "route-policy test\n  duplicate\n  not_duplicate1"
     )
     workflow_remediation = WorkflowRemediation(running_config, generated_config)
@@ -190,17 +189,17 @@ def test_sectional_overwrite_no_negate2() -> None:
 
 def test_overwrite_with_negate() -> None:
     platform = Platform.CISCO_XR
-    running_config = get_hconfig_fast_load(
+    running_config = HConfig.from_lines(
         platform, "route-policy test\n  duplicate\n  not_duplicate\n  duplicate"
     )
-    generated_config = get_hconfig_fast_load(
+    generated_config = HConfig.from_lines(
         platform, "route-policy test\n  duplicate\n  not_duplicate"
     )
-    expected_config = get_hconfig_fast_load(
+    expected_config = HConfig.from_lines(
         platform,
         "no route-policy test\nroute-policy test\n  duplicate\n  not_duplicate",
     )
-    delta_config = get_hconfig(platform)
+    delta_config = HConfig.from_text(platform)
     running_config.children["route-policy test"].overwrite_with(
         generated_config.children["route-policy test"], delta_config
     )
@@ -209,18 +208,18 @@ def test_overwrite_with_negate() -> None:
 
 def test_overwrite_with_no_negate() -> None:
     platform = Platform.CISCO_XR
-    running_config = get_hconfig_fast_load(
+    running_config = HConfig.from_lines(
         platform,
         "route-policy test\n  duplicate\n  not-duplicate\n  duplicate\n  duplicate",
     )
-    generated_config = get_hconfig_fast_load(
+    generated_config = HConfig.from_lines(
         platform, "route-policy test\n  duplicate\n  not-duplicate\n  duplicate"
     )
-    expected_config = get_hconfig_fast_load(
+    expected_config = HConfig.from_lines(
         platform,
         "route-policy test\n  duplicate\n  not-duplicate\n  duplicate",
     )
-    delta_config = get_hconfig(platform)
+    delta_config = HConfig.from_text(platform)
     running_config.children["route-policy test"].overwrite_with(
         generated_config.children["route-policy test"], delta_config, negate=False
     )
@@ -230,11 +229,11 @@ def test_overwrite_with_no_negate() -> None:
 def test_remediation_parent_identity() -> None:
     interface_vlan2 = "interface Vlan2"
     platform = Platform.CISCO_IOS
-    running_config_hier = get_hconfig(platform)
+    running_config_hier = HConfig.from_text(platform)
     running_config_hier.add_children_deep(
         (interface_vlan2, "ip address 192.168.1.1/24")
     )
-    generated_config_hier = get_hconfig(platform)
+    generated_config_hier = HConfig.from_text(platform)
     generated_config_hier.add_child(interface_vlan2)
     remediation_config_hier = running_config_hier.remediation(
         generated_config_hier,
@@ -250,9 +249,9 @@ def test_remediation_parent_identity() -> None:
 def test_difference1(platform_a: Platform) -> None:
     rc = ("a", " a1", " a2", " a3", "b")
     step = ("a", " a1", " a2", " a3", " a4", " a5", "b", "c", "d", " d1")
-    rc_hier = get_hconfig(get_hconfig_driver(platform_a), "\n".join(rc))
+    rc_hier = HConfig.from_text(get_hconfig_driver(platform_a), "\n".join(rc))
 
-    difference = get_hconfig(
+    difference = HConfig.from_text(
         get_hconfig_driver(platform_a), "\n".join(step)
     ).difference(rc_hier)
     difference_children = tuple(
@@ -275,8 +274,8 @@ def test_difference2() -> None:
     platform = Platform.CISCO_IOS
     rc = ("a", " a1", " a2", " a3", "b")
     step = ("a", " a1", " a2", " a3", " a4", " a5", "b", "c", "d", " d1")
-    rc_hier = get_hconfig(get_hconfig_driver(platform), "\n".join(rc))
-    step_hier = get_hconfig(get_hconfig_driver(platform), "\n".join(step))
+    rc_hier = HConfig.from_text(get_hconfig_driver(platform), "\n".join(rc))
+    step_hier = HConfig.from_text(get_hconfig_driver(platform), "\n".join(step))
 
     difference_children = tuple(
         c.indented_text() for c in step_hier.difference(rc_hier).all_children_sorted()
@@ -288,8 +287,8 @@ def test_difference3() -> None:
     platform = Platform.CISCO_IOS
     rc = ("ip access-list extended test", " 10 a", " 20 b")
     step = ("ip access-list extended test", " 10 a", " 20 b", " 30 c")
-    rc_hier = get_hconfig(get_hconfig_driver(platform), "\n".join(rc))
-    step_hier = get_hconfig(get_hconfig_driver(platform), "\n".join(step))
+    rc_hier = HConfig.from_text(get_hconfig_driver(platform), "\n".join(rc))
+    step_hier = HConfig.from_text(get_hconfig_driver(platform), "\n".join(step))
 
     difference_children = tuple(
         c.indented_text() for c in step_hier.difference(rc_hier).all_children_sorted()
@@ -300,11 +299,11 @@ def test_difference3() -> None:
 def test_difference_with_acl_none_target() -> None:
     """Test _difference with ACL when target_acl_children is None."""
     platform = Platform.CISCO_IOS
-    running_config = get_hconfig(platform)
+    running_config = HConfig.from_text(platform)
 
     acl = running_config.add_child("ip access-list extended test")
     acl.add_child("10 permit ip any any")
-    target_config = get_hconfig(platform)
+    target_config = HConfig.from_text(platform)
     difference = running_config.difference(target_config)
 
     assert difference.get_child(equals="ip access-list extended test") is not None
@@ -313,10 +312,10 @@ def test_difference_with_acl_none_target() -> None:
 def test_difference_with_negation() -> None:
     """Test _difference with negation prefix."""
     platform = Platform.CISCO_IOS
-    running_config = get_hconfig(platform)
+    running_config = HConfig.from_text(platform)
     running_config.add_child("interface GigabitEthernet0/0")
     running_config.add_child("logging console")
-    generated_config = get_hconfig(platform)
+    generated_config = HConfig.from_text(platform)
     generated_config.add_child("interface GigabitEthernet0/0")
     difference = running_config.difference(generated_config)
 
@@ -326,10 +325,10 @@ def test_difference_with_negation() -> None:
 def test_difference_with_default_prefix() -> None:
     """Test _difference skips lines with 'default' prefix."""
     platform = Platform.CISCO_IOS
-    running_config = get_hconfig(platform)
+    running_config = HConfig.from_text(platform)
     running_config.add_child("interface GigabitEthernet0/0")
     running_config.add_child("default interface GigabitEthernet0/1")
-    generated_config = get_hconfig(platform)
+    generated_config = HConfig.from_text(platform)
     generated_config.add_child("interface GigabitEthernet0/0")
     difference = running_config.difference(generated_config)
 
@@ -339,9 +338,9 @@ def test_difference_with_default_prefix() -> None:
 def test_future_with_negated_command_in_config() -> None:
     """Test _future with negated command."""
     platform = Platform.CISCO_IOS
-    running_config = get_hconfig(platform)
+    running_config = HConfig.from_text(platform)
     running_config.add_child("interface GigabitEthernet0/0")
-    remediation_config = get_hconfig(platform)
+    remediation_config = HConfig.from_text(platform)
     remediation_config.add_child("no interface GigabitEthernet0/0")
     future_config = running_config.future(remediation_config)
 
@@ -351,9 +350,9 @@ def test_future_with_negated_command_in_config() -> None:
 def test_future_with_negation_prefix_match() -> None:
     """Test _future when negated form exists."""
     platform = Platform.CISCO_IOS
-    running_config = get_hconfig(platform)
+    running_config = HConfig.from_text(platform)
     running_config.add_child("no logging console")
-    remediation_config = get_hconfig(platform)
+    remediation_config = HConfig.from_text(platform)
     remediation_config.add_child("logging console")
     future_config = running_config.future(remediation_config)
 
@@ -364,9 +363,9 @@ def test_future_with_negation_prefix_match() -> None:
 def test_future_with_negation_prefix() -> None:
     """Test _future with negation prefix in self."""
     platform = Platform.CISCO_IOS
-    running_config = get_hconfig(platform)
+    running_config = HConfig.from_text(platform)
     running_config.add_child("no ip routing")
-    remediation_config = get_hconfig(platform)
+    remediation_config = HConfig.from_text(platform)
     remediation_config.add_child("ip routing")
     future_config = running_config.future(remediation_config)
 
@@ -377,10 +376,10 @@ def test_future_with_negation_prefix() -> None:
 def test_future_self_child_not_in_negated_or_recursed() -> None:
     """Test _future when self_child is not in negated_or_recursed."""
     platform = Platform.CISCO_IOS
-    running_config = get_hconfig(platform)
+    running_config = HConfig.from_text(platform)
     running_config.add_child("hostname router1")
     running_config.add_child("interface GigabitEthernet0/0")
-    remediation_config = get_hconfig(platform)
+    remediation_config = HConfig.from_text(platform)
     remediation_config.add_child("hostname router2")
     future_config = running_config.future(remediation_config)
 
@@ -391,10 +390,10 @@ def test_future_self_child_not_in_negated_or_recursed() -> None:
 def test_future_with_idempotent_command() -> None:
     """Test _future with idempotent command."""
     platform = Platform.HP_PROCURVE
-    running_config = get_hconfig(platform)
+    running_config = HConfig.from_text(platform)
     interface = running_config.add_child("interface 1/1")
     interface.add_child("untagged vlan 1")
-    remediation_config = get_hconfig(platform)
+    remediation_config = HConfig.from_text(platform)
     remediation_interface = remediation_config.add_child("interface 1/1")
     remediation_interface.add_child("untagged vlan 2")
     future_config = running_config.future(remediation_config)
@@ -407,7 +406,7 @@ def test_future_with_idempotent_command() -> None:
 def test_sectional_exit_text_parent_level_cisco_xr() -> None:
     """Test sectional_exit_text_parent_level returns True for Cisco XR configs with parent-level exit text."""
     platform = Platform.CISCO_XR
-    config = get_hconfig(platform)
+    config = HConfig.from_text(platform)
 
     # Test route-policy which has exit_text_parent_level=True
     route_policy = config.add_child("route-policy TEST")
@@ -441,7 +440,7 @@ def test_sectional_exit_text_parent_level_cisco_xr() -> None:
 def test_sectional_exit_text_parent_level_cisco_xr_false() -> None:
     """Test sectional_exit_text_parent_level returns False for Cisco XR configs without parent-level exit text."""
     platform = Platform.CISCO_XR
-    config = get_hconfig(platform)
+    config = HConfig.from_text(platform)
 
     # Test interface which has exit_text_parent_level=False (default)
     interface = config.add_child("interface GigabitEthernet0/0/0/0")
@@ -455,7 +454,7 @@ def test_sectional_exit_text_parent_level_cisco_xr_false() -> None:
 def test_sectional_exit_text_parent_level_cisco_ios() -> None:
     """Test sectional_exit_text_parent_level returns False for standard Cisco IOS configs."""
     platform = Platform.CISCO_IOS
-    config = get_hconfig(platform)
+    config = HConfig.from_text(platform)
 
     # Cisco IOS interfaces don't have exit_text_parent_level=True
     interface = config.add_child("interface GigabitEthernet0/0")
@@ -473,7 +472,7 @@ def test_sectional_exit_text_parent_level_cisco_ios() -> None:
 def test_sectional_exit_text_parent_level_no_match() -> None:
     """Test sectional_exit_text_parent_level returns False when no rules match."""
     platform = Platform.CISCO_IOS
-    config = get_hconfig(platform)
+    config = HConfig.from_text(platform)
 
     # A child that doesn't match any sectional_exiting rules
     hostname = config.add_child("hostname TEST")
@@ -487,7 +486,7 @@ def test_sectional_exit_text_parent_level_no_match() -> None:
 def test_sectional_exit_text_parent_level_with_nested_children() -> None:
     """Test sectional_exit_text_parent_level with nested child configurations."""
     platform = Platform.CISCO_XR
-    config = get_hconfig(platform)
+    config = HConfig.from_text(platform)
 
     # Create a route-policy with nested children
     route_policy = config.add_child("route-policy TEST")
@@ -503,7 +502,7 @@ def test_sectional_exit_text_parent_level_with_nested_children() -> None:
 def test_sectional_exit_text_parent_level_indentation_in_lines() -> None:
     """Test that sectional_exit_text_parent_level affects indentation in lines output."""
     platform = Platform.CISCO_XR
-    config = get_hconfig(platform)
+    config = HConfig.from_text(platform)
 
     # Create a route-policy with children - exit text should be at parent level (depth - 1)
     route_policy = config.add_child("route-policy TEST")
@@ -522,7 +521,7 @@ def test_sectional_exit_text_parent_level_indentation_in_lines() -> None:
 def test_sectional_exit_text_parent_level_generic_platform() -> None:
     """Test sectional_exit_text_parent_level with generic platform."""
     platform = Platform.GENERIC
-    config = get_hconfig(platform)
+    config = HConfig.from_text(platform)
 
     # Generic platform has no specific sectional_exiting rules with parent_level=True
     section = config.add_child("section test")

--- a/tests/integration/test_remediation.py
+++ b/tests/integration/test_remediation.py
@@ -529,10 +529,7 @@ def test_sectional_exit_text_parent_level_generic_platform() -> None:
 def test_remediation_does_not_mutate_inputs() -> None:
     """remediation() must not modify the running or generated configs (#224)."""
     running_text = (
-        "hostname old\n"
-        "interface GigabitEthernet0/0\n"
-        " description keep\n"
-        " shutdown\n"
+        "hostname old\ninterface GigabitEthernet0/0\n description keep\n shutdown\n"
     )
     generated_text = (
         "hostname new\n"

--- a/tests/integration/test_remediation.py
+++ b/tests/integration/test_remediation.py
@@ -162,9 +162,7 @@ def test_sectional_overwrite_no_negate() -> None:
     platform = Platform.CISCO_XR
     running_config = HConfig.from_lines(platform, "as-path-set test\n  a\n  b")
     generated_config = HConfig.from_lines(platform, "as-path-set test\n  a")
-    expected_remediation_config = HConfig.from_lines(
-        platform, "as-path-set test\n  a"
-    )
+    expected_remediation_config = HConfig.from_lines(platform, "as-path-set test\n  a")
     workflow_remediation = WorkflowRemediation(running_config, generated_config)
     remediation_config = workflow_remediation.remediation_config
     assert remediation_config == expected_remediation_config

--- a/tests/integration/test_unused_objects.py
+++ b/tests/integration/test_unused_objects.py
@@ -1,4 +1,4 @@
-from hier_config import get_hconfig_fast_load
+from hier_config import HConfig
 from hier_config.models import (
     MatchRule,
     Platform,
@@ -35,7 +35,7 @@ def test_unused_acl_detected() -> None:
             ),
         ],
     )
-    config = get_hconfig_fast_load(
+    config = HConfig.from_lines(
         driver,
         (
             "ipv4 access-list USED_ACL",
@@ -66,7 +66,7 @@ def test_used_acl_not_detected() -> None:
             ),
         ],
     )
-    config = get_hconfig_fast_load(
+    config = HConfig.from_lines(
         driver,
         (
             "ipv4 access-list MY_ACL",
@@ -81,7 +81,7 @@ def test_used_acl_not_detected() -> None:
 
 def test_no_unused_object_rules_yields_nothing() -> None:
     """A driver with no unused_objects rules yields nothing."""
-    config = get_hconfig_fast_load(
+    config = HConfig.from_lines(
         Platform.GENERIC,
         ("hostname router1",),
     )
@@ -109,7 +109,7 @@ def test_multiple_reference_locations() -> None:
             ),
         ],
     )
-    config = get_hconfig_fast_load(
+    config = HConfig.from_lines(
         driver,
         (
             "route-policy USED_IN_BGP",
@@ -142,7 +142,7 @@ def test_unused_objects_via_load_driver_rules() -> None:
         ],
     }
     driver = load_driver_rules(options, Platform.CISCO_XR)
-    config = get_hconfig_fast_load(
+    config = HConfig.from_lines(
         driver,
         (
             "ipv4 access-list APPLIED_ACL",
@@ -174,7 +174,7 @@ def test_name_re_without_match_skips_definition() -> None:
             ),
         ],
     )
-    config = get_hconfig_fast_load(
+    config = HConfig.from_lines(
         driver,
         (
             "ipv4 access-list MY_ACL",

--- a/tests/integration/test_various.py
+++ b/tests/integration/test_various.py
@@ -1,4 +1,4 @@
-from hier_config import get_hconfig, get_hconfig_driver
+from hier_config import HConfig, get_hconfig_driver
 from hier_config.models import Platform
 
 
@@ -12,8 +12,8 @@ def test_issue104() -> None:
     )
 
     platform = Platform.CISCO_NXOS
-    running_config = get_hconfig(get_hconfig_driver(platform), running_config_raw)
-    generated_config = get_hconfig(get_hconfig_driver(platform), generated_config_raw)
+    running_config = HConfig.from_text(get_hconfig_driver(platform), running_config_raw)
+    generated_config = HConfig.from_text(get_hconfig_driver(platform), generated_config_raw)
     remediation_config = running_config.remediation(generated_config)
     expected_rem_lines = {
         "no tacacs-server deadtime 3",

--- a/tests/integration/test_various.py
+++ b/tests/integration/test_various.py
@@ -13,7 +13,9 @@ def test_issue104() -> None:
 
     platform = Platform.CISCO_NXOS
     running_config = HConfig.from_text(get_hconfig_driver(platform), running_config_raw)
-    generated_config = HConfig.from_text(get_hconfig_driver(platform), generated_config_raw)
+    generated_config = HConfig.from_text(
+        get_hconfig_driver(platform), generated_config_raw
+    )
     remediation_config = running_config.remediation(generated_config)
     expected_rem_lines = {
         "no tacacs-server deadtime 3",

--- a/tests/integration/test_vyos.py
+++ b/tests/integration/test_vyos.py
@@ -1,4 +1,4 @@
-from hier_config import WorkflowRemediation, get_hconfig, get_hconfig_fast_load
+from hier_config import HConfig, WorkflowRemediation
 from hier_config.models import Platform
 
 
@@ -10,8 +10,8 @@ def test_vyos_basic_remediation() -> None:
     remediation_str = "delete interfaces ethernet eth0 address 192.168.1.1/24\nset interfaces ethernet eth0 address 192.168.2.1/24"
 
     workflow_remediation = WorkflowRemediation(
-        get_hconfig_fast_load(platform, running_config_str),
-        get_hconfig_fast_load(platform, generated_config_str),
+        HConfig.from_lines(platform, running_config_str),
+        HConfig.from_lines(platform, generated_config_str),
     )
 
     assert workflow_remediation.remediation_config_filtered_text() == remediation_str
@@ -20,11 +20,11 @@ def test_vyos_basic_remediation() -> None:
 def test_interface_address_addition_scenario() -> None:
     """Test adding an interface address."""
     platform = Platform.VYOS
-    running_config = get_hconfig_fast_load(
+    running_config = HConfig.from_lines(
         platform,
         ("set interfaces ethernet eth0 address 192.168.1.1/24",),
     )
-    generated_config = get_hconfig_fast_load(
+    generated_config = HConfig.from_lines(
         platform,
         (
             "set interfaces ethernet eth0 address 192.168.1.1/24",
@@ -40,14 +40,14 @@ def test_interface_address_addition_scenario() -> None:
 def test_interface_description_modification_scenario() -> None:
     """Test modifying interface description."""
     platform = Platform.VYOS
-    running_config = get_hconfig_fast_load(
+    running_config = HConfig.from_lines(
         platform,
         (
             "set interfaces ethernet eth0 address 192.168.1.1/24",
             "set interfaces ethernet eth0 description Old Description",
         ),
     )
-    generated_config = get_hconfig_fast_load(
+    generated_config = HConfig.from_lines(
         platform,
         (
             "set interfaces ethernet eth0 address 192.168.1.1/24",
@@ -64,7 +64,7 @@ def test_interface_description_modification_scenario() -> None:
 def test_interface_removal_scenario() -> None:
     """Test removing an interface configuration."""
     platform = Platform.VYOS
-    running_config = get_hconfig_fast_load(
+    running_config = HConfig.from_lines(
         platform,
         (
             "set interfaces ethernet eth0 address 192.168.1.1/24",
@@ -72,7 +72,7 @@ def test_interface_removal_scenario() -> None:
             "set interfaces ethernet eth1 address 10.0.0.1/24",
         ),
     )
-    generated_config = get_hconfig_fast_load(
+    generated_config = HConfig.from_lines(
         platform,
         (
             "set interfaces ethernet eth0 address 192.168.1.1/24",
@@ -88,14 +88,14 @@ def test_interface_removal_scenario() -> None:
 def test_system_configuration_scenario() -> None:
     """Test system configuration changes."""
     platform = Platform.VYOS
-    running_config = get_hconfig_fast_load(
+    running_config = HConfig.from_lines(
         platform,
         (
             "set system host-name old-vyos-router",
             "set system domain-name example.com",
         ),
     )
-    generated_config = get_hconfig_fast_load(
+    generated_config = HConfig.from_lines(
         platform,
         (
             "set system host-name new-vyos-router",
@@ -114,8 +114,8 @@ def test_system_configuration_scenario() -> None:
 def test_empty_to_basic_config_scenario() -> None:
     """Test building configuration from empty state."""
     platform = Platform.VYOS
-    running_config = get_hconfig(platform)
-    generated_config = get_hconfig_fast_load(
+    running_config = HConfig.from_text(platform)
+    generated_config = HConfig.from_lines(
         platform,
         (
             "set system host-name test-router",
@@ -137,7 +137,7 @@ def test_empty_to_basic_config_scenario() -> None:
 def test_nat_configuration_scenario() -> None:
     """Test NAT configuration changes."""
     platform = Platform.VYOS
-    running_config = get_hconfig_fast_load(
+    running_config = HConfig.from_lines(
         platform,
         (
             "set nat source rule 10 outbound-interface eth0",
@@ -145,7 +145,7 @@ def test_nat_configuration_scenario() -> None:
             "set nat source rule 10 translation address masquerade",
         ),
     )
-    generated_config = get_hconfig_fast_load(
+    generated_config = HConfig.from_lines(
         platform,
         (
             "set nat source rule 10 outbound-interface eth0",
@@ -163,7 +163,7 @@ def test_nat_configuration_scenario() -> None:
 def test_firewall_rule_scenario() -> None:
     """Test firewall rule configuration."""
     platform = Platform.VYOS
-    running_config = get_hconfig_fast_load(
+    running_config = HConfig.from_lines(
         platform,
         (
             "set firewall name WAN_LOCAL default-action drop",
@@ -171,7 +171,7 @@ def test_firewall_rule_scenario() -> None:
             "set firewall name WAN_LOCAL rule 10 state established enable",
         ),
     )
-    generated_config = get_hconfig_fast_load(
+    generated_config = HConfig.from_lines(
         platform,
         (
             "set firewall name WAN_LOCAL default-action drop",
@@ -189,11 +189,11 @@ def test_firewall_rule_scenario() -> None:
 def test_ipv6_address_configuration_scenario() -> None:
     """Test configuring IPv6 addresses on interfaces."""
     platform = Platform.VYOS
-    running_config = get_hconfig_fast_load(
+    running_config = HConfig.from_lines(
         platform,
         ("set interfaces ethernet eth0 address 2001:db8:1::1/64",),
     )
-    generated_config = get_hconfig_fast_load(
+    generated_config = HConfig.from_lines(
         platform,
         ("set interfaces ethernet eth0 address 2001:db8:2::1/64",),
     )

--- a/tests/unit/platforms/test_cisco_ios.py
+++ b/tests/unit/platforms/test_cisco_ios.py
@@ -1,4 +1,4 @@
-from hier_config.constructors import get_hconfig
+from hier_config import HConfig
 from hier_config.models import Platform
 
 
@@ -6,7 +6,7 @@ def test_rm_ipv6_acl_sequence_numbers() -> None:
     """Test post-load callback that removes IPv6 ACL sequence numbers."""
     platform = Platform.CISCO_IOS
     config_text = "ipv6 access-list TEST_IPV6_ACL\n sequence 10 permit tcp any any eq 443\n sequence 20 deny ipv6 any any"
-    config = get_hconfig(platform, config_text)
+    config = HConfig.from_text(platform, config_text)
     acl = config.get_child(equals="ipv6 access-list TEST_IPV6_ACL")
 
     assert acl is not None
@@ -19,7 +19,7 @@ def test_remove_ipv4_acl_remarks() -> None:
     """Test post-load callback that removes IPv4 ACL remarks."""
     platform = Platform.CISCO_IOS
     config_text = "ip access-list extended TEST_ACL\n remark Allow HTTPS traffic\n permit tcp any any eq 443\n remark Block all other traffic\n deny ip any any"
-    config = get_hconfig(platform, config_text)
+    config = HConfig.from_text(platform, config_text)
     acl = config.get_child(equals="ip access-list extended TEST_ACL")
 
     assert acl is not None
@@ -32,7 +32,7 @@ def test_add_acl_sequence_numbers() -> None:
     """Test post-load callback that adds sequence numbers to IPv4 ACLs."""
     platform = Platform.CISCO_IOS
     config_text = "ip access-list extended TEST_ACL\n permit tcp any any eq 443\n permit tcp any any eq 80\n deny ip any any"
-    config = get_hconfig(platform, config_text)
+    config = HConfig.from_text(platform, config_text)
     acl = config.get_child(equals="ip access-list extended TEST_ACL")
 
     assert acl is not None

--- a/tests/unit/platforms/test_cisco_xr.py
+++ b/tests/unit/platforms/test_cisco_xr.py
@@ -1,4 +1,4 @@
-from hier_config import get_hconfig, get_hconfig_fast_load
+from hier_config import HConfig
 from hier_config.models import Platform
 
 
@@ -18,7 +18,7 @@ group edge
  !
 end-group
 """
-    hconfig = get_hconfig(platform, config_text)
+    hconfig = HConfig.from_text(platform, config_text)
     children = [child.text for child in hconfig.children]
     assert "hostname router1" in children
     assert "group core" in children
@@ -28,7 +28,7 @@ end-group
 def test_sectional_exit_text_parent_level_route_policy() -> None:
     """Test that route-policy exit text appears at parent level (no indentation)."""
     platform = Platform.CISCO_XR
-    config = get_hconfig_fast_load(
+    config = HConfig.from_lines(
         platform,
         (
             "route-policy TEST",
@@ -53,7 +53,7 @@ def test_sectional_exit_text_parent_level_route_policy() -> None:
 def test_sectional_exit_text_parent_level_prefix_set() -> None:
     """Test that prefix-set exit text appears at parent level (no indentation)."""
     platform = Platform.CISCO_XR
-    config = get_hconfig_fast_load(
+    config = HConfig.from_lines(
         platform,
         (
             "prefix-set TEST_PREFIX",
@@ -78,7 +78,7 @@ def test_sectional_exit_text_parent_level_prefix_set() -> None:
 def test_sectional_exit_text_parent_level_policy_map() -> None:
     """Test that policy-map exit text appears at parent level (no indentation)."""
     platform = Platform.CISCO_XR
-    config = get_hconfig_fast_load(
+    config = HConfig.from_lines(
         platform,
         (
             "policy-map TEST_POLICY",
@@ -104,7 +104,7 @@ def test_sectional_exit_text_parent_level_policy_map() -> None:
 def test_sectional_exit_text_parent_level_class_map() -> None:
     """Test that class-map exit text appears at parent level (no indentation)."""
     platform = Platform.CISCO_XR
-    config = get_hconfig_fast_load(
+    config = HConfig.from_lines(
         platform,
         (
             "class-map match-any TEST_CLASS",
@@ -127,7 +127,7 @@ def test_sectional_exit_text_parent_level_class_map() -> None:
 def test_sectional_exit_text_parent_level_community_set() -> None:
     """Test that community-set exit text appears at parent level (no indentation)."""
     platform = Platform.CISCO_XR
-    config = get_hconfig_fast_load(
+    config = HConfig.from_lines(
         platform,
         (
             "community-set TEST_COMM",
@@ -152,7 +152,7 @@ def test_sectional_exit_text_parent_level_community_set() -> None:
 def test_sectional_exit_text_parent_level_extcommunity_set() -> None:
     """Test that extcommunity-set exit text appears at parent level (no indentation)."""
     platform = Platform.CISCO_XR
-    config = get_hconfig_fast_load(
+    config = HConfig.from_lines(
         platform,
         (
             "extcommunity-set rt TEST_RT",
@@ -177,7 +177,7 @@ def test_sectional_exit_text_parent_level_extcommunity_set() -> None:
 def test_sectional_exit_text_parent_level_template() -> None:
     """Test that template exit text appears at parent level (no indentation)."""
     platform = Platform.CISCO_XR
-    config = get_hconfig_fast_load(
+    config = HConfig.from_lines(
         platform,
         (
             "template TEST_TEMPLATE",
@@ -200,7 +200,7 @@ def test_sectional_exit_text_parent_level_template() -> None:
 def test_sectional_exit_text_current_level_interface() -> None:
     """Test that interface exit text appears at current level (with indentation)."""
     platform = Platform.CISCO_XR
-    config = get_hconfig_fast_load(
+    config = HConfig.from_lines(
         platform,
         (
             "interface GigabitEthernet0/0/0/0",
@@ -225,7 +225,7 @@ def test_sectional_exit_text_current_level_interface() -> None:
 def test_sectional_exit_text_current_level_router_bgp() -> None:
     """Test that router bgp exit text appears at current level (with indentation)."""
     platform = Platform.CISCO_XR
-    config = get_hconfig_fast_load(
+    config = HConfig.from_lines(
         platform,
         (
             "router bgp 65000",
@@ -250,7 +250,7 @@ def test_sectional_exit_text_current_level_router_bgp() -> None:
 def test_sectional_exit_text_multiple_sections() -> None:
     """Test multiple sections with different exit text level behaviors."""
     platform = Platform.CISCO_XR
-    config = get_hconfig_fast_load(
+    config = HConfig.from_lines(
         platform,
         (
             "route-policy TEST1",
@@ -316,7 +316,7 @@ telemetry model-driven
  !
 !
 """
-    hconfig = get_hconfig(platform, config_text)
+    hconfig = HConfig.from_text(platform, config_text)
     telemetry = hconfig.get_child(equals="telemetry model-driven")
     assert telemetry is not None
     child_texts = [child.text for child in telemetry.children]
@@ -328,7 +328,7 @@ telemetry model-driven
 
 def test_xr_comment_attached_to_next_sibling() -> None:
     """IOS-XR inline comments are attached to the next sibling's comments set."""
-    config = get_hconfig(
+    config = HConfig.from_text(
         Platform.CISCO_XR,
         """\
 router isis backbone
@@ -350,7 +350,7 @@ router isis backbone
 
 def test_xr_multiple_comments_before_line() -> None:
     """Multiple consecutive comment lines are all attached to the next sibling."""
-    config = get_hconfig(
+    config = HConfig.from_text(
         Platform.CISCO_XR,
         """\
 router isis backbone
@@ -369,7 +369,7 @@ router isis backbone
 
 def test_xr_comment_lines_not_parsed_as_children() -> None:
     """Comment lines starting with ! should not appear as config children."""
-    config = get_hconfig(
+    config = HConfig.from_text(
         Platform.CISCO_XR,
         """\
 router isis backbone
@@ -385,7 +385,7 @@ router isis backbone
 
 def test_xr_top_level_bang_delimiters_stripped() -> None:
     """Top-level ! delimiters (with no comment text) are stripped."""
-    config = get_hconfig(
+    config = HConfig.from_text(
         Platform.CISCO_XR,
         """\
 hostname router1
@@ -403,7 +403,7 @@ interface GigabitEthernet0/0/0/0
 
 def test_xr_comment_preservation_with_fast_load() -> None:
     """Comments are also preserved when using get_hconfig_fast_load."""
-    config = get_hconfig_fast_load(
+    config = HConfig.from_lines(
         Platform.CISCO_XR,
         (
             "router isis backbone",
@@ -420,7 +420,7 @@ def test_xr_comment_preservation_with_fast_load() -> None:
 
 def test_xr_hash_comments_still_stripped() -> None:
     """Lines starting with # are still stripped (not preserved)."""
-    config = get_hconfig(
+    config = HConfig.from_text(
         Platform.CISCO_XR,
         """\
 hostname router1
@@ -434,7 +434,7 @@ interface GigabitEthernet0/0/0/0
 
 def test_xr_comment_with_leading_bang_preserved() -> None:
     """A comment containing ! in its body is preserved correctly."""
-    config = get_hconfig(
+    config = HConfig.from_text(
         Platform.CISCO_XR,
         """\
 router isis backbone
@@ -451,7 +451,7 @@ router isis backbone
 
 def test_xr_trailing_comment_with_no_following_sibling_is_dropped() -> None:
     """A trailing ! comment at the end of a section with no following sibling is silently dropped."""
-    config = get_hconfig(
+    config = HConfig.from_text(
         Platform.CISCO_XR,
         """\
 router isis backbone

--- a/tests/unit/platforms/test_driver_base.py
+++ b/tests/unit/platforms/test_driver_base.py
@@ -1,6 +1,5 @@
-from hier_config import get_hconfig_driver
+from hier_config import HConfig, get_hconfig_driver
 from hier_config.child import HConfigChild
-from hier_config.constructors import get_hconfig
 from hier_config.models import Platform
 from hier_config.platforms.arista_eos.driver import HConfigDriverAristaEOS
 from hier_config.platforms.cisco_ios.driver import HConfigDriverCiscoIOS
@@ -30,7 +29,7 @@ def test_driver_base_properties() -> None:
     assert not driver.declaration_prefix
     assert driver.negation_prefix == "no "
 
-    config = get_hconfig(Platform.GENERIC)
+    config = HConfig.from_text(Platform.GENERIC)
     child = HConfigChild(config, "interface GigabitEthernet0/0")
     result = driver.swap_negation(child)
     assert result.text == "no interface GigabitEthernet0/0"

--- a/tests/unit/platforms/test_fortinet_fortios.py
+++ b/tests/unit/platforms/test_fortinet_fortios.py
@@ -1,5 +1,5 @@
+from hier_config import HConfig
 from hier_config.child import HConfigChild
-from hier_config.constructors import get_hconfig
 from hier_config.models import Platform
 from hier_config.platforms.fortinet_fortios.driver import HConfigDriverFortinetFortiOS
 
@@ -7,7 +7,7 @@ from hier_config.platforms.fortinet_fortios.driver import HConfigDriverFortinetF
 def test_swap_negation_direct() -> None:
     """Test swap_negation method directly to cover set-to-unset conversion."""
     driver = HConfigDriverFortinetFortiOS()
-    config = get_hconfig(Platform.FORTINET_FORTIOS)
+    config = HConfig.from_text(Platform.FORTINET_FORTIOS)
     child = HConfigChild(config, "set description 'test value'")
     result = driver.swap_negation(child)
     assert result.text == "unset description"
@@ -25,7 +25,7 @@ def test_swap_negation_drops_parameters_intentionally() -> None:
     attribute name must be dropped (#225).
     """
     driver = HConfigDriverFortinetFortiOS()
-    config = get_hconfig(Platform.FORTINET_FORTIOS)
+    config = HConfig.from_text(Platform.FORTINET_FORTIOS)
     child = HConfigChild(config, 'set description "Port 1"')
     result = driver.swap_negation(child)
 
@@ -35,7 +35,7 @@ def test_swap_negation_drops_parameters_intentionally() -> None:
 def test_swap_negation_bare_set_is_unchanged() -> None:
     """A bare `set` command with no attribute has nothing to negate (#225)."""
     driver = HConfigDriverFortinetFortiOS()
-    config = get_hconfig(Platform.FORTINET_FORTIOS)
+    config = HConfig.from_text(Platform.FORTINET_FORTIOS)
     child = HConfigChild(config, "set")
     result = driver.swap_negation(child)
 
@@ -45,7 +45,7 @@ def test_swap_negation_bare_set_is_unchanged() -> None:
 def test_idempotent_for_matches_same_attribute() -> None:
     """Two `set` commands for the same attribute are idempotent (#225)."""
     driver = HConfigDriverFortinetFortiOS()
-    config = get_hconfig(Platform.FORTINET_FORTIOS)
+    config = HConfig.from_text(Platform.FORTINET_FORTIOS)
     child = HConfigChild(config, "set primary 192.0.2.1")
     other = HConfigChild(config, "set primary 192.0.2.3")
 
@@ -55,7 +55,7 @@ def test_idempotent_for_matches_same_attribute() -> None:
 def test_idempotent_for_different_attribute_returns_none() -> None:
     """`set` commands for different attributes are not idempotent (#225)."""
     driver = HConfigDriverFortinetFortiOS()
-    config = get_hconfig(Platform.FORTINET_FORTIOS)
+    config = HConfig.from_text(Platform.FORTINET_FORTIOS)
     child = HConfigChild(config, "set primary 192.0.2.1")
     other = HConfigChild(config, "set secondary 192.0.2.3")
 
@@ -65,7 +65,7 @@ def test_idempotent_for_different_attribute_returns_none() -> None:
 def test_idempotent_for_single_word_commands_do_not_crash() -> None:
     """Single-word commands must not raise IndexError in idempotent_for (#225)."""
     driver = HConfigDriverFortinetFortiOS()
-    config = get_hconfig(Platform.FORTINET_FORTIOS)
+    config = HConfig.from_text(Platform.FORTINET_FORTIOS)
     child = HConfigChild(config, "set")
     other = HConfigChild(config, "set")
 

--- a/tests/unit/platforms/test_hp_procurve.py
+++ b/tests/unit/platforms/test_hp_procurve.py
@@ -1,4 +1,4 @@
-from hier_config.constructors import get_hconfig
+from hier_config import HConfig
 from hier_config.models import Platform
 
 
@@ -6,7 +6,7 @@ def test_fixup_aaa_port_access_ranges() -> None:
     """Test post-load callback that expands interface ranges in AAA port-access commands (covers lines 33-38)."""
     platform = Platform.HP_PROCURVE
     config_text = "aaa port-access authenticator 1/15-1/20,1/26-1/28\naaa port-access mac-based 2/14-2/16\naaa port-access authenticator 1/1"
-    config = get_hconfig(platform, config_text)
+    config = HConfig.from_text(platform, config_text)
 
     assert config.get_child(equals="aaa port-access authenticator 1/15") is not None
     assert config.get_child(equals="aaa port-access authenticator 1/16") is not None
@@ -32,7 +32,7 @@ def test_fixup_vlan_transformation() -> None:
     """Test post-load callback that transforms VLAN config to interface config (covers lines 63-88)."""
     platform = Platform.HP_PROCURVE
     config_text = "vlan 80\n   untagged 2/43-2/44,3/43-3/44\n   tagged 1/23,2/23,Trk1\nvlan 90\n   untagged 5/29\n   no untagged 1/2-1/5"
-    config = get_hconfig(platform, config_text)
+    config = HConfig.from_text(platform, config_text)
 
     interface_2_43 = config.get_child(equals="interface 2/43")
     assert interface_2_43 is not None
@@ -83,7 +83,7 @@ def test_fixup_device_profile_tagged_vlans() -> None:
     """Test post-load callback that separates device-profile tagged-vlans onto individual lines (covers lines 104-110)."""
     platform = Platform.HP_PROCURVE
     config_text = 'device-profile name "phone"\n   tagged-vlan 10,20,30\ndevice-profile name "printer"\n   tagged-vlan 40'
-    config = get_hconfig(platform, config_text)
+    config = HConfig.from_text(platform, config_text)
     device_profile_phone = config.get_child(equals='device-profile name "phone"')
 
     assert device_profile_phone is not None

--- a/tests/unit/platforms/test_juniper_junos.py
+++ b/tests/unit/platforms/test_juniper_junos.py
@@ -1,7 +1,7 @@
+from hier_config import HConfig
 import pytest
 
 from hier_config.child import HConfigChild
-from hier_config.constructors import get_hconfig
 from hier_config.models import Platform
 from hier_config.platforms.juniper_junos.driver import HConfigDriverJuniperJUNOS
 
@@ -10,7 +10,7 @@ def test_swap_negation_delete_to_set() -> None:
     """Test swapping from 'delete' to 'set' prefix."""
     platform = Platform.JUNIPER_JUNOS
     driver = HConfigDriverJuniperJUNOS()
-    root = get_hconfig(platform)
+    root = HConfig.from_text(platform)
     child = HConfigChild(root, "delete vlans test_vlan vlan-id 100")
     result = driver.swap_negation(child)
     assert result.text == "set vlans test_vlan vlan-id 100"
@@ -21,7 +21,7 @@ def test_swap_negation_set_to_delete() -> None:
     """Test swapping from 'set' to 'delete' prefix."""
     platform = Platform.JUNIPER_JUNOS
     driver = HConfigDriverJuniperJUNOS()
-    root = get_hconfig(platform)
+    root = HConfig.from_text(platform)
     child = HConfigChild(root, "set vlans test_vlan vlan-id 100")
     result = driver.swap_negation(child)
     assert result.text == "delete vlans test_vlan vlan-id 100"
@@ -32,7 +32,7 @@ def test_swap_negation_invalid_prefix() -> None:
     """Test ValueError when text has neither 'set' nor 'delete' prefix."""
     platform = Platform.JUNIPER_JUNOS
     driver = HConfigDriverJuniperJUNOS()
-    root = get_hconfig(platform)
+    root = HConfig.from_text(platform)
     child = HConfigChild(root, "vlans test_vlan vlan-id 100")
     with pytest.raises(ValueError, match="did not start with") as exc_info:
         driver.swap_negation(child)

--- a/tests/unit/platforms/test_juniper_junos.py
+++ b/tests/unit/platforms/test_juniper_junos.py
@@ -1,6 +1,6 @@
-from hier_config import HConfig
 import pytest
 
+from hier_config import HConfig
 from hier_config.child import HConfigChild
 from hier_config.models import Platform
 from hier_config.platforms.juniper_junos.driver import HConfigDriverJuniperJUNOS

--- a/tests/unit/platforms/test_nokia_srl.py
+++ b/tests/unit/platforms/test_nokia_srl.py
@@ -1,4 +1,4 @@
-from hier_config import get_hconfig
+from hier_config import HConfig
 from hier_config.child import HConfigChild
 from hier_config.models import Platform
 from hier_config.platforms.nokia_srl.driver import HConfigDriverNokiaSRL
@@ -8,7 +8,7 @@ def test_swap_negation_delete_to_set() -> None:
     """Test swapping from 'delete' to 'set' prefix."""
     platform = Platform.NOKIA_SRL
     driver = HConfigDriverNokiaSRL()
-    root = get_hconfig(platform)
+    root = HConfig.from_text(platform)
 
     child = HConfigChild(
         root, "delete interface ethernet-1/1 subinterface 0 ipv4 address 192.168.1.1/24"
@@ -26,7 +26,7 @@ def test_swap_negation_set_to_delete() -> None:
     """Test swapping from 'set' to 'delete' prefix."""
     platform = Platform.NOKIA_SRL
     driver = HConfigDriverNokiaSRL()
-    root = get_hconfig(platform)
+    root = HConfig.from_text(platform)
 
     child = HConfigChild(
         root, "set interface ethernet-1/1 subinterface 0 ipv4 address 192.168.1.1/24"
@@ -43,7 +43,7 @@ def test_swap_negation_set_to_delete() -> None:
 def test_swap_negation_no_prefix() -> None:
     """Test swap_negation when text has neither prefix."""
     driver = HConfigDriverNokiaSRL()
-    root = get_hconfig(Platform.NOKIA_SRL)
+    root = HConfig.from_text(Platform.NOKIA_SRL)
 
     child = HConfigChild(
         root, "interface ethernet-1/1 subinterface 0 ipv4 address 192.168.1.1/24"

--- a/tests/unit/platforms/test_vyos.py
+++ b/tests/unit/platforms/test_vyos.py
@@ -1,4 +1,4 @@
-from hier_config import get_hconfig
+from hier_config import HConfig
 from hier_config.child import HConfigChild
 from hier_config.models import Platform
 from hier_config.platforms.vyos.driver import HConfigDriverVYOS
@@ -8,7 +8,7 @@ def test_swap_negation_delete_to_set() -> None:
     """Test swapping from 'delete' to 'set' prefix (covers lines 9-11)."""
     platform = Platform.VYOS
     driver = HConfigDriverVYOS()
-    root = get_hconfig(platform)
+    root = HConfig.from_text(platform)
 
     # Create a child with 'delete' prefix
     child = HConfigChild(root, "delete interfaces ethernet eth0 address 192.168.1.1/24")
@@ -24,7 +24,7 @@ def test_swap_negation_set_to_delete() -> None:
     """Test swapping from 'set' to 'delete' prefix (covers lines 10, 12)."""
     platform = Platform.VYOS
     driver = HConfigDriverVYOS()
-    root = get_hconfig(platform)
+    root = HConfig.from_text(platform)
 
     # Create a child with 'set' prefix
     child = HConfigChild(root, "set interfaces ethernet eth0 address 192.168.1.1/24")
@@ -40,7 +40,7 @@ def test_swap_negation_no_prefix() -> None:
     """Test swap_negation behavior when text has neither prefix (covers VyOS-specific behavior)."""
     platform = Platform.VYOS
     driver = HConfigDriverVYOS()
-    root = get_hconfig(platform)
+    root = HConfig.from_text(platform)
 
     # Create a child without proper prefix
     child = HConfigChild(root, "interfaces ethernet eth0 address 192.168.1.1/24")

--- a/tests/unit/platforms/views/test_arista_eos.py
+++ b/tests/unit/platforms/views/test_arista_eos.py
@@ -2,12 +2,12 @@
 
 import pytest
 
-from hier_config import Platform, get_hconfig, get_hconfig_view
+from hier_config import HConfig, Platform, get_hconfig_view
 
 
 def test_hostname() -> None:
     """Test hostname returns hostname (covers lines 158-160)."""
-    config = get_hconfig(Platform.ARISTA_EOS)
+    config = HConfig.from_text(Platform.ARISTA_EOS)
     config.add_child("hostname ARISTA-LEAF-01")
 
     view = get_hconfig_view(config)
@@ -16,7 +16,7 @@ def test_hostname() -> None:
 
 def test_hostname_none() -> None:
     """Test hostname returns None (covers line 160)."""
-    config = get_hconfig(Platform.ARISTA_EOS)
+    config = HConfig.from_text(Platform.ARISTA_EOS)
 
     view = get_hconfig_view(config)
     assert view.hostname is None
@@ -24,7 +24,7 @@ def test_hostname_none() -> None:
 
 def test_interface_names_mentioned_not_implemented() -> None:
     """Test interface_names_mentioned raises NotImplementedError (covers line 165)."""
-    config = get_hconfig(Platform.ARISTA_EOS)
+    config = HConfig.from_text(Platform.ARISTA_EOS)
     config.add_child("interface Ethernet1")
 
     view = get_hconfig_view(config)
@@ -35,7 +35,7 @@ def test_interface_names_mentioned_not_implemented() -> None:
 
 def test_interface_views() -> None:
     """Test interface_views yields interface views (covers lines 169-170)."""
-    config = get_hconfig(Platform.ARISTA_EOS)
+    config = HConfig.from_text(Platform.ARISTA_EOS)
     config.add_child("interface Ethernet1")
     config.add_child("interface Ethernet2")
     config.add_child("interface Management1")
@@ -48,7 +48,7 @@ def test_interface_views() -> None:
 
 def test_interfaces() -> None:
     """Test interfaces returns interface children (covers line 174)."""
-    config = get_hconfig(Platform.ARISTA_EOS)
+    config = HConfig.from_text(Platform.ARISTA_EOS)
     config.add_child("interface Ethernet1")
     config.add_child("interface Ethernet2")
 
@@ -60,7 +60,7 @@ def test_interfaces() -> None:
 
 def test_ipv4_default_gw_not_implemented() -> None:
     """Test ipv4_default_gw raises NotImplementedError (covers line 178)."""
-    config = get_hconfig(Platform.ARISTA_EOS)
+    config = HConfig.from_text(Platform.ARISTA_EOS)
 
     view = get_hconfig_view(config)
 
@@ -70,7 +70,7 @@ def test_ipv4_default_gw_not_implemented() -> None:
 
 def test_location_not_implemented() -> None:
     """Test location raises NotImplementedError (covers line 182)."""
-    config = get_hconfig(Platform.ARISTA_EOS)
+    config = HConfig.from_text(Platform.ARISTA_EOS)
 
     view = get_hconfig_view(config)
 
@@ -80,7 +80,7 @@ def test_location_not_implemented() -> None:
 
 def test_stack_members_not_implemented() -> None:
     """Test stack_members raises NotImplementedError (covers line 186)."""
-    config = get_hconfig(Platform.ARISTA_EOS)
+    config = HConfig.from_text(Platform.ARISTA_EOS)
 
     view = get_hconfig_view(config)
 
@@ -90,7 +90,7 @@ def test_stack_members_not_implemented() -> None:
 
 def test_vlans_not_implemented() -> None:
     """Test vlans raises NotImplementedError (covers line 190)."""
-    config = get_hconfig(Platform.ARISTA_EOS)
+    config = HConfig.from_text(Platform.ARISTA_EOS)
 
     view = get_hconfig_view(config)
 

--- a/tests/unit/platforms/views/test_arista_eos.py
+++ b/tests/unit/platforms/views/test_arista_eos.py
@@ -1,12 +1,266 @@
 """Tests for Arista EOS view.py ConfigViewInterfaceAristaEOS and HConfigViewAristaEOS classes."""
 
-import pytest
+from ipaddress import IPv4Address, IPv4Interface
 
-from hier_config import HConfig, Platform, get_hconfig_view
+from hier_config import (
+    HConfig,
+    InterfaceBundleViewMixin,
+    InterfaceNACViewMixin,
+    InterfacePhysicalViewMixin,
+    InterfaceVlanViewMixin,
+    Platform,
+    get_hconfig_view,
+)
+from hier_config.platforms.arista_eos.view import ConfigViewInterfaceAristaEOS
+from hier_config.platforms.models import InterfaceDot1qMode, Vlan
+
+
+def _interface_view(
+    config: HConfig, name: str = "Ethernet1"
+) -> ConfigViewInterfaceAristaEOS:
+    interface_view = get_hconfig_view(config).interface_view_by_name(name)
+    assert isinstance(interface_view, ConfigViewInterfaceAristaEOS)
+    return interface_view
+
+
+def test_capabilities() -> None:
+    """EOS interface views support bundles and VLANs but not NAC or physical."""
+    config = HConfig.from_text(Platform.ARISTA_EOS)
+    config.add_child("interface Ethernet1")
+
+    interface_view = _interface_view(config)
+    assert isinstance(interface_view, InterfaceBundleViewMixin)
+    assert isinstance(interface_view, InterfaceVlanViewMixin)
+    assert not isinstance(interface_view, InterfaceNACViewMixin)
+    assert not isinstance(interface_view, InterfacePhysicalViewMixin)
+
+
+def test_bundle_id() -> None:
+    config = HConfig.from_text(Platform.ARISTA_EOS)
+    config.add_children_deep(("interface Ethernet1", "channel-group 5 mode active"))
+
+    assert _interface_view(config).bundle_id == "5"
+
+
+def test_bundle_id_none() -> None:
+    config = HConfig.from_text(Platform.ARISTA_EOS)
+    config.add_child("interface Ethernet1")
+
+    assert _interface_view(config).bundle_id is None
+
+
+def test_bundle_name() -> None:
+    config = HConfig.from_text(Platform.ARISTA_EOS)
+    config.add_children_deep(("interface Ethernet1", "channel-group 5 mode active"))
+
+    assert _interface_view(config).bundle_name == "Port-Channel5"
+
+
+def test_bundle_member_interfaces() -> None:
+    config = HConfig.from_text(Platform.ARISTA_EOS)
+    config.add_child("interface Port-Channel5")
+    config.add_children_deep(("interface Ethernet1", "channel-group 5 mode active"))
+    config.add_children_deep(("interface Ethernet2", "channel-group 5 mode active"))
+    config.add_children_deep(("interface Ethernet3", "channel-group 6 mode active"))
+
+    interface_view = _interface_view(config, "Port-Channel5")
+    assert list(interface_view.bundle_member_interfaces) == ["Ethernet1", "Ethernet2"]
+
+
+def test_bundle_member_interfaces_not_a_bundle() -> None:
+    config = HConfig.from_text(Platform.ARISTA_EOS)
+    config.add_child("interface Ethernet1")
+
+    assert not list(_interface_view(config).bundle_member_interfaces)
+
+
+def test_is_bundle() -> None:
+    config = HConfig.from_text(Platform.ARISTA_EOS)
+    config.add_child("interface Port-Channel5")
+    config.add_child("interface Ethernet1")
+
+    assert _interface_view(config, "Port-Channel5").is_bundle is True
+    assert _interface_view(config).is_bundle is False
+
+    view = get_hconfig_view(config)
+    assert [iv.name for iv in view.bundle_interface_views] == ["Port-Channel5"]
+
+
+def test_description() -> None:
+    config = HConfig.from_text(Platform.ARISTA_EOS)
+    config.add_children_deep(("interface Ethernet1", "description Uplink to Spine"))
+
+    assert _interface_view(config).description == "Uplink to Spine"
+
+
+def test_description_empty() -> None:
+    config = HConfig.from_text(Platform.ARISTA_EOS)
+    config.add_child("interface Ethernet1")
+
+    assert not _interface_view(config).description
+
+
+def test_enabled() -> None:
+    config = HConfig.from_text(Platform.ARISTA_EOS)
+    config.add_child("interface Ethernet1")
+    config.add_children_deep(("interface Ethernet2", "shutdown"))
+
+    assert _interface_view(config).enabled is True
+    assert _interface_view(config, "Ethernet2").enabled is False
+
+
+def test_ipv4_interfaces_cidr() -> None:
+    config = HConfig.from_text(Platform.ARISTA_EOS)
+    config.add_children_deep(("interface Ethernet1", "ip address 10.1.1.1/24"))
+
+    assert list(_interface_view(config).ipv4_interfaces) == [
+        IPv4Interface("10.1.1.1/24")
+    ]
+
+
+def test_ipv4_interfaces_netmask() -> None:
+    config = HConfig.from_text(Platform.ARISTA_EOS)
+    config.add_children_deep(
+        ("interface Ethernet1", "ip address 10.1.1.1 255.255.255.0")
+    )
+
+    assert _interface_view(config).ipv4_interface == IPv4Interface("10.1.1.1/24")
+
+
+def test_ipv4_interfaces_invalid() -> None:
+    config = HConfig.from_text(Platform.ARISTA_EOS)
+    config.add_children_deep(("interface Ethernet1", "ip address dhcp"))
+
+    assert not list(_interface_view(config).ipv4_interfaces)
+
+
+def test_is_loopback() -> None:
+    config = HConfig.from_text(Platform.ARISTA_EOS)
+    config.add_child("interface Loopback0")
+    config.add_child("interface Ethernet1")
+
+    assert _interface_view(config, "Loopback0").is_loopback is True
+    assert _interface_view(config).is_loopback is False
+
+
+def test_is_svi() -> None:
+    config = HConfig.from_text(Platform.ARISTA_EOS)
+    config.add_child("interface Vlan100")
+    config.add_child("interface Ethernet1")
+
+    assert _interface_view(config, "Vlan100").is_svi is True
+    assert _interface_view(config).is_svi is False
+
+
+def test_name_and_number() -> None:
+    config = HConfig.from_text(Platform.ARISTA_EOS)
+    config.add_child("interface Ethernet3/25")
+
+    interface_view = _interface_view(config, "Ethernet3/25")
+    assert interface_view.name == "Ethernet3/25"
+    assert interface_view.number == "3/25"
+    assert interface_view.port_number == 25
+
+
+def test_subinterface() -> None:
+    config = HConfig.from_text(Platform.ARISTA_EOS)
+    config.add_child("interface Ethernet1.100")
+
+    interface_view = _interface_view(config, "Ethernet1.100")
+    assert interface_view.is_subinterface is True
+    assert interface_view.parent_name == "Ethernet1"
+    assert interface_view.subinterface_number == 100
+
+
+def test_native_vlan_subinterface() -> None:
+    config = HConfig.from_text(Platform.ARISTA_EOS)
+    config.add_children_deep(
+        ("interface Ethernet1.100", "encapsulation dot1q vlan 100")
+    )
+
+    assert _interface_view(config, "Ethernet1.100").native_vlan == 100
+
+
+def test_native_vlan_routed_port() -> None:
+    config = HConfig.from_text(Platform.ARISTA_EOS)
+    config.add_children_deep(("interface Ethernet1", "no switchport"))
+
+    assert _interface_view(config).native_vlan is None
+
+
+def test_native_vlan_trunk() -> None:
+    config = HConfig.from_text(Platform.ARISTA_EOS)
+    interface = config.add_child("interface Ethernet1")
+    interface.add_child("switchport mode trunk")
+    interface.add_child("switchport trunk native vlan 999")
+
+    assert _interface_view(config).native_vlan == 999
+
+
+def test_native_vlan_trunk_default() -> None:
+    config = HConfig.from_text(Platform.ARISTA_EOS)
+    config.add_children_deep(("interface Ethernet1", "switchport mode trunk"))
+
+    assert _interface_view(config).native_vlan is None
+
+
+def test_native_vlan_access() -> None:
+    config = HConfig.from_text(Platform.ARISTA_EOS)
+    config.add_children_deep(("interface Ethernet1", "switchport access vlan 50"))
+
+    interface_view = _interface_view(config)
+    assert interface_view.native_vlan == 50
+    assert interface_view.dot1q_mode == InterfaceDot1qMode.ACCESS
+
+
+def test_native_vlan_default() -> None:
+    config = HConfig.from_text(Platform.ARISTA_EOS)
+    config.add_child("interface Ethernet1")
+
+    assert _interface_view(config).native_vlan == 1
+
+
+def test_tagged_all() -> None:
+    config = HConfig.from_text(Platform.ARISTA_EOS)
+    config.add_children_deep(("interface Ethernet1", "switchport mode trunk"))
+
+    interface_view = _interface_view(config)
+    assert interface_view.tagged_all is True
+    assert interface_view.dot1q_mode == InterfaceDot1qMode.TAGGED_ALL
+
+
+def test_tagged_vlans() -> None:
+    config = HConfig.from_text(Platform.ARISTA_EOS)
+    interface = config.add_child("interface Ethernet1")
+    interface.add_child("switchport mode trunk")
+    interface.add_child("switchport trunk allowed vlan 10,20,30-32")
+
+    interface_view = _interface_view(config)
+    assert interface_view.tagged_vlans == (10, 20, 30, 31, 32)
+    assert interface_view.tagged_all is False
+    assert interface_view.dot1q_mode == InterfaceDot1qMode.TAGGED
+
+
+def test_tagged_vlans_empty() -> None:
+    config = HConfig.from_text(Platform.ARISTA_EOS)
+    config.add_child("interface Ethernet1")
+
+    assert _interface_view(config).tagged_vlans == ()
+
+
+def test_vrf() -> None:
+    config = HConfig.from_text(Platform.ARISTA_EOS)
+    config.add_children_deep(("interface Ethernet1", "vrf RED"))
+    config.add_children_deep(("interface Ethernet2", "vrf forwarding BLUE"))
+    config.add_child("interface Ethernet3")
+
+    assert _interface_view(config).vrf == "RED"
+    assert _interface_view(config, "Ethernet2").vrf == "BLUE"
+    assert not _interface_view(config, "Ethernet3").vrf
 
 
 def test_hostname() -> None:
-    """Test hostname returns hostname (covers lines 158-160)."""
+    """Test hostname returns hostname."""
     config = HConfig.from_text(Platform.ARISTA_EOS)
     config.add_child("hostname ARISTA-LEAF-01")
 
@@ -15,26 +269,24 @@ def test_hostname() -> None:
 
 
 def test_hostname_none() -> None:
-    """Test hostname returns None (covers line 160)."""
+    """Test hostname returns None."""
     config = HConfig.from_text(Platform.ARISTA_EOS)
 
     view = get_hconfig_view(config)
     assert view.hostname is None
 
 
-def test_interface_names_mentioned_not_implemented() -> None:
-    """Test interface_names_mentioned raises NotImplementedError (covers line 165)."""
+def test_interface_names_mentioned() -> None:
     config = HConfig.from_text(Platform.ARISTA_EOS)
     config.add_child("interface Ethernet1")
+    config.add_child("interface Ethernet2")
 
     view = get_hconfig_view(config)
-
-    with pytest.raises(NotImplementedError):
-        _ = view.interface_names_mentioned
+    assert view.interface_names_mentioned == frozenset({"Ethernet1", "Ethernet2"})
 
 
 def test_interface_views() -> None:
-    """Test interface_views yields interface views (covers lines 169-170)."""
+    """Test interface_views yields interface views."""
     config = HConfig.from_text(Platform.ARISTA_EOS)
     config.add_child("interface Ethernet1")
     config.add_child("interface Ethernet2")
@@ -47,7 +299,7 @@ def test_interface_views() -> None:
 
 
 def test_interfaces() -> None:
-    """Test interfaces returns interface children (covers line 174)."""
+    """Test interfaces returns interface children."""
     config = HConfig.from_text(Platform.ARISTA_EOS)
     config.add_child("interface Ethernet1")
     config.add_child("interface Ethernet2")
@@ -58,41 +310,54 @@ def test_interfaces() -> None:
     assert len(interfaces) == 2
 
 
-def test_ipv4_default_gw_not_implemented() -> None:
-    """Test ipv4_default_gw raises NotImplementedError (covers line 178)."""
+def test_ipv4_default_gw() -> None:
+    config = HConfig.from_text(Platform.ARISTA_EOS)
+    config.add_child("ip route 0.0.0.0/0 192.0.2.254")
+
+    view = get_hconfig_view(config)
+    assert view.ipv4_default_gw == IPv4Address("192.0.2.254")
+
+
+def test_ipv4_default_gw_none() -> None:
     config = HConfig.from_text(Platform.ARISTA_EOS)
 
     view = get_hconfig_view(config)
-
-    with pytest.raises(NotImplementedError):
-        _ = view.ipv4_default_gw
+    assert view.ipv4_default_gw is None
 
 
-def test_location_not_implemented() -> None:
-    """Test location raises NotImplementedError (covers line 182)."""
+def test_location() -> None:
+    config = HConfig.from_text(Platform.ARISTA_EOS)
+    config.add_child('snmp-server location "Data Center 1"')
+
+    view = get_hconfig_view(config)
+    assert view.location == "Data Center 1"
+
+
+def test_location_empty() -> None:
     config = HConfig.from_text(Platform.ARISTA_EOS)
 
     view = get_hconfig_view(config)
-
-    with pytest.raises(NotImplementedError):
-        _ = view.location
+    assert not view.location
 
 
-def test_stack_members_not_implemented() -> None:
-    """Test stack_members raises NotImplementedError (covers line 186)."""
+def test_stack_members() -> None:
+    """EOS has no stacking, so stack_members is always empty."""
     config = HConfig.from_text(Platform.ARISTA_EOS)
 
     view = get_hconfig_view(config)
-
-    with pytest.raises(NotImplementedError):
-        _ = list(view.stack_members)
+    assert not list(view.stack_members)
 
 
-def test_vlans_not_implemented() -> None:
-    """Test vlans raises NotImplementedError (covers line 190)."""
+def test_vlans() -> None:
     config = HConfig.from_text(Platform.ARISTA_EOS)
+    config.add_children_deep(("vlan 10", "name PROD"))
+    config.add_child("vlan 20")
+    config.add_children_deep(("interface Ethernet1", "switchport access vlan 30"))
 
     view = get_hconfig_view(config)
-
-    with pytest.raises(NotImplementedError):
-        _ = list(view.vlans)
+    assert list(view.vlans) == [
+        Vlan(id=10, name="PROD"),
+        Vlan(id=20, name=None),
+        Vlan(id=30, name=None),
+    ]
+    assert view.vlan_ids == frozenset({10, 20, 30})

--- a/tests/unit/platforms/views/test_arista_eos.py
+++ b/tests/unit/platforms/views/test_arista_eos.py
@@ -361,3 +361,12 @@ def test_vlans() -> None:
         Vlan(id=30, name=None),
     ]
     assert view.vlan_ids == frozenset({10, 20, 30})
+
+
+def test_port_number_on_bundle_interface() -> None:
+    """port_number must not crash on slash-less names like Port-Channel10 (#278 review)."""
+    config = HConfig.from_text(Platform.ARISTA_EOS, "interface Port-Channel10\n")
+    view = get_hconfig_view(config)
+    interface_view = view.interface_view_by_name("Port-Channel10")
+    assert interface_view is not None
+    assert interface_view.port_number == 10

--- a/tests/unit/platforms/views/test_cisco_ios.py
+++ b/tests/unit/platforms/views/test_cisco_ios.py
@@ -5,6 +5,7 @@ from ipaddress import IPv4Address
 import pytest
 
 from hier_config import HConfig, Platform, get_hconfig_view
+from hier_config.platforms.cisco_ios.view import ConfigViewInterfaceCiscoIOS
 from hier_config.platforms.models import InterfaceDuplex, NACHostMode, StackMember
 
 
@@ -16,7 +17,7 @@ def test_bundle_id() -> None:
 
     view = get_hconfig_view(config)
     interface_view = view.interface_view_by_name("GigabitEthernet0/0")
-    assert interface_view is not None
+    assert isinstance(interface_view, ConfigViewInterfaceCiscoIOS)
     assert interface_view.bundle_id == "10"
 
 
@@ -27,21 +28,62 @@ def test_bundle_id_none() -> None:
 
     view = get_hconfig_view(config)
     interface_view = view.interface_view_by_name("GigabitEthernet0/0")
-    assert interface_view is not None
+    assert isinstance(interface_view, ConfigViewInterfaceCiscoIOS)
     assert interface_view.bundle_id is None
 
 
-def test_bundle_member_interfaces_not_implemented() -> None:
-    """Test bundle_member_interfaces raises NotImplementedError (covers line 29)."""
+def test_bundle_member_interfaces() -> None:
+    """Test bundle_member_interfaces yields the bundle's member interfaces."""
+    config = HConfig.from_text(Platform.CISCO_IOS)
+    config.add_child("interface Port-channel10")
+    config.add_children_deep(
+        ("interface GigabitEthernet0/0", "channel-group 10 mode active")
+    )
+    config.add_children_deep(
+        ("interface GigabitEthernet0/1", "channel-group 10 mode active")
+    )
+    config.add_children_deep(
+        ("interface GigabitEthernet0/2", "channel-group 20 mode active")
+    )
+
+    view = get_hconfig_view(config)
+    interface_view = view.interface_view_by_name("Port-channel10")
+    assert isinstance(interface_view, ConfigViewInterfaceCiscoIOS)
+
+    assert list(interface_view.bundle_member_interfaces) == [
+        "GigabitEthernet0/0",
+        "GigabitEthernet0/1",
+    ]
+
+
+def test_bundle_member_interfaces_not_a_bundle() -> None:
+    """Test bundle_member_interfaces yields nothing for a non-bundle interface."""
     config = HConfig.from_text(Platform.CISCO_IOS)
     config.add_child("interface GigabitEthernet0/0")
 
     view = get_hconfig_view(config)
     interface_view = view.interface_view_by_name("GigabitEthernet0/0")
-    assert interface_view is not None
+    assert isinstance(interface_view, ConfigViewInterfaceCiscoIOS)
 
-    with pytest.raises(NotImplementedError):
-        _ = list(interface_view.bundle_member_interfaces)
+    assert not list(interface_view.bundle_member_interfaces)
+
+
+def test_is_bundle() -> None:
+    """Test is_bundle matches Port-channel interfaces case-insensitively."""
+    config = HConfig.from_text(Platform.CISCO_IOS)
+    config.add_child("interface Port-channel10")
+    config.add_child("interface GigabitEthernet0/0")
+
+    view = get_hconfig_view(config)
+    port_channel = view.interface_view_by_name("Port-channel10")
+    assert isinstance(port_channel, ConfigViewInterfaceCiscoIOS)
+    assert port_channel.is_bundle is True
+
+    ethernet = view.interface_view_by_name("GigabitEthernet0/0")
+    assert isinstance(ethernet, ConfigViewInterfaceCiscoIOS)
+    assert ethernet.is_bundle is False
+
+    assert [iv.name for iv in view.bundle_interface_views] == ["Port-channel10"]
 
 
 def test_bundle_name() -> None:
@@ -52,7 +94,7 @@ def test_bundle_name() -> None:
 
     view = get_hconfig_view(config)
     interface_view = view.interface_view_by_name("GigabitEthernet0/0")
-    assert interface_view is not None
+    assert isinstance(interface_view, ConfigViewInterfaceCiscoIOS)
     assert interface_view.bundle_name == "Port-channel5"
 
 
@@ -63,7 +105,7 @@ def test_bundle_name_none() -> None:
 
     view = get_hconfig_view(config)
     interface_view = view.interface_view_by_name("GigabitEthernet0/0")
-    assert interface_view is not None
+    assert isinstance(interface_view, ConfigViewInterfaceCiscoIOS)
     assert interface_view.bundle_name is None
 
 
@@ -75,7 +117,7 @@ def test_description() -> None:
 
     view = get_hconfig_view(config)
     interface_view = view.interface_view_by_name("GigabitEthernet0/0")
-    assert interface_view is not None
+    assert isinstance(interface_view, ConfigViewInterfaceCiscoIOS)
     assert interface_view.description == "Uplink to Core"
 
 
@@ -86,7 +128,7 @@ def test_description_empty() -> None:
 
     view = get_hconfig_view(config)
     interface_view = view.interface_view_by_name("GigabitEthernet0/0")
-    assert interface_view is not None
+    assert isinstance(interface_view, ConfigViewInterfaceCiscoIOS)
     assert not interface_view.description
 
 
@@ -97,7 +139,7 @@ def test_duplex_auto() -> None:
 
     view = get_hconfig_view(config)
     interface_view = view.interface_view_by_name("GigabitEthernet0/0")
-    assert interface_view is not None
+    assert isinstance(interface_view, ConfigViewInterfaceCiscoIOS)
     assert interface_view.duplex == InterfaceDuplex.AUTO
 
 
@@ -108,7 +150,7 @@ def test_enabled_true() -> None:
 
     view = get_hconfig_view(config)
     interface_view = view.interface_view_by_name("GigabitEthernet0/0")
-    assert interface_view is not None
+    assert isinstance(interface_view, ConfigViewInterfaceCiscoIOS)
     assert interface_view.enabled is True
 
 
@@ -120,7 +162,7 @@ def test_enabled_false() -> None:
 
     view = get_hconfig_view(config)
     interface_view = view.interface_view_by_name("GigabitEthernet0/0")
-    assert interface_view is not None
+    assert isinstance(interface_view, ConfigViewInterfaceCiscoIOS)
     assert interface_view.enabled is False
 
 
@@ -132,7 +174,7 @@ def test_has_nac_port_control() -> None:
 
     view = get_hconfig_view(config)
     interface_view = view.interface_view_by_name("GigabitEthernet0/0")
-    assert interface_view is not None
+    assert isinstance(interface_view, ConfigViewInterfaceCiscoIOS)
     assert interface_view.has_nac is True
 
 
@@ -144,7 +186,7 @@ def test_has_nac_mab() -> None:
 
     view = get_hconfig_view(config)
     interface_view = view.interface_view_by_name("GigabitEthernet0/0")
-    assert interface_view is not None
+    assert isinstance(interface_view, ConfigViewInterfaceCiscoIOS)
     assert interface_view.has_nac is True
 
 
@@ -155,7 +197,7 @@ def test_has_nac_false() -> None:
 
     view = get_hconfig_view(config)
     interface_view = view.interface_view_by_name("GigabitEthernet0/0")
-    assert interface_view is not None
+    assert isinstance(interface_view, ConfigViewInterfaceCiscoIOS)
     assert interface_view.has_nac is False
 
 
@@ -166,7 +208,7 @@ def test_ipv4_interface_none() -> None:
 
     view = get_hconfig_view(config)
     interface_view = view.interface_view_by_name("GigabitEthernet0/0")
-    assert interface_view is not None
+    assert isinstance(interface_view, ConfigViewInterfaceCiscoIOS)
     assert interface_view.ipv4_interface is None
 
 
@@ -178,7 +220,7 @@ def test_nac_control_direction_in_true() -> None:
 
     view = get_hconfig_view(config)
     interface_view = view.interface_view_by_name("GigabitEthernet0/0")
-    assert interface_view is not None
+    assert isinstance(interface_view, ConfigViewInterfaceCiscoIOS)
     assert interface_view.nac_control_direction_in is True
 
 
@@ -189,7 +231,7 @@ def test_nac_control_direction_in_false() -> None:
 
     view = get_hconfig_view(config)
     interface_view = view.interface_view_by_name("GigabitEthernet0/0")
-    assert interface_view is not None
+    assert isinstance(interface_view, ConfigViewInterfaceCiscoIOS)
     assert interface_view.nac_control_direction_in is False
 
 
@@ -201,7 +243,7 @@ def test_nac_host_mode_multi_auth() -> None:
 
     view = get_hconfig_view(config)
     interface_view = view.interface_view_by_name("GigabitEthernet0/0")
-    assert interface_view is not None
+    assert isinstance(interface_view, ConfigViewInterfaceCiscoIOS)
     assert interface_view.nac_host_mode == NACHostMode.MULTI_AUTH
 
 
@@ -213,7 +255,7 @@ def test_nac_host_mode_multi_domain() -> None:
 
     view = get_hconfig_view(config)
     interface_view = view.interface_view_by_name("GigabitEthernet0/0")
-    assert interface_view is not None
+    assert isinstance(interface_view, ConfigViewInterfaceCiscoIOS)
     assert interface_view.nac_host_mode == NACHostMode.MULTI_DOMAIN
 
 
@@ -225,7 +267,7 @@ def test_nac_host_mode_multi_host() -> None:
 
     view = get_hconfig_view(config)
     interface_view = view.interface_view_by_name("GigabitEthernet0/0")
-    assert interface_view is not None
+    assert isinstance(interface_view, ConfigViewInterfaceCiscoIOS)
     assert interface_view.nac_host_mode == NACHostMode.MULTI_HOST
 
 
@@ -237,7 +279,7 @@ def test_nac_host_mode_single_host() -> None:
 
     view = get_hconfig_view(config)
     interface_view = view.interface_view_by_name("GigabitEthernet0/0")
-    assert interface_view is not None
+    assert isinstance(interface_view, ConfigViewInterfaceCiscoIOS)
     assert interface_view.nac_host_mode == NACHostMode.SINGLE_HOST
 
 
@@ -248,7 +290,7 @@ def test_nac_host_mode_none() -> None:
 
     view = get_hconfig_view(config)
     interface_view = view.interface_view_by_name("GigabitEthernet0/0")
-    assert interface_view is not None
+    assert isinstance(interface_view, ConfigViewInterfaceCiscoIOS)
     assert interface_view.nac_host_mode is None
 
 
@@ -260,7 +302,7 @@ def test_nac_mab_first_true() -> None:
 
     view = get_hconfig_view(config)
     interface_view = view.interface_view_by_name("GigabitEthernet0/0")
-    assert interface_view is not None
+    assert isinstance(interface_view, ConfigViewInterfaceCiscoIOS)
     assert interface_view.nac_mab_first is True
 
 
@@ -271,7 +313,7 @@ def test_nac_mab_first_false() -> None:
 
     view = get_hconfig_view(config)
     interface_view = view.interface_view_by_name("GigabitEthernet0/0")
-    assert interface_view is not None
+    assert isinstance(interface_view, ConfigViewInterfaceCiscoIOS)
     assert interface_view.nac_mab_first is False
 
 
@@ -282,7 +324,7 @@ def test_nac_max_dot1x_clients_not_implemented() -> None:
 
     view = get_hconfig_view(config)
     interface_view = view.interface_view_by_name("GigabitEthernet0/0")
-    assert interface_view is not None
+    assert isinstance(interface_view, ConfigViewInterfaceCiscoIOS)
 
     with pytest.raises(NotImplementedError):
         _ = interface_view.nac_max_dot1x_clients
@@ -295,7 +337,7 @@ def test_nac_max_mab_clients_not_implemented() -> None:
 
     view = get_hconfig_view(config)
     interface_view = view.interface_view_by_name("GigabitEthernet0/0")
-    assert interface_view is not None
+    assert isinstance(interface_view, ConfigViewInterfaceCiscoIOS)
 
     with pytest.raises(NotImplementedError):
         _ = interface_view.nac_max_mab_clients
@@ -309,7 +351,7 @@ def test_native_vlan_subinterface() -> None:
 
     view = get_hconfig_view(config)
     interface_view = view.interface_view_by_name("GigabitEthernet0/0.100")
-    assert interface_view is not None
+    assert isinstance(interface_view, ConfigViewInterfaceCiscoIOS)
     assert interface_view.native_vlan == 50
 
 
@@ -321,7 +363,7 @@ def test_native_vlan_no_switchport() -> None:
 
     view = get_hconfig_view(config)
     interface_view = view.interface_view_by_name("GigabitEthernet0/0")
-    assert interface_view is not None
+    assert isinstance(interface_view, ConfigViewInterfaceCiscoIOS)
     assert interface_view.native_vlan is None
 
 
@@ -334,7 +376,7 @@ def test_native_vlan_trunk() -> None:
 
     view = get_hconfig_view(config)
     interface_view = view.interface_view_by_name("GigabitEthernet0/0")
-    assert interface_view is not None
+    assert isinstance(interface_view, ConfigViewInterfaceCiscoIOS)
     assert interface_view.native_vlan == 999
 
 
@@ -346,7 +388,7 @@ def test_native_vlan_trunk_default() -> None:
 
     view = get_hconfig_view(config)
     interface_view = view.interface_view_by_name("GigabitEthernet0/0")
-    assert interface_view is not None
+    assert isinstance(interface_view, ConfigViewInterfaceCiscoIOS)
     assert interface_view.native_vlan is None
 
 
@@ -358,7 +400,7 @@ def test_native_vlan_access() -> None:
 
     view = get_hconfig_view(config)
     interface_view = view.interface_view_by_name("GigabitEthernet0/0")
-    assert interface_view is not None
+    assert isinstance(interface_view, ConfigViewInterfaceCiscoIOS)
     assert interface_view.native_vlan == 50
 
 
@@ -369,7 +411,7 @@ def test_native_vlan_default() -> None:
 
     view = get_hconfig_view(config)
     interface_view = view.interface_view_by_name("GigabitEthernet0/0")
-    assert interface_view is not None
+    assert isinstance(interface_view, ConfigViewInterfaceCiscoIOS)
     assert interface_view.native_vlan == 1
 
 
@@ -380,7 +422,7 @@ def test_poe_true() -> None:
 
     view = get_hconfig_view(config)
     interface_view = view.interface_view_by_name("GigabitEthernet0/0")
-    assert interface_view is not None
+    assert isinstance(interface_view, ConfigViewInterfaceCiscoIOS)
     assert interface_view.poe is True
 
 
@@ -392,7 +434,7 @@ def test_poe_false() -> None:
 
     view = get_hconfig_view(config)
     interface_view = view.interface_view_by_name("GigabitEthernet0/0")
-    assert interface_view is not None
+    assert isinstance(interface_view, ConfigViewInterfaceCiscoIOS)
     assert interface_view.poe is False
 
 
@@ -404,7 +446,7 @@ def test_speed() -> None:
 
     view = get_hconfig_view(config)
     interface_view = view.interface_view_by_name("GigabitEthernet0/0")
-    assert interface_view is not None
+    assert isinstance(interface_view, ConfigViewInterfaceCiscoIOS)
     assert interface_view.speed == (1000,)
 
 
@@ -416,7 +458,7 @@ def test_tagged_all_true() -> None:
 
     view = get_hconfig_view(config)
     interface_view = view.interface_view_by_name("GigabitEthernet0/0")
-    assert interface_view is not None
+    assert isinstance(interface_view, ConfigViewInterfaceCiscoIOS)
     assert interface_view.tagged_all is True
 
 
@@ -427,7 +469,7 @@ def test_tagged_all_false() -> None:
 
     view = get_hconfig_view(config)
     interface_view = view.interface_view_by_name("GigabitEthernet0/0")
-    assert interface_view is not None
+    assert isinstance(interface_view, ConfigViewInterfaceCiscoIOS)
     assert interface_view.tagged_all is False
 
 
@@ -439,7 +481,7 @@ def test_tagged_vlans() -> None:
 
     view = get_hconfig_view(config)
     interface_view = view.interface_view_by_name("GigabitEthernet0/0")
-    assert interface_view is not None
+    assert isinstance(interface_view, ConfigViewInterfaceCiscoIOS)
     assert interface_view.tagged_vlans == (10, 20, 30, 31, 32, 33, 34, 35)
 
 
@@ -450,7 +492,7 @@ def test_tagged_vlans_empty() -> None:
 
     view = get_hconfig_view(config)
     interface_view = view.interface_view_by_name("GigabitEthernet0/0")
-    assert interface_view is not None
+    assert isinstance(interface_view, ConfigViewInterfaceCiscoIOS)
     assert interface_view.tagged_vlans == ()
 
 
@@ -462,7 +504,7 @@ def test_vrf() -> None:
 
     view = get_hconfig_view(config)
     interface_view = view.interface_view_by_name("GigabitEthernet0/0")
-    assert interface_view is not None
+    assert isinstance(interface_view, ConfigViewInterfaceCiscoIOS)
     assert interface_view.vrf == "MGMT"
 
 
@@ -473,7 +515,7 @@ def test_vrf_empty() -> None:
 
     view = get_hconfig_view(config)
     interface_view = view.interface_view_by_name("GigabitEthernet0/0")
-    assert interface_view is not None
+    assert isinstance(interface_view, ConfigViewInterfaceCiscoIOS)
     assert not interface_view.vrf
 
 

--- a/tests/unit/platforms/views/test_cisco_ios.py
+++ b/tests/unit/platforms/views/test_cisco_ios.py
@@ -4,13 +4,13 @@ from ipaddress import IPv4Address
 
 import pytest
 
-from hier_config import Platform, get_hconfig, get_hconfig_view
+from hier_config import HConfig, Platform, get_hconfig_view
 from hier_config.platforms.models import InterfaceDuplex, NACHostMode, StackMember
 
 
 def test_bundle_id() -> None:
     """Test bundle_id returns channel-group ID (covers lines 25, 29)."""
-    config = get_hconfig(Platform.CISCO_IOS)
+    config = HConfig.from_text(Platform.CISCO_IOS)
     interface = config.add_child("interface GigabitEthernet0/0")
     interface.add_child("channel-group 10 mode active")
 
@@ -22,7 +22,7 @@ def test_bundle_id() -> None:
 
 def test_bundle_id_none() -> None:
     """Test bundle_id returns None (covers line 25)."""
-    config = get_hconfig(Platform.CISCO_IOS)
+    config = HConfig.from_text(Platform.CISCO_IOS)
     config.add_child("interface GigabitEthernet0/0")
 
     view = get_hconfig_view(config)
@@ -33,7 +33,7 @@ def test_bundle_id_none() -> None:
 
 def test_bundle_member_interfaces_not_implemented() -> None:
     """Test bundle_member_interfaces raises NotImplementedError (covers line 29)."""
-    config = get_hconfig(Platform.CISCO_IOS)
+    config = HConfig.from_text(Platform.CISCO_IOS)
     config.add_child("interface GigabitEthernet0/0")
 
     view = get_hconfig_view(config)
@@ -46,7 +46,7 @@ def test_bundle_member_interfaces_not_implemented() -> None:
 
 def test_bundle_name() -> None:
     """Test bundle_name returns formatted name (covers lines 35, 39-41)."""
-    config = get_hconfig(Platform.CISCO_IOS)
+    config = HConfig.from_text(Platform.CISCO_IOS)
     interface = config.add_child("interface GigabitEthernet0/0")
     interface.add_child("channel-group 5 mode active")
 
@@ -58,7 +58,7 @@ def test_bundle_name() -> None:
 
 def test_bundle_name_none() -> None:
     """Test bundle_name returns None (covers line 35)."""
-    config = get_hconfig(Platform.CISCO_IOS)
+    config = HConfig.from_text(Platform.CISCO_IOS)
     config.add_child("interface GigabitEthernet0/0")
 
     view = get_hconfig_view(config)
@@ -69,7 +69,7 @@ def test_bundle_name_none() -> None:
 
 def test_description() -> None:
     """Test description returns description text (covers lines 45-47)."""
-    config = get_hconfig(Platform.CISCO_IOS)
+    config = HConfig.from_text(Platform.CISCO_IOS)
     interface = config.add_child("interface GigabitEthernet0/0")
     interface.add_child("description Uplink to Core")
 
@@ -81,7 +81,7 @@ def test_description() -> None:
 
 def test_description_empty() -> None:
     """Test description returns empty string (covers line 47)."""
-    config = get_hconfig(Platform.CISCO_IOS)
+    config = HConfig.from_text(Platform.CISCO_IOS)
     config.add_child("interface GigabitEthernet0/0")
 
     view = get_hconfig_view(config)
@@ -92,7 +92,7 @@ def test_description_empty() -> None:
 
 def test_duplex_auto() -> None:
     """Test duplex returns auto (covers line 51)."""
-    config = get_hconfig(Platform.CISCO_IOS)
+    config = HConfig.from_text(Platform.CISCO_IOS)
     config.add_child("interface GigabitEthernet0/0")
 
     view = get_hconfig_view(config)
@@ -103,7 +103,7 @@ def test_duplex_auto() -> None:
 
 def test_enabled_true() -> None:
     """Test enabled returns True (covers line 55)."""
-    config = get_hconfig(Platform.CISCO_IOS)
+    config = HConfig.from_text(Platform.CISCO_IOS)
     config.add_child("interface GigabitEthernet0/0")
 
     view = get_hconfig_view(config)
@@ -114,7 +114,7 @@ def test_enabled_true() -> None:
 
 def test_enabled_false() -> None:
     """Test enabled returns False when shutdown (covers line 55)."""
-    config = get_hconfig(Platform.CISCO_IOS)
+    config = HConfig.from_text(Platform.CISCO_IOS)
     interface = config.add_child("interface GigabitEthernet0/0")
     interface.add_child("shutdown")
 
@@ -126,7 +126,7 @@ def test_enabled_false() -> None:
 
 def test_has_nac_port_control() -> None:
     """Test has_nac with port-control (covers line 70)."""
-    config = get_hconfig(Platform.CISCO_IOS)
+    config = HConfig.from_text(Platform.CISCO_IOS)
     interface = config.add_child("interface GigabitEthernet0/0")
     interface.add_child("authentication port-control auto")
 
@@ -138,7 +138,7 @@ def test_has_nac_port_control() -> None:
 
 def test_has_nac_mab() -> None:
     """Test has_nac with mab (covers line 70)."""
-    config = get_hconfig(Platform.CISCO_IOS)
+    config = HConfig.from_text(Platform.CISCO_IOS)
     interface = config.add_child("interface GigabitEthernet0/0")
     interface.add_child("mab")
 
@@ -150,7 +150,7 @@ def test_has_nac_mab() -> None:
 
 def test_has_nac_false() -> None:
     """Test has_nac returns False (covers lines 70-74)."""
-    config = get_hconfig(Platform.CISCO_IOS)
+    config = HConfig.from_text(Platform.CISCO_IOS)
     config.add_child("interface GigabitEthernet0/0")
 
     view = get_hconfig_view(config)
@@ -161,7 +161,7 @@ def test_has_nac_false() -> None:
 
 def test_ipv4_interface_none() -> None:
     """Test ipv4_interface returns None (covers line 78)."""
-    config = get_hconfig(Platform.CISCO_IOS)
+    config = HConfig.from_text(Platform.CISCO_IOS)
     config.add_child("interface GigabitEthernet0/0")
 
     view = get_hconfig_view(config)
@@ -172,7 +172,7 @@ def test_ipv4_interface_none() -> None:
 
 def test_nac_control_direction_in_true() -> None:
     """Test nac_control_direction_in returns True (covers line 102)."""
-    config = get_hconfig(Platform.CISCO_IOS)
+    config = HConfig.from_text(Platform.CISCO_IOS)
     interface = config.add_child("interface GigabitEthernet0/0")
     interface.add_child("authentication control-direction in")
 
@@ -184,7 +184,7 @@ def test_nac_control_direction_in_true() -> None:
 
 def test_nac_control_direction_in_false() -> None:
     """Test nac_control_direction_in returns False (covers line 102)."""
-    config = get_hconfig(Platform.CISCO_IOS)
+    config = HConfig.from_text(Platform.CISCO_IOS)
     config.add_child("interface GigabitEthernet0/0")
 
     view = get_hconfig_view(config)
@@ -195,7 +195,7 @@ def test_nac_control_direction_in_false() -> None:
 
 def test_nac_host_mode_multi_auth() -> None:
     """Test nac_host_mode returns MULTI_AUTH (covers lines 107-122)."""
-    config = get_hconfig(Platform.CISCO_IOS)
+    config = HConfig.from_text(Platform.CISCO_IOS)
     interface = config.add_child("interface GigabitEthernet0/0")
     interface.add_child("authentication host-mode multi-auth")
 
@@ -207,7 +207,7 @@ def test_nac_host_mode_multi_auth() -> None:
 
 def test_nac_host_mode_multi_domain() -> None:
     """Test nac_host_mode returns MULTI_DOMAIN (covers lines 107-122)."""
-    config = get_hconfig(Platform.CISCO_IOS)
+    config = HConfig.from_text(Platform.CISCO_IOS)
     interface = config.add_child("interface GigabitEthernet0/0")
     interface.add_child("authentication host-mode multi-domain")
 
@@ -219,7 +219,7 @@ def test_nac_host_mode_multi_domain() -> None:
 
 def test_nac_host_mode_multi_host() -> None:
     """Test nac_host_mode returns MULTI_HOST (covers lines 107-122)."""
-    config = get_hconfig(Platform.CISCO_IOS)
+    config = HConfig.from_text(Platform.CISCO_IOS)
     interface = config.add_child("interface GigabitEthernet0/0")
     interface.add_child("authentication host-mode multi-host")
 
@@ -231,7 +231,7 @@ def test_nac_host_mode_multi_host() -> None:
 
 def test_nac_host_mode_single_host() -> None:
     """Test nac_host_mode returns SINGLE_HOST (covers lines 107-122)."""
-    config = get_hconfig(Platform.CISCO_IOS)
+    config = HConfig.from_text(Platform.CISCO_IOS)
     interface = config.add_child("interface GigabitEthernet0/0")
     interface.add_child("authentication host-mode single-host")
 
@@ -243,7 +243,7 @@ def test_nac_host_mode_single_host() -> None:
 
 def test_nac_host_mode_none() -> None:
     """Test nac_host_mode returns None (covers lines 107-122)."""
-    config = get_hconfig(Platform.CISCO_IOS)
+    config = HConfig.from_text(Platform.CISCO_IOS)
     config.add_child("interface GigabitEthernet0/0")
 
     view = get_hconfig_view(config)
@@ -254,7 +254,7 @@ def test_nac_host_mode_none() -> None:
 
 def test_nac_mab_first_true() -> None:
     """Test nac_mab_first returns True (covers line 127)."""
-    config = get_hconfig(Platform.CISCO_IOS)
+    config = HConfig.from_text(Platform.CISCO_IOS)
     interface = config.add_child("interface GigabitEthernet0/0")
     interface.add_child("authentication order mab dot1x")
 
@@ -266,7 +266,7 @@ def test_nac_mab_first_true() -> None:
 
 def test_nac_mab_first_false() -> None:
     """Test nac_mab_first returns False (covers line 127)."""
-    config = get_hconfig(Platform.CISCO_IOS)
+    config = HConfig.from_text(Platform.CISCO_IOS)
     config.add_child("interface GigabitEthernet0/0")
 
     view = get_hconfig_view(config)
@@ -277,7 +277,7 @@ def test_nac_mab_first_false() -> None:
 
 def test_nac_max_dot1x_clients_not_implemented() -> None:
     """Test nac_max_dot1x_clients raises NotImplementedError (covers line 132)."""
-    config = get_hconfig(Platform.CISCO_IOS)
+    config = HConfig.from_text(Platform.CISCO_IOS)
     config.add_child("interface GigabitEthernet0/0")
 
     view = get_hconfig_view(config)
@@ -290,7 +290,7 @@ def test_nac_max_dot1x_clients_not_implemented() -> None:
 
 def test_nac_max_mab_clients_not_implemented() -> None:
     """Test nac_max_mab_clients raises NotImplementedError (covers line 137)."""
-    config = get_hconfig(Platform.CISCO_IOS)
+    config = HConfig.from_text(Platform.CISCO_IOS)
     config.add_child("interface GigabitEthernet0/0")
 
     view = get_hconfig_view(config)
@@ -303,7 +303,7 @@ def test_nac_max_mab_clients_not_implemented() -> None:
 
 def test_native_vlan_subinterface() -> None:
     """Test native_vlan from subinterface encapsulation (covers lines 149, 162-167)."""
-    config = get_hconfig(Platform.CISCO_IOS)
+    config = HConfig.from_text(Platform.CISCO_IOS)
     interface = config.add_child("interface GigabitEthernet0/0.100")
     interface.add_child("encapsulation dot1Q 50")
 
@@ -315,7 +315,7 @@ def test_native_vlan_subinterface() -> None:
 
 def test_native_vlan_no_switchport() -> None:
     """Test native_vlan returns None for routed port (covers lines 149, 162-167)."""
-    config = get_hconfig(Platform.CISCO_IOS)
+    config = HConfig.from_text(Platform.CISCO_IOS)
     interface = config.add_child("interface GigabitEthernet0/0")
     interface.add_child("no switchport")
 
@@ -327,7 +327,7 @@ def test_native_vlan_no_switchport() -> None:
 
 def test_native_vlan_trunk() -> None:
     """Test native_vlan on trunk port (covers lines 171, 182-184)."""
-    config = get_hconfig(Platform.CISCO_IOS)
+    config = HConfig.from_text(Platform.CISCO_IOS)
     interface = config.add_child("interface GigabitEthernet0/0")
     interface.add_child("switchport mode trunk")
     interface.add_child("switchport trunk native vlan 999")
@@ -340,7 +340,7 @@ def test_native_vlan_trunk() -> None:
 
 def test_native_vlan_trunk_default() -> None:
     """Test native_vlan on trunk without explicit native (covers lines 171, 182-184)."""
-    config = get_hconfig(Platform.CISCO_IOS)
+    config = HConfig.from_text(Platform.CISCO_IOS)
     interface = config.add_child("interface GigabitEthernet0/0")
     interface.add_child("switchport mode trunk")
 
@@ -352,7 +352,7 @@ def test_native_vlan_trunk_default() -> None:
 
 def test_native_vlan_access() -> None:
     """Test native_vlan on access port (covers line 188)."""
-    config = get_hconfig(Platform.CISCO_IOS)
+    config = HConfig.from_text(Platform.CISCO_IOS)
     interface = config.add_child("interface GigabitEthernet0/0")
     interface.add_child("switchport access vlan 50")
 
@@ -364,7 +364,7 @@ def test_native_vlan_access() -> None:
 
 def test_native_vlan_default() -> None:
     """Test native_vlan defaults to 1 (covers line 192)."""
-    config = get_hconfig(Platform.CISCO_IOS)
+    config = HConfig.from_text(Platform.CISCO_IOS)
     config.add_child("interface GigabitEthernet0/0")
 
     view = get_hconfig_view(config)
@@ -375,7 +375,7 @@ def test_native_vlan_default() -> None:
 
 def test_poe_true() -> None:
     """Test poe returns True (covers line 196)."""
-    config = get_hconfig(Platform.CISCO_IOS)
+    config = HConfig.from_text(Platform.CISCO_IOS)
     config.add_child("interface GigabitEthernet0/0")
 
     view = get_hconfig_view(config)
@@ -386,7 +386,7 @@ def test_poe_true() -> None:
 
 def test_poe_false() -> None:
     """Test poe returns False (covers lines 196-200)."""
-    config = get_hconfig(Platform.CISCO_IOS)
+    config = HConfig.from_text(Platform.CISCO_IOS)
     interface = config.add_child("interface GigabitEthernet0/0")
     interface.add_child("power inline never")
 
@@ -398,7 +398,7 @@ def test_poe_false() -> None:
 
 def test_speed() -> None:
     """Test speed returns speed value (covers line 204)."""
-    config = get_hconfig(Platform.CISCO_IOS)
+    config = HConfig.from_text(Platform.CISCO_IOS)
     interface = config.add_child("interface GigabitEthernet0/0")
     interface.add_child("speed 1000")
 
@@ -410,7 +410,7 @@ def test_speed() -> None:
 
 def test_tagged_all_true() -> None:
     """Test tagged_all returns True (covers line 223)."""
-    config = get_hconfig(Platform.CISCO_IOS)
+    config = HConfig.from_text(Platform.CISCO_IOS)
     interface = config.add_child("interface GigabitEthernet0/0")
     interface.add_child("switchport mode trunk")
 
@@ -422,7 +422,7 @@ def test_tagged_all_true() -> None:
 
 def test_tagged_all_false() -> None:
     """Test tagged_all returns False (covers lines 223-225)."""
-    config = get_hconfig(Platform.CISCO_IOS)
+    config = HConfig.from_text(Platform.CISCO_IOS)
     config.add_child("interface GigabitEthernet0/0")
 
     view = get_hconfig_view(config)
@@ -433,7 +433,7 @@ def test_tagged_all_false() -> None:
 
 def test_tagged_vlans() -> None:
     """Test tagged_vlans returns VLAN list (covers line 240)."""
-    config = get_hconfig(Platform.CISCO_IOS)
+    config = HConfig.from_text(Platform.CISCO_IOS)
     interface = config.add_child("interface GigabitEthernet0/0")
     interface.add_child("switchport trunk allowed vlan 10,20,30-35")
 
@@ -445,7 +445,7 @@ def test_tagged_vlans() -> None:
 
 def test_tagged_vlans_empty() -> None:
     """Test tagged_vlans returns empty tuple (covers lines 240, 244-246)."""
-    config = get_hconfig(Platform.CISCO_IOS)
+    config = HConfig.from_text(Platform.CISCO_IOS)
     config.add_child("interface GigabitEthernet0/0")
 
     view = get_hconfig_view(config)
@@ -456,7 +456,7 @@ def test_tagged_vlans_empty() -> None:
 
 def test_vrf() -> None:
     """Test vrf returns VRF name (covers line 251)."""
-    config = get_hconfig(Platform.CISCO_IOS)
+    config = HConfig.from_text(Platform.CISCO_IOS)
     interface = config.add_child("interface GigabitEthernet0/0")
     interface.add_child("ip vrf forwarding MGMT")
 
@@ -468,7 +468,7 @@ def test_vrf() -> None:
 
 def test_vrf_empty() -> None:
     """Test vrf returns empty string (covers line 251)."""
-    config = get_hconfig(Platform.CISCO_IOS)
+    config = HConfig.from_text(Platform.CISCO_IOS)
     config.add_child("interface GigabitEthernet0/0")
 
     view = get_hconfig_view(config)
@@ -479,7 +479,7 @@ def test_vrf_empty() -> None:
 
 def test_hostname() -> None:
     """Test hostname returns hostname (covers lines 270-272)."""
-    config = get_hconfig(Platform.CISCO_IOS)
+    config = HConfig.from_text(Platform.CISCO_IOS)
     config.add_child("hostname ROUTER-01")
 
     view = get_hconfig_view(config)
@@ -488,7 +488,7 @@ def test_hostname() -> None:
 
 def test_hostname_none() -> None:
     """Test hostname returns None (covers line 272)."""
-    config = get_hconfig(Platform.CISCO_IOS)
+    config = HConfig.from_text(Platform.CISCO_IOS)
 
     view = get_hconfig_view(config)
     assert view.hostname is None
@@ -496,7 +496,7 @@ def test_hostname_none() -> None:
 
 def test_interface_names_mentioned() -> None:
     """Test interface_names_mentioned returns interface names (covers line 283)."""
-    config = get_hconfig(Platform.CISCO_IOS)
+    config = HConfig.from_text(Platform.CISCO_IOS)
     config.add_child("interface GigabitEthernet0/0")
     config.add_child("interface GigabitEthernet0/1")
 
@@ -509,7 +509,7 @@ def test_interface_names_mentioned() -> None:
 
 def test_ipv4_default_gw() -> None:
     """Test ipv4_default_gw returns gateway IP (covers lines 283-286)."""
-    config = get_hconfig(Platform.CISCO_IOS)
+    config = HConfig.from_text(Platform.CISCO_IOS)
     config.add_child("ip default-gateway 192.168.1.1")
 
     view = get_hconfig_view(config)
@@ -518,7 +518,7 @@ def test_ipv4_default_gw() -> None:
 
 def test_ipv4_default_gw_none() -> None:
     """Test ipv4_default_gw returns None (covers line 286)."""
-    config = get_hconfig(Platform.CISCO_IOS)
+    config = HConfig.from_text(Platform.CISCO_IOS)
 
     view = get_hconfig_view(config)
     assert view.ipv4_default_gw is None
@@ -526,7 +526,7 @@ def test_ipv4_default_gw_none() -> None:
 
 def test_location() -> None:
     """Test location returns location string (covers lines 301-302)."""
-    config = get_hconfig(Platform.CISCO_IOS)
+    config = HConfig.from_text(Platform.CISCO_IOS)
     config.add_child('snmp-server location "Building A, Floor 2"')
 
     view = get_hconfig_view(config)
@@ -535,7 +535,7 @@ def test_location() -> None:
 
 def test_location_empty() -> None:
     """Test location returns empty string (covers line 302)."""
-    config = get_hconfig(Platform.CISCO_IOS)
+    config = HConfig.from_text(Platform.CISCO_IOS)
 
     view = get_hconfig_view(config)
     assert not view.location
@@ -543,7 +543,7 @@ def test_location_empty() -> None:
 
 def test_stack_members() -> None:
     """Test stack_members yields stack members (covers lines 312-316)."""
-    config = get_hconfig(Platform.CISCO_IOS)
+    config = HConfig.from_text(Platform.CISCO_IOS)
     config.add_child("switch 1 provision ws-c3850-24p")
     config.add_child("switch 2 provision ws-c3850-24p")
 
@@ -561,7 +561,7 @@ def test_stack_members() -> None:
 
 def test_vlans_explicit() -> None:
     """Test vlans yields explicitly defined VLANs (covers lines 264-266)."""
-    config = get_hconfig(Platform.CISCO_IOS)
+    config = HConfig.from_text(Platform.CISCO_IOS)
     vlan10 = config.add_child("vlan 10")
     vlan10.add_child("name Data")
     vlan20 = config.add_child("vlan 20")
@@ -577,7 +577,7 @@ def test_vlans_explicit() -> None:
 
 def test_vlans_from_interfaces() -> None:
     """Test vlans includes VLANs from interfaces (covers lines 264-266)."""
-    config = get_hconfig(Platform.CISCO_IOS)
+    config = HConfig.from_text(Platform.CISCO_IOS)
     interface = config.add_child("interface GigabitEthernet0/0")
     interface.add_child("switchport access vlan 100")
 

--- a/tests/unit/platforms/views/test_cisco_ios.py
+++ b/tests/unit/platforms/views/test_cisco_ios.py
@@ -627,3 +627,12 @@ def test_vlans_from_interfaces() -> None:
     vlans = list(view.vlans)
 
     assert any(v.id == 100 for v in vlans)
+
+
+def test_port_number_on_bundle_interface() -> None:
+    """port_number must not crash on slash-less names like Port-channel10 (#278 review)."""
+    config = HConfig.from_text(Platform.CISCO_IOS, "interface Port-channel10\n")
+    view = get_hconfig_view(config)
+    interface_view = view.interface_view_by_name("Port-channel10")
+    assert interface_view is not None
+    assert interface_view.port_number == 10

--- a/tests/unit/platforms/views/test_cisco_nxos.py
+++ b/tests/unit/platforms/views/test_cisco_nxos.py
@@ -1,507 +1,336 @@
 """Tests for Cisco NX-OS view.py ConfigViewInterfaceCiscoNXOS and HConfigViewCiscoNXOS classes."""
 
-from ipaddress import IPv4Interface
+from ipaddress import IPv4Address, IPv4Interface
 
-import pytest
-
-from hier_config import HConfig, Platform, get_hconfig_view
-
-
-def test_bundle_id_not_implemented() -> None:
-    """Test bundle_id raises NotImplementedError (covers line 22)."""
-    config = HConfig.from_text(Platform.CISCO_NXOS)
-    config.add_child("interface port-channel1")
-
-    view = get_hconfig_view(config)
-    interface_view = view.interface_view_by_name("port-channel1")
-    assert interface_view is not None
-
-    with pytest.raises(NotImplementedError):
-        _ = interface_view.bundle_id
+from hier_config import (
+    HConfig,
+    InterfaceBundleViewMixin,
+    InterfaceNACViewMixin,
+    InterfacePhysicalViewMixin,
+    InterfaceVlanViewMixin,
+    Platform,
+    get_hconfig_view,
+)
+from hier_config.platforms.cisco_nxos.view import ConfigViewInterfaceCiscoNXOS
+from hier_config.platforms.models import InterfaceDot1qMode, Vlan
 
 
-def test_bundle_member_interfaces_not_implemented() -> None:
-    """Test bundle_member_interfaces raises NotImplementedError (covers line 26)."""
-    config = HConfig.from_text(Platform.CISCO_NXOS)
-    config.add_child("interface Ethernet1/1")
-
-    view = get_hconfig_view(config)
-    interface_view = view.interface_view_by_name("Ethernet1/1")
-    assert interface_view is not None
-
-    with pytest.raises(NotImplementedError):
-        _ = list(interface_view.bundle_member_interfaces)
+def _interface_view(
+    config: HConfig, name: str = "Ethernet1/1"
+) -> ConfigViewInterfaceCiscoNXOS:
+    interface_view = get_hconfig_view(config).interface_view_by_name(name)
+    assert isinstance(interface_view, ConfigViewInterfaceCiscoNXOS)
+    return interface_view
 
 
-def test_bundle_name_not_implemented() -> None:
-    """Test bundle_name raises NotImplementedError (covers line 30)."""
+def test_capabilities() -> None:
+    """NX-OS interface views support bundles and VLANs but not NAC or physical."""
     config = HConfig.from_text(Platform.CISCO_NXOS)
     config.add_child("interface Ethernet1/1")
 
-    view = get_hconfig_view(config)
-    interface_view = view.interface_view_by_name("Ethernet1/1")
-    assert interface_view is not None
+    interface_view = _interface_view(config)
+    assert isinstance(interface_view, InterfaceBundleViewMixin)
+    assert isinstance(interface_view, InterfaceVlanViewMixin)
+    assert not isinstance(interface_view, InterfaceNACViewMixin)
+    assert not isinstance(interface_view, InterfacePhysicalViewMixin)
 
-    with pytest.raises(NotImplementedError):
-        _ = interface_view.bundle_name
+
+def test_bundle_id() -> None:
+    config = HConfig.from_text(Platform.CISCO_NXOS)
+    config.add_children_deep(("interface Ethernet1/1", "channel-group 10 mode active"))
+
+    assert _interface_view(config).bundle_id == "10"
+
+
+def test_bundle_id_none() -> None:
+    config = HConfig.from_text(Platform.CISCO_NXOS)
+    config.add_child("interface Ethernet1/1")
+
+    assert _interface_view(config).bundle_id is None
+
+
+def test_bundle_name() -> None:
+    config = HConfig.from_text(Platform.CISCO_NXOS)
+    config.add_children_deep(("interface Ethernet1/1", "channel-group 10 mode active"))
+
+    assert _interface_view(config).bundle_name == "port-channel10"
+
+
+def test_bundle_member_interfaces() -> None:
+    config = HConfig.from_text(Platform.CISCO_NXOS)
+    config.add_child("interface port-channel10")
+    config.add_children_deep(("interface Ethernet1/1", "channel-group 10 mode active"))
+    config.add_children_deep(("interface Ethernet1/2", "channel-group 10 mode active"))
+    config.add_children_deep(("interface Ethernet1/3", "channel-group 20 mode active"))
+
+    interface_view = _interface_view(config, "port-channel10")
+    assert list(interface_view.bundle_member_interfaces) == [
+        "Ethernet1/1",
+        "Ethernet1/2",
+    ]
+
+
+def test_bundle_member_interfaces_not_a_bundle() -> None:
+    config = HConfig.from_text(Platform.CISCO_NXOS)
+    config.add_child("interface Ethernet1/1")
+
+    assert not list(_interface_view(config).bundle_member_interfaces)
 
 
 def test_description() -> None:
-    """Test description returns description text (covers lines 34-36)."""
+    """Test description returns description text."""
     config = HConfig.from_text(Platform.CISCO_NXOS)
     interface = config.add_child("interface Ethernet1/1")
     interface.add_child("description Uplink to Core")
 
-    view = get_hconfig_view(config)
-    interface_view = view.interface_view_by_name("Ethernet1/1")
-    assert interface_view is not None
-    assert interface_view.description == "Uplink to Core"
+    assert _interface_view(config).description == "Uplink to Core"
 
 
 def test_description_empty() -> None:
-    """Test description returns empty string (covers line 36)."""
+    """Test description returns empty string."""
     config = HConfig.from_text(Platform.CISCO_NXOS)
     config.add_child("interface Ethernet1/1")
 
-    view = get_hconfig_view(config)
-    interface_view = view.interface_view_by_name("Ethernet1/1")
-    assert interface_view is not None
-    assert not interface_view.description
+    assert not _interface_view(config).description
 
 
-def test_duplex_not_implemented() -> None:
-    """Test duplex raises NotImplementedError (covers line 40)."""
+def test_enabled() -> None:
     config = HConfig.from_text(Platform.CISCO_NXOS)
     config.add_child("interface Ethernet1/1")
+    config.add_children_deep(("interface Ethernet1/2", "shutdown"))
 
-    view = get_hconfig_view(config)
-    interface_view = view.interface_view_by_name("Ethernet1/1")
-    assert interface_view is not None
-
-    with pytest.raises(NotImplementedError):
-        _ = interface_view.duplex
-
-
-def test_enabled_not_implemented() -> None:
-    """Test enabled raises NotImplementedError (covers line 44)."""
-    config = HConfig.from_text(Platform.CISCO_NXOS)
-    config.add_child("interface Ethernet1/1")
-
-    view = get_hconfig_view(config)
-    interface_view = view.interface_view_by_name("Ethernet1/1")
-    assert interface_view is not None
-
-    with pytest.raises(NotImplementedError):
-        _ = interface_view.enabled
-
-
-def test_has_nac_not_implemented() -> None:
-    """Test has_nac raises NotImplementedError (covers line 49)."""
-    config = HConfig.from_text(Platform.CISCO_NXOS)
-    config.add_child("interface Ethernet1/1")
-
-    view = get_hconfig_view(config)
-    interface_view = view.interface_view_by_name("Ethernet1/1")
-    assert interface_view is not None
-
-    with pytest.raises(NotImplementedError):
-        _ = interface_view.has_nac
+    assert _interface_view(config).enabled is True
+    assert _interface_view(config, "Ethernet1/2").enabled is False
 
 
 def test_ipv4_interface_none() -> None:
-    """Test ipv4_interface returns None (covers line 53)."""
+    """Test ipv4_interface returns None."""
     config = HConfig.from_text(Platform.CISCO_NXOS)
     config.add_child("interface Ethernet1/1")
 
-    view = get_hconfig_view(config)
-    interface_view = view.interface_view_by_name("Ethernet1/1")
-    assert interface_view is not None
-    assert interface_view.ipv4_interface is None
+    assert _interface_view(config).ipv4_interface is None
 
 
 def test_ipv4_interfaces() -> None:
-    """Test ipv4_interfaces returns IP addresses (covers lines 57-62)."""
+    """Test ipv4_interfaces returns IP addresses."""
     config = HConfig.from_text(Platform.CISCO_NXOS)
     interface = config.add_child("interface Ethernet1/1")
     interface.add_child("ip address 10.1.1.1 255.255.255.0")
 
-    view = get_hconfig_view(config)
-    interface_view = view.interface_view_by_name("Ethernet1/1")
-    assert interface_view is not None
+    assert list(_interface_view(config).ipv4_interfaces) == [
+        IPv4Interface("10.1.1.1/24")
+    ]
 
-    ips = list(interface_view.ipv4_interfaces)
-    assert len(ips) == 1
-    assert ips[0] == IPv4Interface("10.1.1.1/24")
+
+def test_ipv4_interfaces_cidr() -> None:
+    """Test ipv4_interfaces supports NX-OS address/prefix syntax."""
+    config = HConfig.from_text(Platform.CISCO_NXOS)
+    config.add_children_deep(("interface Ethernet1/1", "ip address 10.1.1.1/24"))
+
+    assert _interface_view(config).ipv4_interface == IPv4Interface("10.1.1.1/24")
 
 
 def test_ipv4_interfaces_invalid() -> None:
-    """Test ipv4_interfaces skips invalid addresses (covers line 62)."""
+    """Test ipv4_interfaces skips invalid addresses."""
     config = HConfig.from_text(Platform.CISCO_NXOS)
     interface = config.add_child("interface Ethernet1/1")
     interface.add_child("ip address dhcp")
 
-    view = get_hconfig_view(config)
-    interface_view = view.interface_view_by_name("Ethernet1/1")
-    assert interface_view is not None
-
-    ips = list(interface_view.ipv4_interfaces)
-    assert len(ips) == 0
+    assert not list(_interface_view(config).ipv4_interfaces)
 
 
 def test_is_bundle_true() -> None:
-    """Test is_bundle returns True (covers line 66)."""
+    """Test is_bundle returns True."""
     config = HConfig.from_text(Platform.CISCO_NXOS)
     config.add_child("interface port-channel10")
 
-    view = get_hconfig_view(config)
-    interface_view = view.interface_view_by_name("port-channel10")
-    assert interface_view is not None
-    assert interface_view.is_bundle is True
+    assert _interface_view(config, "port-channel10").is_bundle is True
 
 
 def test_is_bundle_false() -> None:
-    """Test is_bundle returns False (covers line 66)."""
+    """Test is_bundle returns False."""
     config = HConfig.from_text(Platform.CISCO_NXOS)
     config.add_child("interface Ethernet1/1")
 
-    view = get_hconfig_view(config)
-    interface_view = view.interface_view_by_name("Ethernet1/1")
-    assert interface_view is not None
-    assert interface_view.is_bundle is False
+    assert _interface_view(config).is_bundle is False
 
 
-def test_is_loopback_true() -> None:
-    """Test is_loopback returns True (covers line 70)."""
+def test_is_loopback() -> None:
     config = HConfig.from_text(Platform.CISCO_NXOS)
     config.add_child("interface loopback0")
-
-    view = get_hconfig_view(config)
-    interface_view = view.interface_view_by_name("loopback0")
-    assert interface_view is not None
-    assert interface_view.is_loopback is True
-
-
-def test_is_loopback_false() -> None:
-    """Test is_loopback returns False (covers line 70)."""
-    config = HConfig.from_text(Platform.CISCO_NXOS)
     config.add_child("interface Ethernet1/1")
 
-    view = get_hconfig_view(config)
-    interface_view = view.interface_view_by_name("Ethernet1/1")
-    assert interface_view is not None
-    assert interface_view.is_loopback is False
+    assert _interface_view(config, "loopback0").is_loopback is True
+    assert _interface_view(config).is_loopback is False
 
 
-def test_is_subinterface_true() -> None:
-    """Test is_subinterface returns True (covers line 74)."""
+def test_is_subinterface() -> None:
     config = HConfig.from_text(Platform.CISCO_NXOS)
     config.add_child("interface Ethernet1/1.100")
-
-    view = get_hconfig_view(config)
-    interface_view = view.interface_view_by_name("Ethernet1/1.100")
-    assert interface_view is not None
-    assert interface_view.is_subinterface is True
-
-
-def test_is_subinterface_false() -> None:
-    """Test is_subinterface returns False (covers line 74)."""
-    config = HConfig.from_text(Platform.CISCO_NXOS)
     config.add_child("interface Ethernet1/1")
 
-    view = get_hconfig_view(config)
-    interface_view = view.interface_view_by_name("Ethernet1/1")
-    assert interface_view is not None
-    assert interface_view.is_subinterface is False
+    assert _interface_view(config, "Ethernet1/1.100").is_subinterface is True
+    assert _interface_view(config).is_subinterface is False
 
 
-def test_is_svi_true() -> None:
-    """Test is_svi returns True (covers line 78)."""
+def test_is_svi() -> None:
     config = HConfig.from_text(Platform.CISCO_NXOS)
     config.add_child("interface vlan100")
-
-    view = get_hconfig_view(config)
-    interface_view = view.interface_view_by_name("vlan100")
-    assert interface_view is not None
-    assert interface_view.is_svi is True
-
-
-def test_is_svi_false() -> None:
-    """Test is_svi returns False (covers line 78)."""
-    config = HConfig.from_text(Platform.CISCO_NXOS)
     config.add_child("interface Ethernet1/1")
 
-    view = get_hconfig_view(config)
-    interface_view = view.interface_view_by_name("Ethernet1/1")
-    assert interface_view is not None
-    assert interface_view.is_svi is False
-
-
-def test_module_number() -> None:
-    """Test module_number returns module (covers lines 82-85)."""
-    config = HConfig.from_text(Platform.CISCO_NXOS)
-    config.add_child("interface Ethernet2/15")
-
-    view = get_hconfig_view(config)
-    interface_view = view.interface_view_by_name("Ethernet2/15")
-    assert interface_view is not None
-    assert interface_view.module_number == 2
-
-
-def test_module_number_none() -> None:
-    """Test module_number returns None (covers lines 84-85)."""
-    config = HConfig.from_text(Platform.CISCO_NXOS)
-    config.add_child("interface loopback0")
-
-    view = get_hconfig_view(config)
-    interface_view = view.interface_view_by_name("loopback0")
-    assert interface_view is not None
-    assert interface_view.module_number is None
-
-
-def test_nac_control_direction_in_not_implemented() -> None:
-    """Test nac_control_direction_in raises NotImplementedError (covers line 90)."""
-    config = HConfig.from_text(Platform.CISCO_NXOS)
-    config.add_child("interface Ethernet1/1")
-
-    view = get_hconfig_view(config)
-    interface_view = view.interface_view_by_name("Ethernet1/1")
-    assert interface_view is not None
-
-    with pytest.raises(NotImplementedError):
-        _ = interface_view.nac_control_direction_in
-
-
-def test_nac_host_mode_not_implemented() -> None:
-    """Test nac_host_mode raises NotImplementedError (covers line 95)."""
-    config = HConfig.from_text(Platform.CISCO_NXOS)
-    config.add_child("interface Ethernet1/1")
-
-    view = get_hconfig_view(config)
-    interface_view = view.interface_view_by_name("Ethernet1/1")
-    assert interface_view is not None
-
-    with pytest.raises(NotImplementedError):
-        _ = interface_view.nac_host_mode
-
-
-def test_nac_mab_first_not_implemented() -> None:
-    """Test nac_mab_first raises NotImplementedError (covers line 100)."""
-    config = HConfig.from_text(Platform.CISCO_NXOS)
-    config.add_child("interface Ethernet1/1")
-
-    view = get_hconfig_view(config)
-    interface_view = view.interface_view_by_name("Ethernet1/1")
-    assert interface_view is not None
-
-    with pytest.raises(NotImplementedError):
-        _ = interface_view.nac_mab_first
-
-
-def test_nac_max_dot1x_clients_not_implemented() -> None:
-    """Test nac_max_dot1x_clients raises NotImplementedError (covers line 105)."""
-    config = HConfig.from_text(Platform.CISCO_NXOS)
-    config.add_child("interface Ethernet1/1")
-
-    view = get_hconfig_view(config)
-    interface_view = view.interface_view_by_name("Ethernet1/1")
-    assert interface_view is not None
-
-    with pytest.raises(NotImplementedError):
-        _ = interface_view.nac_max_dot1x_clients
-
-
-def test_nac_max_mab_clients_not_implemented() -> None:
-    """Test nac_max_mab_clients raises NotImplementedError (covers line 110)."""
-    config = HConfig.from_text(Platform.CISCO_NXOS)
-    config.add_child("interface Ethernet1/1")
-
-    view = get_hconfig_view(config)
-    interface_view = view.interface_view_by_name("Ethernet1/1")
-    assert interface_view is not None
-
-    with pytest.raises(NotImplementedError):
-        _ = interface_view.nac_max_mab_clients
+    assert _interface_view(config, "vlan100").is_svi is True
+    assert _interface_view(config).is_svi is False
 
 
 def test_name() -> None:
-    """Test name returns interface name (covers line 114)."""
+    """Test name returns interface name."""
     config = HConfig.from_text(Platform.CISCO_NXOS)
     config.add_child("interface Ethernet1/10")
 
-    view = get_hconfig_view(config)
-    interface_view = view.interface_view_by_name("Ethernet1/10")
-    assert interface_view is not None
-    assert interface_view.name == "Ethernet1/10"
+    assert _interface_view(config, "Ethernet1/10").name == "Ethernet1/10"
 
 
-def test_native_vlan_not_implemented() -> None:
-    """Test native_vlan raises NotImplementedError (covers line 118)."""
+def test_native_vlan_subinterface() -> None:
+    config = HConfig.from_text(Platform.CISCO_NXOS)
+    config.add_children_deep(("interface Ethernet1/1.100", "encapsulation dot1q 100"))
+
+    assert _interface_view(config, "Ethernet1/1.100").native_vlan == 100
+
+
+def test_native_vlan_routed_port() -> None:
+    config = HConfig.from_text(Platform.CISCO_NXOS)
+    config.add_children_deep(("interface Ethernet1/1", "no switchport"))
+
+    assert _interface_view(config).native_vlan is None
+
+
+def test_native_vlan_trunk() -> None:
+    config = HConfig.from_text(Platform.CISCO_NXOS)
+    interface = config.add_child("interface Ethernet1/1")
+    interface.add_child("switchport mode trunk")
+    interface.add_child("switchport trunk native vlan 999")
+
+    assert _interface_view(config).native_vlan == 999
+
+
+def test_native_vlan_trunk_default() -> None:
+    config = HConfig.from_text(Platform.CISCO_NXOS)
+    config.add_children_deep(("interface Ethernet1/1", "switchport mode trunk"))
+
+    assert _interface_view(config).native_vlan is None
+
+
+def test_native_vlan_access() -> None:
+    config = HConfig.from_text(Platform.CISCO_NXOS)
+    config.add_children_deep(("interface Ethernet1/1", "switchport access vlan 50"))
+
+    interface_view = _interface_view(config)
+    assert interface_view.native_vlan == 50
+    assert interface_view.dot1q_mode == InterfaceDot1qMode.ACCESS
+
+
+def test_native_vlan_default() -> None:
     config = HConfig.from_text(Platform.CISCO_NXOS)
     config.add_child("interface Ethernet1/1")
 
-    view = get_hconfig_view(config)
-    interface_view = view.interface_view_by_name("Ethernet1/1")
-    assert interface_view is not None
-
-    with pytest.raises(NotImplementedError):
-        _ = interface_view.native_vlan
+    assert _interface_view(config).native_vlan == 1
 
 
 def test_number() -> None:
-    """Test number returns interface number (covers line 122)."""
+    """Test number returns interface number."""
     config = HConfig.from_text(Platform.CISCO_NXOS)
     config.add_child("interface Ethernet3/25")
 
-    view = get_hconfig_view(config)
-    interface_view = view.interface_view_by_name("Ethernet3/25")
-    assert interface_view is not None
-    assert interface_view.number == "3/25"
+    assert _interface_view(config, "Ethernet3/25").number == "3/25"
 
 
 def test_parent_name() -> None:
-    """Test parent_name returns parent interface (covers lines 126-128)."""
+    """Test parent_name returns parent interface."""
     config = HConfig.from_text(Platform.CISCO_NXOS)
     config.add_child("interface Ethernet1/1.200")
 
-    view = get_hconfig_view(config)
-    interface_view = view.interface_view_by_name("Ethernet1/1.200")
-    assert interface_view is not None
-    assert interface_view.parent_name == "Ethernet1/1"
+    assert _interface_view(config, "Ethernet1/1.200").parent_name == "Ethernet1/1"
 
 
 def test_parent_name_none() -> None:
-    """Test parent_name returns None (covers line 128)."""
+    """Test parent_name returns None."""
     config = HConfig.from_text(Platform.CISCO_NXOS)
     config.add_child("interface Ethernet1/1")
 
-    view = get_hconfig_view(config)
-    interface_view = view.interface_view_by_name("Ethernet1/1")
-    assert interface_view is not None
-    assert interface_view.parent_name is None
-
-
-def test_poe_not_implemented() -> None:
-    """Test poe raises NotImplementedError (covers line 132)."""
-    config = HConfig.from_text(Platform.CISCO_NXOS)
-    config.add_child("interface Ethernet1/1")
-
-    view = get_hconfig_view(config)
-    interface_view = view.interface_view_by_name("Ethernet1/1")
-    assert interface_view is not None
-
-    with pytest.raises(NotImplementedError):
-        _ = interface_view.poe
+    assert _interface_view(config).parent_name is None
 
 
 def test_port_number() -> None:
-    """Test port_number returns port number (covers line 136)."""
+    """Test port_number returns port number."""
     config = HConfig.from_text(Platform.CISCO_NXOS)
     config.add_child("interface Ethernet2/48")
 
-    view = get_hconfig_view(config)
-    interface_view = view.interface_view_by_name("Ethernet2/48")
-    assert interface_view is not None
-    assert interface_view.port_number == 48
+    assert _interface_view(config, "Ethernet2/48").port_number == 48
 
 
 def test_port_number_with_subinterface() -> None:
-    """Test port_number with subinterface (covers line 136)."""
+    """Test port_number with subinterface."""
     config = HConfig.from_text(Platform.CISCO_NXOS)
     config.add_child("interface Ethernet1/5.300")
 
-    view = get_hconfig_view(config)
-    interface_view = view.interface_view_by_name("Ethernet1/5.300")
-    assert interface_view is not None
-    assert interface_view.port_number == 5
-
-
-def test_speed_not_implemented() -> None:
-    """Test speed raises NotImplementedError (covers line 140)."""
-    config = HConfig.from_text(Platform.CISCO_NXOS)
-    config.add_child("interface Ethernet1/1")
-
-    view = get_hconfig_view(config)
-    interface_view = view.interface_view_by_name("Ethernet1/1")
-    assert interface_view is not None
-
-    with pytest.raises(NotImplementedError):
-        _ = interface_view.speed
+    assert _interface_view(config, "Ethernet1/5.300").port_number == 5
 
 
 def test_subinterface_number() -> None:
-    """Test subinterface_number returns number (covers line 144)."""
+    """Test subinterface_number returns number."""
     config = HConfig.from_text(Platform.CISCO_NXOS)
     config.add_child("interface Ethernet1/1.999")
 
-    view = get_hconfig_view(config)
-    interface_view = view.interface_view_by_name("Ethernet1/1.999")
-    assert interface_view is not None
-    assert interface_view.subinterface_number == 999
+    assert _interface_view(config, "Ethernet1/1.999").subinterface_number == 999
 
 
 def test_subinterface_number_none() -> None:
-    """Test subinterface_number returns None (covers line 144)."""
+    """Test subinterface_number returns None."""
     config = HConfig.from_text(Platform.CISCO_NXOS)
     config.add_child("interface Ethernet1/1")
 
-    view = get_hconfig_view(config)
-    interface_view = view.interface_view_by_name("Ethernet1/1")
-    assert interface_view is not None
-    assert interface_view.subinterface_number is None
+    assert _interface_view(config).subinterface_number is None
 
 
-def test_tagged_all_not_implemented() -> None:
-    """Test tagged_all raises NotImplementedError (covers line 148)."""
+def test_tagged_all() -> None:
+    config = HConfig.from_text(Platform.CISCO_NXOS)
+    config.add_children_deep(("interface Ethernet1/1", "switchport mode trunk"))
+
+    interface_view = _interface_view(config)
+    assert interface_view.tagged_all is True
+    assert interface_view.dot1q_mode == InterfaceDot1qMode.TAGGED_ALL
+
+
+def test_tagged_vlans() -> None:
+    config = HConfig.from_text(Platform.CISCO_NXOS)
+    interface = config.add_child("interface Ethernet1/1")
+    interface.add_child("switchport mode trunk")
+    interface.add_child("switchport trunk allowed vlan 10,20,30-32")
+
+    interface_view = _interface_view(config)
+    assert interface_view.tagged_vlans == (10, 20, 30, 31, 32)
+    assert interface_view.tagged_all is False
+    assert interface_view.dot1q_mode == InterfaceDot1qMode.TAGGED
+
+
+def test_tagged_vlans_empty() -> None:
     config = HConfig.from_text(Platform.CISCO_NXOS)
     config.add_child("interface Ethernet1/1")
 
-    view = get_hconfig_view(config)
-    interface_view = view.interface_view_by_name("Ethernet1/1")
-    assert interface_view is not None
-
-    with pytest.raises(NotImplementedError):
-        _ = interface_view.tagged_all
+    assert _interface_view(config).tagged_vlans == ()
 
 
-def test_tagged_vlans_not_implemented() -> None:
-    """Test tagged_vlans raises NotImplementedError (covers line 152)."""
+def test_vrf() -> None:
     config = HConfig.from_text(Platform.CISCO_NXOS)
-    config.add_child("interface Ethernet1/1")
+    config.add_children_deep(("interface Ethernet1/1", "vrf member RED"))
+    config.add_child("interface Ethernet1/2")
 
-    view = get_hconfig_view(config)
-    interface_view = view.interface_view_by_name("Ethernet1/1")
-    assert interface_view is not None
-
-    with pytest.raises(NotImplementedError):
-        _ = interface_view.tagged_vlans
-
-
-def test_vrf_not_implemented() -> None:
-    """Test vrf raises NotImplementedError (covers line 156)."""
-    config = HConfig.from_text(Platform.CISCO_NXOS)
-    config.add_child("interface Ethernet1/1")
-
-    view = get_hconfig_view(config)
-    interface_view = view.interface_view_by_name("Ethernet1/1")
-    assert interface_view is not None
-
-    with pytest.raises(NotImplementedError):
-        _ = interface_view.vrf
-
-
-def test_bundle_prefix() -> None:
-    """Test _bundle_prefix returns 'port-channel' (covers line 160)."""
-    config = HConfig.from_text(Platform.CISCO_NXOS)
-    config.add_child("interface port-channel1")
-
-    view = get_hconfig_view(config)
-    interface_view = view.interface_view_by_name("port-channel1")
-    assert interface_view is not None
-    assert interface_view.is_bundle
+    assert _interface_view(config).vrf == "RED"
+    assert not _interface_view(config, "Ethernet1/2").vrf
 
 
 def test_hostname() -> None:
-    """Test hostname returns hostname (covers lines 175-177)."""
+    """Test hostname returns hostname."""
     config = HConfig.from_text(Platform.CISCO_NXOS)
     config.add_child("hostname NEXUS-CORE-01")
 
@@ -510,26 +339,24 @@ def test_hostname() -> None:
 
 
 def test_hostname_none() -> None:
-    """Test hostname returns None (covers line 177)."""
+    """Test hostname returns None."""
     config = HConfig.from_text(Platform.CISCO_NXOS)
 
     view = get_hconfig_view(config)
     assert view.hostname is None
 
 
-def test_interface_names_mentioned_not_implemented() -> None:
-    """Test interface_names_mentioned raises NotImplementedError (covers line 182)."""
+def test_interface_names_mentioned() -> None:
     config = HConfig.from_text(Platform.CISCO_NXOS)
     config.add_child("interface Ethernet1/1")
+    config.add_child("interface Ethernet1/2")
 
     view = get_hconfig_view(config)
-
-    with pytest.raises(NotImplementedError):
-        _ = view.interface_names_mentioned
+    assert view.interface_names_mentioned == frozenset({"Ethernet1/1", "Ethernet1/2"})
 
 
 def test_interface_views() -> None:
-    """Test interface_views yields interface views (covers lines 186-187)."""
+    """Test interface_views yields interface views."""
     config = HConfig.from_text(Platform.CISCO_NXOS)
     config.add_child("interface Ethernet1/1")
     config.add_child("interface Ethernet1/2")
@@ -545,7 +372,7 @@ def test_interface_views() -> None:
 
 
 def test_interfaces() -> None:
-    """Test interfaces returns interface children (covers line 191)."""
+    """Test interfaces returns interface children."""
     config = HConfig.from_text(Platform.CISCO_NXOS)
     config.add_child("interface Ethernet1/1")
     config.add_child("interface Ethernet1/2")
@@ -557,41 +384,54 @@ def test_interfaces() -> None:
     assert len(interfaces) == 3
 
 
-def test_ipv4_default_gw_not_implemented() -> None:
-    """Test ipv4_default_gw raises NotImplementedError (covers line 195)."""
+def test_ipv4_default_gw() -> None:
+    config = HConfig.from_text(Platform.CISCO_NXOS)
+    config.add_child("ip route 0.0.0.0/0 192.0.2.254")
+
+    view = get_hconfig_view(config)
+    assert view.ipv4_default_gw == IPv4Address("192.0.2.254")
+
+
+def test_ipv4_default_gw_none() -> None:
     config = HConfig.from_text(Platform.CISCO_NXOS)
 
     view = get_hconfig_view(config)
-
-    with pytest.raises(NotImplementedError):
-        _ = view.ipv4_default_gw
+    assert view.ipv4_default_gw is None
 
 
-def test_location_not_implemented() -> None:
-    """Test location raises NotImplementedError (covers line 199)."""
+def test_location() -> None:
+    config = HConfig.from_text(Platform.CISCO_NXOS)
+    config.add_child('snmp-server location "Data Center 1"')
+
+    view = get_hconfig_view(config)
+    assert view.location == "Data Center 1"
+
+
+def test_location_empty() -> None:
     config = HConfig.from_text(Platform.CISCO_NXOS)
 
     view = get_hconfig_view(config)
-
-    with pytest.raises(NotImplementedError):
-        _ = view.location
+    assert not view.location
 
 
-def test_stack_members_not_implemented() -> None:
-    """Test stack_members raises NotImplementedError (covers line 203)."""
+def test_stack_members() -> None:
+    """NX-OS has no stacking, so stack_members is always empty."""
     config = HConfig.from_text(Platform.CISCO_NXOS)
 
     view = get_hconfig_view(config)
-
-    with pytest.raises(NotImplementedError):
-        _ = list(view.stack_members)
+    assert not list(view.stack_members)
 
 
-def test_vlans_not_implemented() -> None:
-    """Test vlans raises NotImplementedError (covers line 207)."""
+def test_vlans() -> None:
     config = HConfig.from_text(Platform.CISCO_NXOS)
+    config.add_children_deep(("vlan 10", "name PROD"))
+    config.add_child("vlan 20")
+    config.add_children_deep(("interface Ethernet1/1", "switchport access vlan 30"))
 
     view = get_hconfig_view(config)
-
-    with pytest.raises(NotImplementedError):
-        _ = list(view.vlans)
+    assert list(view.vlans) == [
+        Vlan(id=10, name="PROD"),
+        Vlan(id=20, name=None),
+        Vlan(id=30, name=None),
+    ]
+    assert view.vlan_ids == frozenset({10, 20, 30})

--- a/tests/unit/platforms/views/test_cisco_nxos.py
+++ b/tests/unit/platforms/views/test_cisco_nxos.py
@@ -435,3 +435,12 @@ def test_vlans() -> None:
         Vlan(id=30, name=None),
     ]
     assert view.vlan_ids == frozenset({10, 20, 30})
+
+
+def test_port_number_on_bundle_interface() -> None:
+    """port_number must not crash on slash-less names like port-channel10 (#278 review)."""
+    config = HConfig.from_text(Platform.CISCO_NXOS, "interface port-channel10\n")
+    view = get_hconfig_view(config)
+    interface_view = view.interface_view_by_name("port-channel10")
+    assert interface_view is not None
+    assert interface_view.port_number == 10

--- a/tests/unit/platforms/views/test_cisco_nxos.py
+++ b/tests/unit/platforms/views/test_cisco_nxos.py
@@ -4,12 +4,12 @@ from ipaddress import IPv4Interface
 
 import pytest
 
-from hier_config import Platform, get_hconfig, get_hconfig_view
+from hier_config import HConfig, Platform, get_hconfig_view
 
 
 def test_bundle_id_not_implemented() -> None:
     """Test bundle_id raises NotImplementedError (covers line 22)."""
-    config = get_hconfig(Platform.CISCO_NXOS)
+    config = HConfig.from_text(Platform.CISCO_NXOS)
     config.add_child("interface port-channel1")
 
     view = get_hconfig_view(config)
@@ -22,7 +22,7 @@ def test_bundle_id_not_implemented() -> None:
 
 def test_bundle_member_interfaces_not_implemented() -> None:
     """Test bundle_member_interfaces raises NotImplementedError (covers line 26)."""
-    config = get_hconfig(Platform.CISCO_NXOS)
+    config = HConfig.from_text(Platform.CISCO_NXOS)
     config.add_child("interface Ethernet1/1")
 
     view = get_hconfig_view(config)
@@ -35,7 +35,7 @@ def test_bundle_member_interfaces_not_implemented() -> None:
 
 def test_bundle_name_not_implemented() -> None:
     """Test bundle_name raises NotImplementedError (covers line 30)."""
-    config = get_hconfig(Platform.CISCO_NXOS)
+    config = HConfig.from_text(Platform.CISCO_NXOS)
     config.add_child("interface Ethernet1/1")
 
     view = get_hconfig_view(config)
@@ -48,7 +48,7 @@ def test_bundle_name_not_implemented() -> None:
 
 def test_description() -> None:
     """Test description returns description text (covers lines 34-36)."""
-    config = get_hconfig(Platform.CISCO_NXOS)
+    config = HConfig.from_text(Platform.CISCO_NXOS)
     interface = config.add_child("interface Ethernet1/1")
     interface.add_child("description Uplink to Core")
 
@@ -60,7 +60,7 @@ def test_description() -> None:
 
 def test_description_empty() -> None:
     """Test description returns empty string (covers line 36)."""
-    config = get_hconfig(Platform.CISCO_NXOS)
+    config = HConfig.from_text(Platform.CISCO_NXOS)
     config.add_child("interface Ethernet1/1")
 
     view = get_hconfig_view(config)
@@ -71,7 +71,7 @@ def test_description_empty() -> None:
 
 def test_duplex_not_implemented() -> None:
     """Test duplex raises NotImplementedError (covers line 40)."""
-    config = get_hconfig(Platform.CISCO_NXOS)
+    config = HConfig.from_text(Platform.CISCO_NXOS)
     config.add_child("interface Ethernet1/1")
 
     view = get_hconfig_view(config)
@@ -84,7 +84,7 @@ def test_duplex_not_implemented() -> None:
 
 def test_enabled_not_implemented() -> None:
     """Test enabled raises NotImplementedError (covers line 44)."""
-    config = get_hconfig(Platform.CISCO_NXOS)
+    config = HConfig.from_text(Platform.CISCO_NXOS)
     config.add_child("interface Ethernet1/1")
 
     view = get_hconfig_view(config)
@@ -97,7 +97,7 @@ def test_enabled_not_implemented() -> None:
 
 def test_has_nac_not_implemented() -> None:
     """Test has_nac raises NotImplementedError (covers line 49)."""
-    config = get_hconfig(Platform.CISCO_NXOS)
+    config = HConfig.from_text(Platform.CISCO_NXOS)
     config.add_child("interface Ethernet1/1")
 
     view = get_hconfig_view(config)
@@ -110,7 +110,7 @@ def test_has_nac_not_implemented() -> None:
 
 def test_ipv4_interface_none() -> None:
     """Test ipv4_interface returns None (covers line 53)."""
-    config = get_hconfig(Platform.CISCO_NXOS)
+    config = HConfig.from_text(Platform.CISCO_NXOS)
     config.add_child("interface Ethernet1/1")
 
     view = get_hconfig_view(config)
@@ -121,7 +121,7 @@ def test_ipv4_interface_none() -> None:
 
 def test_ipv4_interfaces() -> None:
     """Test ipv4_interfaces returns IP addresses (covers lines 57-62)."""
-    config = get_hconfig(Platform.CISCO_NXOS)
+    config = HConfig.from_text(Platform.CISCO_NXOS)
     interface = config.add_child("interface Ethernet1/1")
     interface.add_child("ip address 10.1.1.1 255.255.255.0")
 
@@ -136,7 +136,7 @@ def test_ipv4_interfaces() -> None:
 
 def test_ipv4_interfaces_invalid() -> None:
     """Test ipv4_interfaces skips invalid addresses (covers line 62)."""
-    config = get_hconfig(Platform.CISCO_NXOS)
+    config = HConfig.from_text(Platform.CISCO_NXOS)
     interface = config.add_child("interface Ethernet1/1")
     interface.add_child("ip address dhcp")
 
@@ -150,7 +150,7 @@ def test_ipv4_interfaces_invalid() -> None:
 
 def test_is_bundle_true() -> None:
     """Test is_bundle returns True (covers line 66)."""
-    config = get_hconfig(Platform.CISCO_NXOS)
+    config = HConfig.from_text(Platform.CISCO_NXOS)
     config.add_child("interface port-channel10")
 
     view = get_hconfig_view(config)
@@ -161,7 +161,7 @@ def test_is_bundle_true() -> None:
 
 def test_is_bundle_false() -> None:
     """Test is_bundle returns False (covers line 66)."""
-    config = get_hconfig(Platform.CISCO_NXOS)
+    config = HConfig.from_text(Platform.CISCO_NXOS)
     config.add_child("interface Ethernet1/1")
 
     view = get_hconfig_view(config)
@@ -172,7 +172,7 @@ def test_is_bundle_false() -> None:
 
 def test_is_loopback_true() -> None:
     """Test is_loopback returns True (covers line 70)."""
-    config = get_hconfig(Platform.CISCO_NXOS)
+    config = HConfig.from_text(Platform.CISCO_NXOS)
     config.add_child("interface loopback0")
 
     view = get_hconfig_view(config)
@@ -183,7 +183,7 @@ def test_is_loopback_true() -> None:
 
 def test_is_loopback_false() -> None:
     """Test is_loopback returns False (covers line 70)."""
-    config = get_hconfig(Platform.CISCO_NXOS)
+    config = HConfig.from_text(Platform.CISCO_NXOS)
     config.add_child("interface Ethernet1/1")
 
     view = get_hconfig_view(config)
@@ -194,7 +194,7 @@ def test_is_loopback_false() -> None:
 
 def test_is_subinterface_true() -> None:
     """Test is_subinterface returns True (covers line 74)."""
-    config = get_hconfig(Platform.CISCO_NXOS)
+    config = HConfig.from_text(Platform.CISCO_NXOS)
     config.add_child("interface Ethernet1/1.100")
 
     view = get_hconfig_view(config)
@@ -205,7 +205,7 @@ def test_is_subinterface_true() -> None:
 
 def test_is_subinterface_false() -> None:
     """Test is_subinterface returns False (covers line 74)."""
-    config = get_hconfig(Platform.CISCO_NXOS)
+    config = HConfig.from_text(Platform.CISCO_NXOS)
     config.add_child("interface Ethernet1/1")
 
     view = get_hconfig_view(config)
@@ -216,7 +216,7 @@ def test_is_subinterface_false() -> None:
 
 def test_is_svi_true() -> None:
     """Test is_svi returns True (covers line 78)."""
-    config = get_hconfig(Platform.CISCO_NXOS)
+    config = HConfig.from_text(Platform.CISCO_NXOS)
     config.add_child("interface vlan100")
 
     view = get_hconfig_view(config)
@@ -227,7 +227,7 @@ def test_is_svi_true() -> None:
 
 def test_is_svi_false() -> None:
     """Test is_svi returns False (covers line 78)."""
-    config = get_hconfig(Platform.CISCO_NXOS)
+    config = HConfig.from_text(Platform.CISCO_NXOS)
     config.add_child("interface Ethernet1/1")
 
     view = get_hconfig_view(config)
@@ -238,7 +238,7 @@ def test_is_svi_false() -> None:
 
 def test_module_number() -> None:
     """Test module_number returns module (covers lines 82-85)."""
-    config = get_hconfig(Platform.CISCO_NXOS)
+    config = HConfig.from_text(Platform.CISCO_NXOS)
     config.add_child("interface Ethernet2/15")
 
     view = get_hconfig_view(config)
@@ -249,7 +249,7 @@ def test_module_number() -> None:
 
 def test_module_number_none() -> None:
     """Test module_number returns None (covers lines 84-85)."""
-    config = get_hconfig(Platform.CISCO_NXOS)
+    config = HConfig.from_text(Platform.CISCO_NXOS)
     config.add_child("interface loopback0")
 
     view = get_hconfig_view(config)
@@ -260,7 +260,7 @@ def test_module_number_none() -> None:
 
 def test_nac_control_direction_in_not_implemented() -> None:
     """Test nac_control_direction_in raises NotImplementedError (covers line 90)."""
-    config = get_hconfig(Platform.CISCO_NXOS)
+    config = HConfig.from_text(Platform.CISCO_NXOS)
     config.add_child("interface Ethernet1/1")
 
     view = get_hconfig_view(config)
@@ -273,7 +273,7 @@ def test_nac_control_direction_in_not_implemented() -> None:
 
 def test_nac_host_mode_not_implemented() -> None:
     """Test nac_host_mode raises NotImplementedError (covers line 95)."""
-    config = get_hconfig(Platform.CISCO_NXOS)
+    config = HConfig.from_text(Platform.CISCO_NXOS)
     config.add_child("interface Ethernet1/1")
 
     view = get_hconfig_view(config)
@@ -286,7 +286,7 @@ def test_nac_host_mode_not_implemented() -> None:
 
 def test_nac_mab_first_not_implemented() -> None:
     """Test nac_mab_first raises NotImplementedError (covers line 100)."""
-    config = get_hconfig(Platform.CISCO_NXOS)
+    config = HConfig.from_text(Platform.CISCO_NXOS)
     config.add_child("interface Ethernet1/1")
 
     view = get_hconfig_view(config)
@@ -299,7 +299,7 @@ def test_nac_mab_first_not_implemented() -> None:
 
 def test_nac_max_dot1x_clients_not_implemented() -> None:
     """Test nac_max_dot1x_clients raises NotImplementedError (covers line 105)."""
-    config = get_hconfig(Platform.CISCO_NXOS)
+    config = HConfig.from_text(Platform.CISCO_NXOS)
     config.add_child("interface Ethernet1/1")
 
     view = get_hconfig_view(config)
@@ -312,7 +312,7 @@ def test_nac_max_dot1x_clients_not_implemented() -> None:
 
 def test_nac_max_mab_clients_not_implemented() -> None:
     """Test nac_max_mab_clients raises NotImplementedError (covers line 110)."""
-    config = get_hconfig(Platform.CISCO_NXOS)
+    config = HConfig.from_text(Platform.CISCO_NXOS)
     config.add_child("interface Ethernet1/1")
 
     view = get_hconfig_view(config)
@@ -325,7 +325,7 @@ def test_nac_max_mab_clients_not_implemented() -> None:
 
 def test_name() -> None:
     """Test name returns interface name (covers line 114)."""
-    config = get_hconfig(Platform.CISCO_NXOS)
+    config = HConfig.from_text(Platform.CISCO_NXOS)
     config.add_child("interface Ethernet1/10")
 
     view = get_hconfig_view(config)
@@ -336,7 +336,7 @@ def test_name() -> None:
 
 def test_native_vlan_not_implemented() -> None:
     """Test native_vlan raises NotImplementedError (covers line 118)."""
-    config = get_hconfig(Platform.CISCO_NXOS)
+    config = HConfig.from_text(Platform.CISCO_NXOS)
     config.add_child("interface Ethernet1/1")
 
     view = get_hconfig_view(config)
@@ -349,7 +349,7 @@ def test_native_vlan_not_implemented() -> None:
 
 def test_number() -> None:
     """Test number returns interface number (covers line 122)."""
-    config = get_hconfig(Platform.CISCO_NXOS)
+    config = HConfig.from_text(Platform.CISCO_NXOS)
     config.add_child("interface Ethernet3/25")
 
     view = get_hconfig_view(config)
@@ -360,7 +360,7 @@ def test_number() -> None:
 
 def test_parent_name() -> None:
     """Test parent_name returns parent interface (covers lines 126-128)."""
-    config = get_hconfig(Platform.CISCO_NXOS)
+    config = HConfig.from_text(Platform.CISCO_NXOS)
     config.add_child("interface Ethernet1/1.200")
 
     view = get_hconfig_view(config)
@@ -371,7 +371,7 @@ def test_parent_name() -> None:
 
 def test_parent_name_none() -> None:
     """Test parent_name returns None (covers line 128)."""
-    config = get_hconfig(Platform.CISCO_NXOS)
+    config = HConfig.from_text(Platform.CISCO_NXOS)
     config.add_child("interface Ethernet1/1")
 
     view = get_hconfig_view(config)
@@ -382,7 +382,7 @@ def test_parent_name_none() -> None:
 
 def test_poe_not_implemented() -> None:
     """Test poe raises NotImplementedError (covers line 132)."""
-    config = get_hconfig(Platform.CISCO_NXOS)
+    config = HConfig.from_text(Platform.CISCO_NXOS)
     config.add_child("interface Ethernet1/1")
 
     view = get_hconfig_view(config)
@@ -395,7 +395,7 @@ def test_poe_not_implemented() -> None:
 
 def test_port_number() -> None:
     """Test port_number returns port number (covers line 136)."""
-    config = get_hconfig(Platform.CISCO_NXOS)
+    config = HConfig.from_text(Platform.CISCO_NXOS)
     config.add_child("interface Ethernet2/48")
 
     view = get_hconfig_view(config)
@@ -406,7 +406,7 @@ def test_port_number() -> None:
 
 def test_port_number_with_subinterface() -> None:
     """Test port_number with subinterface (covers line 136)."""
-    config = get_hconfig(Platform.CISCO_NXOS)
+    config = HConfig.from_text(Platform.CISCO_NXOS)
     config.add_child("interface Ethernet1/5.300")
 
     view = get_hconfig_view(config)
@@ -417,7 +417,7 @@ def test_port_number_with_subinterface() -> None:
 
 def test_speed_not_implemented() -> None:
     """Test speed raises NotImplementedError (covers line 140)."""
-    config = get_hconfig(Platform.CISCO_NXOS)
+    config = HConfig.from_text(Platform.CISCO_NXOS)
     config.add_child("interface Ethernet1/1")
 
     view = get_hconfig_view(config)
@@ -430,7 +430,7 @@ def test_speed_not_implemented() -> None:
 
 def test_subinterface_number() -> None:
     """Test subinterface_number returns number (covers line 144)."""
-    config = get_hconfig(Platform.CISCO_NXOS)
+    config = HConfig.from_text(Platform.CISCO_NXOS)
     config.add_child("interface Ethernet1/1.999")
 
     view = get_hconfig_view(config)
@@ -441,7 +441,7 @@ def test_subinterface_number() -> None:
 
 def test_subinterface_number_none() -> None:
     """Test subinterface_number returns None (covers line 144)."""
-    config = get_hconfig(Platform.CISCO_NXOS)
+    config = HConfig.from_text(Platform.CISCO_NXOS)
     config.add_child("interface Ethernet1/1")
 
     view = get_hconfig_view(config)
@@ -452,7 +452,7 @@ def test_subinterface_number_none() -> None:
 
 def test_tagged_all_not_implemented() -> None:
     """Test tagged_all raises NotImplementedError (covers line 148)."""
-    config = get_hconfig(Platform.CISCO_NXOS)
+    config = HConfig.from_text(Platform.CISCO_NXOS)
     config.add_child("interface Ethernet1/1")
 
     view = get_hconfig_view(config)
@@ -465,7 +465,7 @@ def test_tagged_all_not_implemented() -> None:
 
 def test_tagged_vlans_not_implemented() -> None:
     """Test tagged_vlans raises NotImplementedError (covers line 152)."""
-    config = get_hconfig(Platform.CISCO_NXOS)
+    config = HConfig.from_text(Platform.CISCO_NXOS)
     config.add_child("interface Ethernet1/1")
 
     view = get_hconfig_view(config)
@@ -478,7 +478,7 @@ def test_tagged_vlans_not_implemented() -> None:
 
 def test_vrf_not_implemented() -> None:
     """Test vrf raises NotImplementedError (covers line 156)."""
-    config = get_hconfig(Platform.CISCO_NXOS)
+    config = HConfig.from_text(Platform.CISCO_NXOS)
     config.add_child("interface Ethernet1/1")
 
     view = get_hconfig_view(config)
@@ -491,7 +491,7 @@ def test_vrf_not_implemented() -> None:
 
 def test_bundle_prefix() -> None:
     """Test _bundle_prefix returns 'port-channel' (covers line 160)."""
-    config = get_hconfig(Platform.CISCO_NXOS)
+    config = HConfig.from_text(Platform.CISCO_NXOS)
     config.add_child("interface port-channel1")
 
     view = get_hconfig_view(config)
@@ -502,7 +502,7 @@ def test_bundle_prefix() -> None:
 
 def test_hostname() -> None:
     """Test hostname returns hostname (covers lines 175-177)."""
-    config = get_hconfig(Platform.CISCO_NXOS)
+    config = HConfig.from_text(Platform.CISCO_NXOS)
     config.add_child("hostname NEXUS-CORE-01")
 
     view = get_hconfig_view(config)
@@ -511,7 +511,7 @@ def test_hostname() -> None:
 
 def test_hostname_none() -> None:
     """Test hostname returns None (covers line 177)."""
-    config = get_hconfig(Platform.CISCO_NXOS)
+    config = HConfig.from_text(Platform.CISCO_NXOS)
 
     view = get_hconfig_view(config)
     assert view.hostname is None
@@ -519,7 +519,7 @@ def test_hostname_none() -> None:
 
 def test_interface_names_mentioned_not_implemented() -> None:
     """Test interface_names_mentioned raises NotImplementedError (covers line 182)."""
-    config = get_hconfig(Platform.CISCO_NXOS)
+    config = HConfig.from_text(Platform.CISCO_NXOS)
     config.add_child("interface Ethernet1/1")
 
     view = get_hconfig_view(config)
@@ -530,7 +530,7 @@ def test_interface_names_mentioned_not_implemented() -> None:
 
 def test_interface_views() -> None:
     """Test interface_views yields interface views (covers lines 186-187)."""
-    config = get_hconfig(Platform.CISCO_NXOS)
+    config = HConfig.from_text(Platform.CISCO_NXOS)
     config.add_child("interface Ethernet1/1")
     config.add_child("interface Ethernet1/2")
     config.add_child("interface loopback0")
@@ -546,7 +546,7 @@ def test_interface_views() -> None:
 
 def test_interfaces() -> None:
     """Test interfaces returns interface children (covers line 191)."""
-    config = get_hconfig(Platform.CISCO_NXOS)
+    config = HConfig.from_text(Platform.CISCO_NXOS)
     config.add_child("interface Ethernet1/1")
     config.add_child("interface Ethernet1/2")
     config.add_child("interface port-channel1")
@@ -559,7 +559,7 @@ def test_interfaces() -> None:
 
 def test_ipv4_default_gw_not_implemented() -> None:
     """Test ipv4_default_gw raises NotImplementedError (covers line 195)."""
-    config = get_hconfig(Platform.CISCO_NXOS)
+    config = HConfig.from_text(Platform.CISCO_NXOS)
 
     view = get_hconfig_view(config)
 
@@ -569,7 +569,7 @@ def test_ipv4_default_gw_not_implemented() -> None:
 
 def test_location_not_implemented() -> None:
     """Test location raises NotImplementedError (covers line 199)."""
-    config = get_hconfig(Platform.CISCO_NXOS)
+    config = HConfig.from_text(Platform.CISCO_NXOS)
 
     view = get_hconfig_view(config)
 
@@ -579,7 +579,7 @@ def test_location_not_implemented() -> None:
 
 def test_stack_members_not_implemented() -> None:
     """Test stack_members raises NotImplementedError (covers line 203)."""
-    config = get_hconfig(Platform.CISCO_NXOS)
+    config = HConfig.from_text(Platform.CISCO_NXOS)
 
     view = get_hconfig_view(config)
 
@@ -589,7 +589,7 @@ def test_stack_members_not_implemented() -> None:
 
 def test_vlans_not_implemented() -> None:
     """Test vlans raises NotImplementedError (covers line 207)."""
-    config = get_hconfig(Platform.CISCO_NXOS)
+    config = HConfig.from_text(Platform.CISCO_NXOS)
 
     view = get_hconfig_view(config)
 

--- a/tests/unit/platforms/views/test_cisco_xr.py
+++ b/tests/unit/platforms/views/test_cisco_xr.py
@@ -375,3 +375,12 @@ def test_vlans() -> None:
         Vlan(id=200, name=None),
     ]
     assert view.vlan_ids == frozenset({100, 200})
+
+
+def test_port_number_on_bundle_interface() -> None:
+    """port_number must not crash on slash-less names like Bundle-Ether10 (#278 review)."""
+    config = HConfig.from_text(Platform.CISCO_XR, "interface Bundle-Ether10\n")
+    view = get_hconfig_view(config)
+    interface_view = view.interface_view_by_name("Bundle-Ether10")
+    assert interface_view is not None
+    assert interface_view.port_number == 10

--- a/tests/unit/platforms/views/test_cisco_xr.py
+++ b/tests/unit/platforms/views/test_cisco_xr.py
@@ -4,12 +4,12 @@ from ipaddress import IPv4Interface
 
 import pytest
 
-from hier_config import Platform, get_hconfig, get_hconfig_view
+from hier_config import HConfig, Platform, get_hconfig_view
 
 
 def test_bundle_id_not_implemented() -> None:
     """Test bundle_id raises NotImplementedError (covers line 26)."""
-    config = get_hconfig(Platform.CISCO_XR)
+    config = HConfig.from_text(Platform.CISCO_XR)
     config.add_child("interface Bundle-Ether1")
 
     view = get_hconfig_view(config)
@@ -22,7 +22,7 @@ def test_bundle_id_not_implemented() -> None:
 
 def test_bundle_member_interfaces_not_implemented() -> None:
     """Test bundle_member_interfaces raises NotImplementedError (covers line 30)."""
-    config = get_hconfig(Platform.CISCO_XR)
+    config = HConfig.from_text(Platform.CISCO_XR)
     config.add_child("interface GigabitEthernet0/0/0/0")
 
     view = get_hconfig_view(config)
@@ -35,7 +35,7 @@ def test_bundle_member_interfaces_not_implemented() -> None:
 
 def test_bundle_name_with_bundle_id() -> None:
     """Test bundle_name returns formatted name (covers lines 34-36)."""
-    config = get_hconfig(Platform.CISCO_XR)
+    config = HConfig.from_text(Platform.CISCO_XR)
     config.add_child("interface Bundle-Ether1")
 
     view = get_hconfig_view(config)
@@ -47,7 +47,7 @@ def test_bundle_name_with_bundle_id() -> None:
 
 def test_bundle_name_none() -> None:
     """Test bundle_name returns None when not bundle (covers line 36)."""
-    config = get_hconfig(Platform.CISCO_XR)
+    config = HConfig.from_text(Platform.CISCO_XR)
     config.add_child("interface GigabitEthernet0/0/0/0")
 
     view = get_hconfig_view(config)
@@ -59,7 +59,7 @@ def test_bundle_name_none() -> None:
 
 def test_description() -> None:
     """Test description returns description text (covers lines 40-42)."""
-    config = get_hconfig(Platform.CISCO_XR)
+    config = HConfig.from_text(Platform.CISCO_XR)
     interface = config.add_child("interface GigabitEthernet0/0/0/0")
     interface.add_child("description Uplink to Core")
 
@@ -71,7 +71,7 @@ def test_description() -> None:
 
 def test_description_empty() -> None:
     """Test description returns empty string (covers line 42)."""
-    config = get_hconfig(Platform.CISCO_XR)
+    config = HConfig.from_text(Platform.CISCO_XR)
     config.add_child("interface GigabitEthernet0/0/0/0")
 
     view = get_hconfig_view(config)
@@ -82,7 +82,7 @@ def test_description_empty() -> None:
 
 def test_duplex_not_implemented() -> None:
     """Test duplex raises NotImplementedError (covers line 46)."""
-    config = get_hconfig(Platform.CISCO_XR)
+    config = HConfig.from_text(Platform.CISCO_XR)
     config.add_child("interface GigabitEthernet0/0/0/0")
 
     view = get_hconfig_view(config)
@@ -95,7 +95,7 @@ def test_duplex_not_implemented() -> None:
 
 def test_enabled_not_implemented() -> None:
     """Test enabled raises NotImplementedError (covers line 50)."""
-    config = get_hconfig(Platform.CISCO_XR)
+    config = HConfig.from_text(Platform.CISCO_XR)
     config.add_child("interface GigabitEthernet0/0/0/0")
 
     view = get_hconfig_view(config)
@@ -108,7 +108,7 @@ def test_enabled_not_implemented() -> None:
 
 def test_has_nac_not_implemented() -> None:
     """Test has_nac raises NotImplementedError (covers line 55)."""
-    config = get_hconfig(Platform.CISCO_XR)
+    config = HConfig.from_text(Platform.CISCO_XR)
     config.add_child("interface GigabitEthernet0/0/0/0")
 
     view = get_hconfig_view(config)
@@ -121,7 +121,7 @@ def test_has_nac_not_implemented() -> None:
 
 def test_ipv4_interface_none() -> None:
     """Test ipv4_interface returns None (covers line 59)."""
-    config = get_hconfig(Platform.CISCO_XR)
+    config = HConfig.from_text(Platform.CISCO_XR)
     config.add_child("interface GigabitEthernet0/0/0/0")
 
     view = get_hconfig_view(config)
@@ -132,7 +132,7 @@ def test_ipv4_interface_none() -> None:
 
 def test_ipv4_interfaces() -> None:
     """Test ipv4_interfaces returns IP addresses (covers lines 63-68)."""
-    config = get_hconfig(Platform.CISCO_XR)
+    config = HConfig.from_text(Platform.CISCO_XR)
     interface = config.add_child("interface GigabitEthernet0/0/0/0")
     interface.add_child("ipv4 address 192.168.1.1 255.255.255.0")
 
@@ -147,7 +147,7 @@ def test_ipv4_interfaces() -> None:
 
 def test_ipv4_interfaces_invalid() -> None:
     """Test ipv4_interfaces skips invalid addresses (covers line 68)."""
-    config = get_hconfig(Platform.CISCO_XR)
+    config = HConfig.from_text(Platform.CISCO_XR)
     interface = config.add_child("interface GigabitEthernet0/0/0/0")
     interface.add_child("ipv4 address dhcp")
 
@@ -161,7 +161,7 @@ def test_ipv4_interfaces_invalid() -> None:
 
 def test_is_bundle_false() -> None:
     """Test is_bundle returns False (covers line 72)."""
-    config = get_hconfig(Platform.CISCO_XR)
+    config = HConfig.from_text(Platform.CISCO_XR)
     config.add_child("interface GigabitEthernet0/0/0/0")
 
     view = get_hconfig_view(config)
@@ -172,7 +172,7 @@ def test_is_bundle_false() -> None:
 
 def test_is_loopback_true() -> None:
     """Test is_loopback returns True (covers line 76)."""
-    config = get_hconfig(Platform.CISCO_XR)
+    config = HConfig.from_text(Platform.CISCO_XR)
     config.add_child("interface Loopback0")
 
     view = get_hconfig_view(config)
@@ -183,7 +183,7 @@ def test_is_loopback_true() -> None:
 
 def test_is_loopback_false() -> None:
     """Test is_loopback returns False (covers line 76)."""
-    config = get_hconfig(Platform.CISCO_XR)
+    config = HConfig.from_text(Platform.CISCO_XR)
     config.add_child("interface GigabitEthernet0/0/0/0")
 
     view = get_hconfig_view(config)
@@ -194,7 +194,7 @@ def test_is_loopback_false() -> None:
 
 def test_is_subinterface_true() -> None:
     """Test is_subinterface returns True (covers line 80)."""
-    config = get_hconfig(Platform.CISCO_XR)
+    config = HConfig.from_text(Platform.CISCO_XR)
     config.add_child("interface GigabitEthernet0/0/0/0.100")
 
     view = get_hconfig_view(config)
@@ -205,7 +205,7 @@ def test_is_subinterface_true() -> None:
 
 def test_is_subinterface_false() -> None:
     """Test is_subinterface returns False (covers line 80)."""
-    config = get_hconfig(Platform.CISCO_XR)
+    config = HConfig.from_text(Platform.CISCO_XR)
     config.add_child("interface GigabitEthernet0/0/0/0")
 
     view = get_hconfig_view(config)
@@ -216,7 +216,7 @@ def test_is_subinterface_false() -> None:
 
 def test_is_svi_true() -> None:
     """Test is_svi returns True (covers line 84)."""
-    config = get_hconfig(Platform.CISCO_XR)
+    config = HConfig.from_text(Platform.CISCO_XR)
     config.add_child("interface vlan100")
 
     view = get_hconfig_view(config)
@@ -227,7 +227,7 @@ def test_is_svi_true() -> None:
 
 def test_is_svi_false() -> None:
     """Test is_svi returns False (covers line 84)."""
-    config = get_hconfig(Platform.CISCO_XR)
+    config = HConfig.from_text(Platform.CISCO_XR)
     config.add_child("interface GigabitEthernet0/0/0/0")
 
     view = get_hconfig_view(config)
@@ -238,7 +238,7 @@ def test_is_svi_false() -> None:
 
 def test_module_number() -> None:
     """Test module_number returns module (covers lines 88-91)."""
-    config = get_hconfig(Platform.CISCO_XR)
+    config = HConfig.from_text(Platform.CISCO_XR)
     config.add_child("interface GigabitEthernet0/2/0/5")
 
     view = get_hconfig_view(config)
@@ -249,7 +249,7 @@ def test_module_number() -> None:
 
 def test_module_number_none() -> None:
     """Test module_number returns None (covers lines 90-91)."""
-    config = get_hconfig(Platform.CISCO_XR)
+    config = HConfig.from_text(Platform.CISCO_XR)
     config.add_child("interface Loopback0")
 
     view = get_hconfig_view(config)
@@ -260,7 +260,7 @@ def test_module_number_none() -> None:
 
 def test_nac_control_direction_in_not_implemented() -> None:
     """Test nac_control_direction_in raises NotImplementedError (covers line 96)."""
-    config = get_hconfig(Platform.CISCO_XR)
+    config = HConfig.from_text(Platform.CISCO_XR)
     config.add_child("interface GigabitEthernet0/0/0/0")
 
     view = get_hconfig_view(config)
@@ -273,7 +273,7 @@ def test_nac_control_direction_in_not_implemented() -> None:
 
 def test_nac_host_mode_not_implemented() -> None:
     """Test nac_host_mode raises NotImplementedError (covers line 101)."""
-    config = get_hconfig(Platform.CISCO_XR)
+    config = HConfig.from_text(Platform.CISCO_XR)
     config.add_child("interface GigabitEthernet0/0/0/0")
 
     view = get_hconfig_view(config)
@@ -286,7 +286,7 @@ def test_nac_host_mode_not_implemented() -> None:
 
 def test_nac_mab_first_not_implemented() -> None:
     """Test nac_mab_first raises NotImplementedError (covers line 106)."""
-    config = get_hconfig(Platform.CISCO_XR)
+    config = HConfig.from_text(Platform.CISCO_XR)
     config.add_child("interface GigabitEthernet0/0/0/0")
 
     view = get_hconfig_view(config)
@@ -299,7 +299,7 @@ def test_nac_mab_first_not_implemented() -> None:
 
 def test_nac_max_dot1x_clients_not_implemented() -> None:
     """Test nac_max_dot1x_clients raises NotImplementedError (covers line 111)."""
-    config = get_hconfig(Platform.CISCO_XR)
+    config = HConfig.from_text(Platform.CISCO_XR)
     config.add_child("interface GigabitEthernet0/0/0/0")
 
     view = get_hconfig_view(config)
@@ -312,7 +312,7 @@ def test_nac_max_dot1x_clients_not_implemented() -> None:
 
 def test_nac_max_mab_clients_not_implemented() -> None:
     """Test nac_max_mab_clients raises NotImplementedError (covers line 116)."""
-    config = get_hconfig(Platform.CISCO_XR)
+    config = HConfig.from_text(Platform.CISCO_XR)
     config.add_child("interface GigabitEthernet0/0/0/0")
 
     view = get_hconfig_view(config)
@@ -325,7 +325,7 @@ def test_nac_max_mab_clients_not_implemented() -> None:
 
 def test_name() -> None:
     """Test name returns interface name (covers line 120)."""
-    config = get_hconfig(Platform.CISCO_XR)
+    config = HConfig.from_text(Platform.CISCO_XR)
     config.add_child("interface GigabitEthernet0/0/0/10")
 
     view = get_hconfig_view(config)
@@ -336,7 +336,7 @@ def test_name() -> None:
 
 def test_native_vlan_not_implemented() -> None:
     """Test native_vlan raises NotImplementedError (covers line 124)."""
-    config = get_hconfig(Platform.CISCO_XR)
+    config = HConfig.from_text(Platform.CISCO_XR)
     config.add_child("interface GigabitEthernet0/0/0/0")
 
     view = get_hconfig_view(config)
@@ -349,7 +349,7 @@ def test_native_vlan_not_implemented() -> None:
 
 def test_number() -> None:
     """Test number returns interface number (covers line 128)."""
-    config = get_hconfig(Platform.CISCO_XR)
+    config = HConfig.from_text(Platform.CISCO_XR)
     config.add_child("interface GigabitEthernet0/1/2/15")
 
     view = get_hconfig_view(config)
@@ -360,7 +360,7 @@ def test_number() -> None:
 
 def test_parent_name() -> None:
     """Test parent_name returns parent interface (covers lines 132-134)."""
-    config = get_hconfig(Platform.CISCO_XR)
+    config = HConfig.from_text(Platform.CISCO_XR)
     config.add_child("interface GigabitEthernet0/0/0/0.100")
 
     view = get_hconfig_view(config)
@@ -371,7 +371,7 @@ def test_parent_name() -> None:
 
 def test_parent_name_none() -> None:
     """Test parent_name returns None (covers line 134)."""
-    config = get_hconfig(Platform.CISCO_XR)
+    config = HConfig.from_text(Platform.CISCO_XR)
     config.add_child("interface GigabitEthernet0/0/0/0")
 
     view = get_hconfig_view(config)
@@ -382,7 +382,7 @@ def test_parent_name_none() -> None:
 
 def test_poe_not_implemented() -> None:
     """Test poe raises NotImplementedError (covers line 138)."""
-    config = get_hconfig(Platform.CISCO_XR)
+    config = HConfig.from_text(Platform.CISCO_XR)
     config.add_child("interface GigabitEthernet0/0/0/0")
 
     view = get_hconfig_view(config)
@@ -395,7 +395,7 @@ def test_poe_not_implemented() -> None:
 
 def test_port_number() -> None:
     """Test port_number returns port number (covers line 142)."""
-    config = get_hconfig(Platform.CISCO_XR)
+    config = HConfig.from_text(Platform.CISCO_XR)
     config.add_child("interface GigabitEthernet0/2/1/25")
 
     view = get_hconfig_view(config)
@@ -406,7 +406,7 @@ def test_port_number() -> None:
 
 def test_port_number_with_subinterface() -> None:
     """Test port_number with subinterface (covers line 142)."""
-    config = get_hconfig(Platform.CISCO_XR)
+    config = HConfig.from_text(Platform.CISCO_XR)
     config.add_child("interface GigabitEthernet0/0/0/5.200")
 
     view = get_hconfig_view(config)
@@ -417,7 +417,7 @@ def test_port_number_with_subinterface() -> None:
 
 def test_speed_not_implemented() -> None:
     """Test speed raises NotImplementedError (covers line 146)."""
-    config = get_hconfig(Platform.CISCO_XR)
+    config = HConfig.from_text(Platform.CISCO_XR)
     config.add_child("interface GigabitEthernet0/0/0/0")
 
     view = get_hconfig_view(config)
@@ -430,7 +430,7 @@ def test_speed_not_implemented() -> None:
 
 def test_subinterface_number() -> None:
     """Test subinterface_number returns number (covers line 150)."""
-    config = get_hconfig(Platform.CISCO_XR)
+    config = HConfig.from_text(Platform.CISCO_XR)
     config.add_child("interface GigabitEthernet0/0/0/0.500")
 
     view = get_hconfig_view(config)
@@ -441,7 +441,7 @@ def test_subinterface_number() -> None:
 
 def test_subinterface_number_none() -> None:
     """Test subinterface_number returns None (covers line 150)."""
-    config = get_hconfig(Platform.CISCO_XR)
+    config = HConfig.from_text(Platform.CISCO_XR)
     config.add_child("interface GigabitEthernet0/0/0/0")
 
     view = get_hconfig_view(config)
@@ -452,7 +452,7 @@ def test_subinterface_number_none() -> None:
 
 def test_tagged_all_not_implemented() -> None:
     """Test tagged_all raises NotImplementedError (covers line 154)."""
-    config = get_hconfig(Platform.CISCO_XR)
+    config = HConfig.from_text(Platform.CISCO_XR)
     config.add_child("interface GigabitEthernet0/0/0/0")
 
     view = get_hconfig_view(config)
@@ -465,7 +465,7 @@ def test_tagged_all_not_implemented() -> None:
 
 def test_tagged_vlans_not_implemented() -> None:
     """Test tagged_vlans raises NotImplementedError (covers line 158)."""
-    config = get_hconfig(Platform.CISCO_XR)
+    config = HConfig.from_text(Platform.CISCO_XR)
     config.add_child("interface GigabitEthernet0/0/0/0")
 
     view = get_hconfig_view(config)
@@ -478,7 +478,7 @@ def test_tagged_vlans_not_implemented() -> None:
 
 def test_vrf_not_implemented() -> None:
     """Test vrf raises NotImplementedError (covers line 162)."""
-    config = get_hconfig(Platform.CISCO_XR)
+    config = HConfig.from_text(Platform.CISCO_XR)
     config.add_child("interface GigabitEthernet0/0/0/0")
 
     view = get_hconfig_view(config)
@@ -491,7 +491,7 @@ def test_vrf_not_implemented() -> None:
 
 def test_hostname() -> None:
     """Test hostname returns hostname (covers lines 177-179)."""
-    config = get_hconfig(Platform.CISCO_XR)
+    config = HConfig.from_text(Platform.CISCO_XR)
     config.add_child("hostname CORE-ROUTER-01")
 
     view = get_hconfig_view(config)
@@ -500,7 +500,7 @@ def test_hostname() -> None:
 
 def test_hostname_none() -> None:
     """Test hostname returns None (covers line 179)."""
-    config = get_hconfig(Platform.CISCO_XR)
+    config = HConfig.from_text(Platform.CISCO_XR)
 
     view = get_hconfig_view(config)
     assert view.hostname is None
@@ -508,7 +508,7 @@ def test_hostname_none() -> None:
 
 def test_interface_names_mentioned_not_implemented() -> None:
     """Test interface_names_mentioned raises NotImplementedError (covers line 183)."""
-    config = get_hconfig(Platform.CISCO_XR)
+    config = HConfig.from_text(Platform.CISCO_XR)
     config.add_child("interface GigabitEthernet0/0/0/0")
 
     view = get_hconfig_view(config)
@@ -519,7 +519,7 @@ def test_interface_names_mentioned_not_implemented() -> None:
 
 def test_interface_views() -> None:
     """Test interface_views yields interface views (covers lines 187-188)."""
-    config = get_hconfig(Platform.CISCO_XR)
+    config = HConfig.from_text(Platform.CISCO_XR)
     config.add_child("interface GigabitEthernet0/0/0/0")
     config.add_child("interface GigabitEthernet0/0/0/1")
 
@@ -533,7 +533,7 @@ def test_interface_views() -> None:
 
 def test_interfaces() -> None:
     """Test interfaces returns interface children (covers line 192)."""
-    config = get_hconfig(Platform.CISCO_XR)
+    config = HConfig.from_text(Platform.CISCO_XR)
     config.add_child("interface GigabitEthernet0/0/0/0")
     config.add_child("interface GigabitEthernet0/0/0/1")
     config.add_child("interface Loopback0")
@@ -546,7 +546,7 @@ def test_interfaces() -> None:
 
 def test_ipv4_default_gw_not_implemented() -> None:
     """Test ipv4_default_gw raises NotImplementedError (covers line 196)."""
-    config = get_hconfig(Platform.CISCO_XR)
+    config = HConfig.from_text(Platform.CISCO_XR)
 
     view = get_hconfig_view(config)
 
@@ -556,7 +556,7 @@ def test_ipv4_default_gw_not_implemented() -> None:
 
 def test_location_not_implemented() -> None:
     """Test location raises NotImplementedError (covers line 200)."""
-    config = get_hconfig(Platform.CISCO_XR)
+    config = HConfig.from_text(Platform.CISCO_XR)
 
     view = get_hconfig_view(config)
 
@@ -566,7 +566,7 @@ def test_location_not_implemented() -> None:
 
 def test_stack_members_not_implemented() -> None:
     """Test stack_members raises NotImplementedError (covers line 204)."""
-    config = get_hconfig(Platform.CISCO_XR)
+    config = HConfig.from_text(Platform.CISCO_XR)
 
     view = get_hconfig_view(config)
 
@@ -576,7 +576,7 @@ def test_stack_members_not_implemented() -> None:
 
 def test_vlans_not_implemented() -> None:
     """Test vlans raises NotImplementedError (covers line 208)."""
-    config = get_hconfig(Platform.CISCO_XR)
+    config = HConfig.from_text(Platform.CISCO_XR)
 
     view = get_hconfig_view(config)
 

--- a/tests/unit/platforms/views/test_cisco_xr.py
+++ b/tests/unit/platforms/views/test_cisco_xr.py
@@ -1,584 +1,377 @@
 """Tests for Cisco IOS-XR view.py ConfigViewInterfaceCiscoIOSXR and HConfigViewCiscoIOSXR classes."""
 
-from ipaddress import IPv4Interface
+from ipaddress import IPv4Address, IPv4Interface
 
-import pytest
+from hier_config import (
+    HConfig,
+    InterfaceBundleViewMixin,
+    InterfaceNACViewMixin,
+    InterfacePhysicalViewMixin,
+    InterfaceVlanViewMixin,
+    Platform,
+    get_hconfig_view,
+)
+from hier_config.platforms.cisco_xr.view import ConfigViewInterfaceCiscoIOSXR
+from hier_config.platforms.models import Vlan
 
-from hier_config import HConfig, Platform, get_hconfig_view
+
+def _interface_view(
+    config: HConfig, name: str = "GigabitEthernet0/0/0/1"
+) -> ConfigViewInterfaceCiscoIOSXR:
+    interface_view = get_hconfig_view(config).interface_view_by_name(name)
+    assert isinstance(interface_view, ConfigViewInterfaceCiscoIOSXR)
+    return interface_view
 
 
-def test_bundle_id_not_implemented() -> None:
-    """Test bundle_id raises NotImplementedError (covers line 26)."""
+def test_capabilities() -> None:
+    """IOS XR interface views support bundles and VLANs but not NAC or physical."""
     config = HConfig.from_text(Platform.CISCO_XR)
-    config.add_child("interface Bundle-Ether1")
+    config.add_child("interface GigabitEthernet0/0/0/1")
 
-    view = get_hconfig_view(config)
-    interface_view = view.interface_view_by_name("Bundle-Ether1")
-    assert interface_view is not None
+    interface_view = _interface_view(config)
+    assert isinstance(interface_view, InterfaceBundleViewMixin)
+    assert isinstance(interface_view, InterfaceVlanViewMixin)
+    assert not isinstance(interface_view, InterfaceNACViewMixin)
+    assert not isinstance(interface_view, InterfacePhysicalViewMixin)
 
-    with pytest.raises(NotImplementedError):
-        _ = interface_view.bundle_id
 
-
-def test_bundle_member_interfaces_not_implemented() -> None:
-    """Test bundle_member_interfaces raises NotImplementedError (covers line 30)."""
+def test_bundle_id() -> None:
     config = HConfig.from_text(Platform.CISCO_XR)
-    config.add_child("interface GigabitEthernet0/0/0/0")
+    config.add_children_deep(
+        ("interface GigabitEthernet0/0/0/1", "bundle id 42 mode active")
+    )
 
-    view = get_hconfig_view(config)
-    interface_view = view.interface_view_by_name("GigabitEthernet0/0/0/0")
-    assert interface_view is not None
-
-    with pytest.raises(NotImplementedError):
-        _ = list(interface_view.bundle_member_interfaces)
+    assert _interface_view(config).bundle_id == "42"
 
 
-def test_bundle_name_with_bundle_id() -> None:
-    """Test bundle_name returns formatted name (covers lines 34-36)."""
+def test_bundle_id_none() -> None:
     config = HConfig.from_text(Platform.CISCO_XR)
-    config.add_child("interface Bundle-Ether1")
+    config.add_child("interface GigabitEthernet0/0/0/1")
 
-    view = get_hconfig_view(config)
-    interface_view = view.interface_view_by_name("Bundle-Ether1")
-    assert interface_view is not None
-    with pytest.raises(NotImplementedError):
-        _ = interface_view.bundle_name
+    assert _interface_view(config).bundle_id is None
+
+
+def test_bundle_name() -> None:
+    config = HConfig.from_text(Platform.CISCO_XR)
+    config.add_children_deep(
+        ("interface GigabitEthernet0/0/0/1", "bundle id 42 mode active")
+    )
+
+    assert _interface_view(config).bundle_name == "Bundle-Ether42"
 
 
 def test_bundle_name_none() -> None:
-    """Test bundle_name returns None when not bundle (covers line 36)."""
     config = HConfig.from_text(Platform.CISCO_XR)
-    config.add_child("interface GigabitEthernet0/0/0/0")
+    config.add_child("interface GigabitEthernet0/0/0/1")
+
+    assert _interface_view(config).bundle_name is None
+
+
+def test_bundle_member_interfaces() -> None:
+    config = HConfig.from_text(Platform.CISCO_XR)
+    config.add_child("interface Bundle-Ether42")
+    config.add_children_deep(
+        ("interface GigabitEthernet0/0/0/1", "bundle id 42 mode active")
+    )
+    config.add_children_deep(
+        ("interface GigabitEthernet0/0/0/2", "bundle id 42 mode active")
+    )
+    config.add_children_deep(
+        ("interface GigabitEthernet0/0/0/3", "bundle id 43 mode active")
+    )
+
+    interface_view = _interface_view(config, "Bundle-Ether42")
+    assert list(interface_view.bundle_member_interfaces) == [
+        "GigabitEthernet0/0/0/1",
+        "GigabitEthernet0/0/0/2",
+    ]
+
+
+def test_bundle_member_interfaces_not_a_bundle() -> None:
+    config = HConfig.from_text(Platform.CISCO_XR)
+    config.add_child("interface GigabitEthernet0/0/0/1")
+
+    assert not list(_interface_view(config).bundle_member_interfaces)
+
+
+def test_is_bundle() -> None:
+    config = HConfig.from_text(Platform.CISCO_XR)
+    config.add_child("interface Bundle-Ether42")
+    config.add_child("interface GigabitEthernet0/0/0/1")
+
+    assert _interface_view(config, "Bundle-Ether42").is_bundle is True
+    assert _interface_view(config).is_bundle is False
 
     view = get_hconfig_view(config)
-    interface_view = view.interface_view_by_name("GigabitEthernet0/0/0/0")
-    assert interface_view is not None
-    with pytest.raises(NotImplementedError):
-        _ = interface_view.bundle_name
+    assert [iv.name for iv in view.bundle_interface_views] == ["Bundle-Ether42"]
 
 
 def test_description() -> None:
-    """Test description returns description text (covers lines 40-42)."""
+    """Test description returns description text."""
     config = HConfig.from_text(Platform.CISCO_XR)
-    interface = config.add_child("interface GigabitEthernet0/0/0/0")
-    interface.add_child("description Uplink to Core")
+    config.add_children_deep(("interface GigabitEthernet0/0/0/1", "description Uplink"))
 
-    view = get_hconfig_view(config)
-    interface_view = view.interface_view_by_name("GigabitEthernet0/0/0/0")
-    assert interface_view is not None
-    assert interface_view.description == "Uplink to Core"
+    assert _interface_view(config).description == "Uplink"
 
 
 def test_description_empty() -> None:
-    """Test description returns empty string (covers line 42)."""
+    """Test description returns empty string."""
     config = HConfig.from_text(Platform.CISCO_XR)
-    config.add_child("interface GigabitEthernet0/0/0/0")
+    config.add_child("interface GigabitEthernet0/0/0/1")
 
-    view = get_hconfig_view(config)
-    interface_view = view.interface_view_by_name("GigabitEthernet0/0/0/0")
-    assert interface_view is not None
-    assert not interface_view.description
+    assert not _interface_view(config).description
 
 
-def test_duplex_not_implemented() -> None:
-    """Test duplex raises NotImplementedError (covers line 46)."""
+def test_enabled() -> None:
     config = HConfig.from_text(Platform.CISCO_XR)
-    config.add_child("interface GigabitEthernet0/0/0/0")
+    config.add_child("interface GigabitEthernet0/0/0/1")
+    config.add_children_deep(("interface GigabitEthernet0/0/0/2", "shutdown"))
 
-    view = get_hconfig_view(config)
-    interface_view = view.interface_view_by_name("GigabitEthernet0/0/0/0")
-    assert interface_view is not None
-
-    with pytest.raises(NotImplementedError):
-        _ = interface_view.duplex
+    assert _interface_view(config).enabled is True
+    assert _interface_view(config, "GigabitEthernet0/0/0/2").enabled is False
 
 
-def test_enabled_not_implemented() -> None:
-    """Test enabled raises NotImplementedError (covers line 50)."""
+def test_ipv4_interfaces_netmask() -> None:
     config = HConfig.from_text(Platform.CISCO_XR)
-    config.add_child("interface GigabitEthernet0/0/0/0")
+    config.add_children_deep(
+        ("interface GigabitEthernet0/0/0/1", "ipv4 address 10.1.1.1 255.255.255.0")
+    )
 
-    view = get_hconfig_view(config)
-    interface_view = view.interface_view_by_name("GigabitEthernet0/0/0/0")
-    assert interface_view is not None
-
-    with pytest.raises(NotImplementedError):
-        _ = interface_view.enabled
+    assert list(_interface_view(config).ipv4_interfaces) == [
+        IPv4Interface("10.1.1.1/24")
+    ]
 
 
-def test_has_nac_not_implemented() -> None:
-    """Test has_nac raises NotImplementedError (covers line 55)."""
+def test_ipv4_interfaces_cidr() -> None:
     config = HConfig.from_text(Platform.CISCO_XR)
-    config.add_child("interface GigabitEthernet0/0/0/0")
+    config.add_children_deep(
+        ("interface GigabitEthernet0/0/0/1", "ipv4 address 10.1.1.1/24")
+    )
 
-    view = get_hconfig_view(config)
-    interface_view = view.interface_view_by_name("GigabitEthernet0/0/0/0")
-    assert interface_view is not None
-
-    with pytest.raises(NotImplementedError):
-        _ = interface_view.has_nac
+    assert _interface_view(config).ipv4_interface == IPv4Interface("10.1.1.1/24")
 
 
-def test_ipv4_interface_none() -> None:
-    """Test ipv4_interface returns None (covers line 59)."""
+def test_ipv4_interfaces_cidr_with_space() -> None:
     config = HConfig.from_text(Platform.CISCO_XR)
-    config.add_child("interface GigabitEthernet0/0/0/0")
+    config.add_children_deep(
+        ("interface GigabitEthernet0/0/0/1", "ipv4 address 10.1.1.1 /24")
+    )
 
-    view = get_hconfig_view(config)
-    interface_view = view.interface_view_by_name("GigabitEthernet0/0/0/0")
-    assert interface_view is not None
-    assert interface_view.ipv4_interface is None
-
-
-def test_ipv4_interfaces() -> None:
-    """Test ipv4_interfaces returns IP addresses (covers lines 63-68)."""
-    config = HConfig.from_text(Platform.CISCO_XR)
-    interface = config.add_child("interface GigabitEthernet0/0/0/0")
-    interface.add_child("ipv4 address 192.168.1.1 255.255.255.0")
-
-    view = get_hconfig_view(config)
-    interface_view = view.interface_view_by_name("GigabitEthernet0/0/0/0")
-    assert interface_view is not None
-
-    ips = list(interface_view.ipv4_interfaces)
-    assert len(ips) == 1
-    assert ips[0] == IPv4Interface("192.168.1.1/24")
+    assert _interface_view(config).ipv4_interface == IPv4Interface("10.1.1.1/24")
 
 
 def test_ipv4_interfaces_invalid() -> None:
-    """Test ipv4_interfaces skips invalid addresses (covers line 68)."""
     config = HConfig.from_text(Platform.CISCO_XR)
-    interface = config.add_child("interface GigabitEthernet0/0/0/0")
-    interface.add_child("ipv4 address dhcp")
+    config.add_children_deep(("interface GigabitEthernet0/0/0/1", "ipv4 address dhcp"))
 
-    view = get_hconfig_view(config)
-    interface_view = view.interface_view_by_name("GigabitEthernet0/0/0/0")
-    assert interface_view is not None
-
-    ips = list(interface_view.ipv4_interfaces)
-    assert len(ips) == 0
+    assert not list(_interface_view(config).ipv4_interfaces)
 
 
-def test_is_bundle_false() -> None:
-    """Test is_bundle returns False (covers line 72)."""
-    config = HConfig.from_text(Platform.CISCO_XR)
-    config.add_child("interface GigabitEthernet0/0/0/0")
-
-    view = get_hconfig_view(config)
-    interface_view = view.interface_view_by_name("GigabitEthernet0/0/0/0")
-    assert interface_view is not None
-    assert interface_view.is_bundle is False
-
-
-def test_is_loopback_true() -> None:
-    """Test is_loopback returns True (covers line 76)."""
+def test_is_loopback() -> None:
     config = HConfig.from_text(Platform.CISCO_XR)
     config.add_child("interface Loopback0")
+    config.add_child("interface GigabitEthernet0/0/0/1")
 
-    view = get_hconfig_view(config)
-    interface_view = view.interface_view_by_name("Loopback0")
-    assert interface_view is not None
-    assert interface_view.is_loopback is True
+    assert _interface_view(config, "Loopback0").is_loopback is True
+    assert _interface_view(config).is_loopback is False
 
 
-def test_is_loopback_false() -> None:
-    """Test is_loopback returns False (covers line 76)."""
+def test_is_svi() -> None:
     config = HConfig.from_text(Platform.CISCO_XR)
-    config.add_child("interface GigabitEthernet0/0/0/0")
+    config.add_child("interface GigabitEthernet0/0/0/1")
 
-    view = get_hconfig_view(config)
-    interface_view = view.interface_view_by_name("GigabitEthernet0/0/0/0")
-    assert interface_view is not None
-    assert interface_view.is_loopback is False
+    assert _interface_view(config).is_svi is False
 
 
-def test_is_subinterface_true() -> None:
-    """Test is_subinterface returns True (covers line 80)."""
+def test_name_and_number() -> None:
     config = HConfig.from_text(Platform.CISCO_XR)
-    config.add_child("interface GigabitEthernet0/0/0/0.100")
+    config.add_child("interface GigabitEthernet0/1/2/3")
 
-    view = get_hconfig_view(config)
-    interface_view = view.interface_view_by_name("GigabitEthernet0/0/0/0.100")
-    assert interface_view is not None
-    assert interface_view.is_subinterface is True
+    interface_view = _interface_view(config, "GigabitEthernet0/1/2/3")
+    assert interface_view.name == "GigabitEthernet0/1/2/3"
+    assert interface_view.number == "0/1/2/3"
+    assert interface_view.port_number == 3
 
 
-def test_is_subinterface_false() -> None:
-    """Test is_subinterface returns False (covers line 80)."""
+def test_subinterface() -> None:
     config = HConfig.from_text(Platform.CISCO_XR)
-    config.add_child("interface GigabitEthernet0/0/0/0")
+    config.add_child("interface GigabitEthernet0/0/0/1.100")
+    config.add_child("interface GigabitEthernet0/0/0/1")
 
-    view = get_hconfig_view(config)
-    interface_view = view.interface_view_by_name("GigabitEthernet0/0/0/0")
-    assert interface_view is not None
+    subinterface_view = _interface_view(config, "GigabitEthernet0/0/0/1.100")
+    assert subinterface_view.is_subinterface is True
+    assert subinterface_view.parent_name == "GigabitEthernet0/0/0/1"
+    assert subinterface_view.subinterface_number == 100
+
+    interface_view = _interface_view(config)
     assert interface_view.is_subinterface is False
-
-
-def test_is_svi_true() -> None:
-    """Test is_svi returns True (covers line 84)."""
-    config = HConfig.from_text(Platform.CISCO_XR)
-    config.add_child("interface vlan100")
-
-    view = get_hconfig_view(config)
-    interface_view = view.interface_view_by_name("vlan100")
-    assert interface_view is not None
-    assert interface_view.is_svi is True
-
-
-def test_is_svi_false() -> None:
-    """Test is_svi returns False (covers line 84)."""
-    config = HConfig.from_text(Platform.CISCO_XR)
-    config.add_child("interface GigabitEthernet0/0/0/0")
-
-    view = get_hconfig_view(config)
-    interface_view = view.interface_view_by_name("GigabitEthernet0/0/0/0")
-    assert interface_view is not None
-    assert interface_view.is_svi is False
-
-
-def test_module_number() -> None:
-    """Test module_number returns module (covers lines 88-91)."""
-    config = HConfig.from_text(Platform.CISCO_XR)
-    config.add_child("interface GigabitEthernet0/2/0/5")
-
-    view = get_hconfig_view(config)
-    interface_view = view.interface_view_by_name("GigabitEthernet0/2/0/5")
-    assert interface_view is not None
-    assert interface_view.module_number == 0
-
-
-def test_module_number_none() -> None:
-    """Test module_number returns None (covers lines 90-91)."""
-    config = HConfig.from_text(Platform.CISCO_XR)
-    config.add_child("interface Loopback0")
-
-    view = get_hconfig_view(config)
-    interface_view = view.interface_view_by_name("Loopback0")
-    assert interface_view is not None
-    assert interface_view.module_number is None
-
-
-def test_nac_control_direction_in_not_implemented() -> None:
-    """Test nac_control_direction_in raises NotImplementedError (covers line 96)."""
-    config = HConfig.from_text(Platform.CISCO_XR)
-    config.add_child("interface GigabitEthernet0/0/0/0")
-
-    view = get_hconfig_view(config)
-    interface_view = view.interface_view_by_name("GigabitEthernet0/0/0/0")
-    assert interface_view is not None
-
-    with pytest.raises(NotImplementedError):
-        _ = interface_view.nac_control_direction_in
-
-
-def test_nac_host_mode_not_implemented() -> None:
-    """Test nac_host_mode raises NotImplementedError (covers line 101)."""
-    config = HConfig.from_text(Platform.CISCO_XR)
-    config.add_child("interface GigabitEthernet0/0/0/0")
-
-    view = get_hconfig_view(config)
-    interface_view = view.interface_view_by_name("GigabitEthernet0/0/0/0")
-    assert interface_view is not None
-
-    with pytest.raises(NotImplementedError):
-        _ = interface_view.nac_host_mode
-
-
-def test_nac_mab_first_not_implemented() -> None:
-    """Test nac_mab_first raises NotImplementedError (covers line 106)."""
-    config = HConfig.from_text(Platform.CISCO_XR)
-    config.add_child("interface GigabitEthernet0/0/0/0")
-
-    view = get_hconfig_view(config)
-    interface_view = view.interface_view_by_name("GigabitEthernet0/0/0/0")
-    assert interface_view is not None
-
-    with pytest.raises(NotImplementedError):
-        _ = interface_view.nac_mab_first
-
-
-def test_nac_max_dot1x_clients_not_implemented() -> None:
-    """Test nac_max_dot1x_clients raises NotImplementedError (covers line 111)."""
-    config = HConfig.from_text(Platform.CISCO_XR)
-    config.add_child("interface GigabitEthernet0/0/0/0")
-
-    view = get_hconfig_view(config)
-    interface_view = view.interface_view_by_name("GigabitEthernet0/0/0/0")
-    assert interface_view is not None
-
-    with pytest.raises(NotImplementedError):
-        _ = interface_view.nac_max_dot1x_clients
-
-
-def test_nac_max_mab_clients_not_implemented() -> None:
-    """Test nac_max_mab_clients raises NotImplementedError (covers line 116)."""
-    config = HConfig.from_text(Platform.CISCO_XR)
-    config.add_child("interface GigabitEthernet0/0/0/0")
-
-    view = get_hconfig_view(config)
-    interface_view = view.interface_view_by_name("GigabitEthernet0/0/0/0")
-    assert interface_view is not None
-
-    with pytest.raises(NotImplementedError):
-        _ = interface_view.nac_max_mab_clients
-
-
-def test_name() -> None:
-    """Test name returns interface name (covers line 120)."""
-    config = HConfig.from_text(Platform.CISCO_XR)
-    config.add_child("interface GigabitEthernet0/0/0/10")
-
-    view = get_hconfig_view(config)
-    interface_view = view.interface_view_by_name("GigabitEthernet0/0/0/10")
-    assert interface_view is not None
-    assert interface_view.name == "GigabitEthernet0/0/0/10"
-
-
-def test_native_vlan_not_implemented() -> None:
-    """Test native_vlan raises NotImplementedError (covers line 124)."""
-    config = HConfig.from_text(Platform.CISCO_XR)
-    config.add_child("interface GigabitEthernet0/0/0/0")
-
-    view = get_hconfig_view(config)
-    interface_view = view.interface_view_by_name("GigabitEthernet0/0/0/0")
-    assert interface_view is not None
-
-    with pytest.raises(NotImplementedError):
-        _ = interface_view.native_vlan
-
-
-def test_number() -> None:
-    """Test number returns interface number (covers line 128)."""
-    config = HConfig.from_text(Platform.CISCO_XR)
-    config.add_child("interface GigabitEthernet0/1/2/15")
-
-    view = get_hconfig_view(config)
-    interface_view = view.interface_view_by_name("GigabitEthernet0/1/2/15")
-    assert interface_view is not None
-    assert interface_view.number == "0/1/2/15"
-
-
-def test_parent_name() -> None:
-    """Test parent_name returns parent interface (covers lines 132-134)."""
-    config = HConfig.from_text(Platform.CISCO_XR)
-    config.add_child("interface GigabitEthernet0/0/0/0.100")
-
-    view = get_hconfig_view(config)
-    interface_view = view.interface_view_by_name("GigabitEthernet0/0/0/0.100")
-    assert interface_view is not None
-    assert interface_view.parent_name == "GigabitEthernet0/0/0/0"
-
-
-def test_parent_name_none() -> None:
-    """Test parent_name returns None (covers line 134)."""
-    config = HConfig.from_text(Platform.CISCO_XR)
-    config.add_child("interface GigabitEthernet0/0/0/0")
-
-    view = get_hconfig_view(config)
-    interface_view = view.interface_view_by_name("GigabitEthernet0/0/0/0")
-    assert interface_view is not None
     assert interface_view.parent_name is None
-
-
-def test_poe_not_implemented() -> None:
-    """Test poe raises NotImplementedError (covers line 138)."""
-    config = HConfig.from_text(Platform.CISCO_XR)
-    config.add_child("interface GigabitEthernet0/0/0/0")
-
-    view = get_hconfig_view(config)
-    interface_view = view.interface_view_by_name("GigabitEthernet0/0/0/0")
-    assert interface_view is not None
-
-    with pytest.raises(NotImplementedError):
-        _ = interface_view.poe
-
-
-def test_port_number() -> None:
-    """Test port_number returns port number (covers line 142)."""
-    config = HConfig.from_text(Platform.CISCO_XR)
-    config.add_child("interface GigabitEthernet0/2/1/25")
-
-    view = get_hconfig_view(config)
-    interface_view = view.interface_view_by_name("GigabitEthernet0/2/1/25")
-    assert interface_view is not None
-    assert interface_view.port_number == 25
-
-
-def test_port_number_with_subinterface() -> None:
-    """Test port_number with subinterface (covers line 142)."""
-    config = HConfig.from_text(Platform.CISCO_XR)
-    config.add_child("interface GigabitEthernet0/0/0/5.200")
-
-    view = get_hconfig_view(config)
-    interface_view = view.interface_view_by_name("GigabitEthernet0/0/0/5.200")
-    assert interface_view is not None
-    assert interface_view.port_number == 5
-
-
-def test_speed_not_implemented() -> None:
-    """Test speed raises NotImplementedError (covers line 146)."""
-    config = HConfig.from_text(Platform.CISCO_XR)
-    config.add_child("interface GigabitEthernet0/0/0/0")
-
-    view = get_hconfig_view(config)
-    interface_view = view.interface_view_by_name("GigabitEthernet0/0/0/0")
-    assert interface_view is not None
-
-    with pytest.raises(NotImplementedError):
-        _ = interface_view.speed
-
-
-def test_subinterface_number() -> None:
-    """Test subinterface_number returns number (covers line 150)."""
-    config = HConfig.from_text(Platform.CISCO_XR)
-    config.add_child("interface GigabitEthernet0/0/0/0.500")
-
-    view = get_hconfig_view(config)
-    interface_view = view.interface_view_by_name("GigabitEthernet0/0/0/0.500")
-    assert interface_view is not None
-    assert interface_view.subinterface_number == 500
-
-
-def test_subinterface_number_none() -> None:
-    """Test subinterface_number returns None (covers line 150)."""
-    config = HConfig.from_text(Platform.CISCO_XR)
-    config.add_child("interface GigabitEthernet0/0/0/0")
-
-    view = get_hconfig_view(config)
-    interface_view = view.interface_view_by_name("GigabitEthernet0/0/0/0")
-    assert interface_view is not None
     assert interface_view.subinterface_number is None
 
 
-def test_tagged_all_not_implemented() -> None:
-    """Test tagged_all raises NotImplementedError (covers line 154)."""
+def test_native_vlan_subinterface() -> None:
     config = HConfig.from_text(Platform.CISCO_XR)
-    config.add_child("interface GigabitEthernet0/0/0/0")
+    config.add_children_deep(
+        ("interface GigabitEthernet0/0/0/1.100", "encapsulation dot1q 100")
+    )
 
-    view = get_hconfig_view(config)
-    interface_view = view.interface_view_by_name("GigabitEthernet0/0/0/0")
-    assert interface_view is not None
-
-    with pytest.raises(NotImplementedError):
-        _ = interface_view.tagged_all
+    assert _interface_view(config, "GigabitEthernet0/0/0/1.100").native_vlan == 100
 
 
-def test_tagged_vlans_not_implemented() -> None:
-    """Test tagged_vlans raises NotImplementedError (covers line 158)."""
+def test_native_vlan_none() -> None:
     config = HConfig.from_text(Platform.CISCO_XR)
-    config.add_child("interface GigabitEthernet0/0/0/0")
+    config.add_child("interface GigabitEthernet0/0/0/1")
 
-    view = get_hconfig_view(config)
-    interface_view = view.interface_view_by_name("GigabitEthernet0/0/0/0")
-    assert interface_view is not None
-
-    with pytest.raises(NotImplementedError):
-        _ = interface_view.tagged_vlans
+    assert _interface_view(config).native_vlan is None
 
 
-def test_vrf_not_implemented() -> None:
-    """Test vrf raises NotImplementedError (covers line 162)."""
+def test_tagged_all_and_tagged_vlans() -> None:
+    """IOS XR interfaces never carry switchport-style tagged VLANs."""
     config = HConfig.from_text(Platform.CISCO_XR)
-    config.add_child("interface GigabitEthernet0/0/0/0")
+    config.add_child("interface GigabitEthernet0/0/0/1")
 
-    view = get_hconfig_view(config)
-    interface_view = view.interface_view_by_name("GigabitEthernet0/0/0/0")
-    assert interface_view is not None
+    interface_view = _interface_view(config)
+    assert interface_view.tagged_all is False
+    assert interface_view.tagged_vlans == ()
+    assert interface_view.dot1q_mode is None
 
-    with pytest.raises(NotImplementedError):
-        _ = interface_view.vrf
+
+def test_vrf() -> None:
+    config = HConfig.from_text(Platform.CISCO_XR)
+    config.add_children_deep(("interface GigabitEthernet0/0/0/1", "vrf RED"))
+    config.add_child("interface GigabitEthernet0/0/0/2")
+
+    assert _interface_view(config).vrf == "RED"
+    assert not _interface_view(config, "GigabitEthernet0/0/0/2").vrf
 
 
 def test_hostname() -> None:
-    """Test hostname returns hostname (covers lines 177-179)."""
+    """Test hostname returns hostname."""
     config = HConfig.from_text(Platform.CISCO_XR)
-    config.add_child("hostname CORE-ROUTER-01")
+    config.add_child("hostname XR-PE-01")
 
     view = get_hconfig_view(config)
-    assert view.hostname == "core-router-01"
+    assert view.hostname == "xr-pe-01"
 
 
 def test_hostname_none() -> None:
-    """Test hostname returns None (covers line 179)."""
+    """Test hostname returns None."""
     config = HConfig.from_text(Platform.CISCO_XR)
 
     view = get_hconfig_view(config)
     assert view.hostname is None
 
 
-def test_interface_names_mentioned_not_implemented() -> None:
-    """Test interface_names_mentioned raises NotImplementedError (covers line 183)."""
+def test_interface_names_mentioned() -> None:
     config = HConfig.from_text(Platform.CISCO_XR)
-    config.add_child("interface GigabitEthernet0/0/0/0")
+    config.add_child("interface GigabitEthernet0/0/0/1")
+    config.add_child("interface Bundle-Ether42")
 
     view = get_hconfig_view(config)
-
-    with pytest.raises(NotImplementedError):
-        _ = view.interface_names_mentioned
+    assert view.interface_names_mentioned == frozenset(
+        {"GigabitEthernet0/0/0/1", "Bundle-Ether42"}
+    )
 
 
 def test_interface_views() -> None:
-    """Test interface_views yields interface views (covers lines 187-188)."""
+    """Test interface_views yields interface views."""
     config = HConfig.from_text(Platform.CISCO_XR)
-    config.add_child("interface GigabitEthernet0/0/0/0")
     config.add_child("interface GigabitEthernet0/0/0/1")
+    config.add_child("interface GigabitEthernet0/0/0/2")
+    config.add_child("interface Loopback0")
 
     view = get_hconfig_view(config)
     interface_views = list(view.interface_views)
 
-    assert len(interface_views) == 2
-    assert any(iv.name == "GigabitEthernet0/0/0/0" for iv in interface_views)
-    assert any(iv.name == "GigabitEthernet0/0/0/1" for iv in interface_views)
+    assert len(interface_views) == 3
 
 
 def test_interfaces() -> None:
-    """Test interfaces returns interface children (covers line 192)."""
+    """Test interfaces returns interface children."""
     config = HConfig.from_text(Platform.CISCO_XR)
-    config.add_child("interface GigabitEthernet0/0/0/0")
     config.add_child("interface GigabitEthernet0/0/0/1")
-    config.add_child("interface Loopback0")
+    config.add_child("interface GigabitEthernet0/0/0/2")
 
     view = get_hconfig_view(config)
     interfaces = list(view.interfaces)
 
-    assert len(interfaces) == 3
+    assert len(interfaces) == 2
 
 
-def test_ipv4_default_gw_not_implemented() -> None:
-    """Test ipv4_default_gw raises NotImplementedError (covers line 196)."""
+def test_ipv4_default_gw() -> None:
+    config = HConfig.from_text(Platform.CISCO_XR)
+    config.add_children_deep(
+        (
+            "router static",
+            "address-family ipv4 unicast",
+            "0.0.0.0/0 192.0.2.254",
+        )
+    )
+
+    view = get_hconfig_view(config)
+    assert view.ipv4_default_gw == IPv4Address("192.0.2.254")
+
+
+def test_ipv4_default_gw_none() -> None:
     config = HConfig.from_text(Platform.CISCO_XR)
 
     view = get_hconfig_view(config)
-
-    with pytest.raises(NotImplementedError):
-        _ = view.ipv4_default_gw
+    assert view.ipv4_default_gw is None
 
 
-def test_location_not_implemented() -> None:
-    """Test location raises NotImplementedError (covers line 200)."""
+def test_ipv4_default_gw_none_without_default_route() -> None:
+    config = HConfig.from_text(Platform.CISCO_XR)
+    config.add_children_deep(
+        (
+            "router static",
+            "address-family ipv4 unicast",
+            "10.0.0.0/8 192.0.2.1",
+        )
+    )
+
+    view = get_hconfig_view(config)
+    assert view.ipv4_default_gw is None
+
+
+def test_location() -> None:
+    config = HConfig.from_text(Platform.CISCO_XR)
+    config.add_child('snmp-server location "Data Center 1"')
+
+    view = get_hconfig_view(config)
+    assert view.location == "Data Center 1"
+
+
+def test_location_empty() -> None:
     config = HConfig.from_text(Platform.CISCO_XR)
 
     view = get_hconfig_view(config)
-
-    with pytest.raises(NotImplementedError):
-        _ = view.location
+    assert not view.location
 
 
-def test_stack_members_not_implemented() -> None:
-    """Test stack_members raises NotImplementedError (covers line 204)."""
+def test_stack_members() -> None:
+    """IOS XR has no stacking, so stack_members is always empty."""
     config = HConfig.from_text(Platform.CISCO_XR)
 
     view = get_hconfig_view(config)
-
-    with pytest.raises(NotImplementedError):
-        _ = list(view.stack_members)
+    assert not list(view.stack_members)
 
 
-def test_vlans_not_implemented() -> None:
-    """Test vlans raises NotImplementedError (covers line 208)."""
+def test_vlans() -> None:
+    """VLANs are derived from sub-interface encapsulations."""
     config = HConfig.from_text(Platform.CISCO_XR)
+    config.add_children_deep(
+        ("interface GigabitEthernet0/0/0/1.100", "encapsulation dot1q 100")
+    )
+    config.add_children_deep(
+        ("interface GigabitEthernet0/0/0/1.200", "encapsulation dot1q 200")
+    )
+    config.add_children_deep(
+        ("interface GigabitEthernet0/0/0/2.100", "encapsulation dot1q 100")
+    )
 
     view = get_hconfig_view(config)
-
-    with pytest.raises(NotImplementedError):
-        _ = list(view.vlans)
+    assert list(view.vlans) == [
+        Vlan(id=100, name=None),
+        Vlan(id=200, name=None),
+    ]
+    assert view.vlan_ids == frozenset({100, 200})

--- a/tests/unit/platforms/views/test_hp_procurve.py
+++ b/tests/unit/platforms/views/test_hp_procurve.py
@@ -4,13 +4,13 @@ from ipaddress import IPv4Address, IPv4Interface
 
 import pytest
 
-from hier_config import Platform, get_hconfig, get_hconfig_view
+from hier_config import HConfig, Platform, get_hconfig_view
 from hier_config.platforms.models import InterfaceDuplex, StackMember
 
 
 def test_bundle_id_not_implemented() -> None:
     """Test bundle_id raises NotImplementedError (covers line 26)."""
-    config = get_hconfig(Platform.HP_PROCURVE)
+    config = HConfig.from_text(Platform.HP_PROCURVE)
     config.add_child("interface Trk1")
 
     view = get_hconfig_view(config)
@@ -23,7 +23,7 @@ def test_bundle_id_not_implemented() -> None:
 
 def test_bundle_member_interfaces() -> None:
     """Test bundle_member_interfaces returns member interfaces (covers lines 31-42)."""
-    config = get_hconfig(Platform.HP_PROCURVE)
+    config = HConfig.from_text(Platform.HP_PROCURVE)
     config.add_child("interface Trk1")
     config.add_child("trunk 1/45,2/45 trk1 trunk")
 
@@ -38,7 +38,7 @@ def test_bundle_member_interfaces() -> None:
 
 def test_bundle_member_interfaces_bundle_not_found_error() -> None:
     """Test bundle_member_interfaces raises TypeError when bundle config missing (covers lines 33-36)."""
-    config = get_hconfig(Platform.HP_PROCURVE)
+    config = HConfig.from_text(Platform.HP_PROCURVE)
     config.add_child("interface Trk1")
 
     view = get_hconfig_view(config)
@@ -53,7 +53,7 @@ def test_bundle_member_interfaces_bundle_not_found_error() -> None:
 
 def test_bundle_member_interfaces_value_error() -> None:
     """Test bundle_member_interfaces raises ValueError for non-bundle (covers lines 38-40)."""
-    config = get_hconfig(Platform.HP_PROCURVE)
+    config = HConfig.from_text(Platform.HP_PROCURVE)
     config.add_child("interface 1/1")
 
     view = get_hconfig_view(config)
@@ -66,7 +66,7 @@ def test_bundle_member_interfaces_value_error() -> None:
 
 def test_bundle_name() -> None:
     """Test bundle_name returns bundle name (covers lines 46-53)."""
-    config = get_hconfig(Platform.HP_PROCURVE)
+    config = HConfig.from_text(Platform.HP_PROCURVE)
     config.add_child("interface 1/1")
     config.add_child("trunk 1/1-2 trk1 lacp")
 
@@ -78,7 +78,7 @@ def test_bundle_name() -> None:
 
 def test_bundle_name_none() -> None:
     """Test bundle_name returns None when not in bundle (covers line 53)."""
-    config = get_hconfig(Platform.HP_PROCURVE)
+    config = HConfig.from_text(Platform.HP_PROCURVE)
     config.add_child("interface 1/1")
 
     view = get_hconfig_view(config)
@@ -89,7 +89,7 @@ def test_bundle_name_none() -> None:
 
 def test_description() -> None:
     """Test description returns interface name (covers lines 57-59)."""
-    config = get_hconfig(Platform.HP_PROCURVE)
+    config = HConfig.from_text(Platform.HP_PROCURVE)
     config.add_children_deep(("interface 1/1", 'name "uplink port"'))
 
     view = get_hconfig_view(config)
@@ -100,7 +100,7 @@ def test_description() -> None:
 
 def test_description_empty() -> None:
     """Test description returns empty string (covers line 59)."""
-    config = get_hconfig(Platform.HP_PROCURVE)
+    config = HConfig.from_text(Platform.HP_PROCURVE)
     config.add_child("interface 1/1")
 
     view = get_hconfig_view(config)
@@ -111,7 +111,7 @@ def test_description_empty() -> None:
 
 def test_duplex_auto() -> None:
     """Test duplex returns auto (covers line 65)."""
-    config = get_hconfig(Platform.HP_PROCURVE)
+    config = HConfig.from_text(Platform.HP_PROCURVE)
     config.add_child("interface 1/1")
 
     view = get_hconfig_view(config)
@@ -122,7 +122,7 @@ def test_duplex_auto() -> None:
 
 def test_enabled_true() -> None:
     """Test enabled returns True (covers line 69)."""
-    config = get_hconfig(Platform.HP_PROCURVE)
+    config = HConfig.from_text(Platform.HP_PROCURVE)
     config.add_child("interface 1/1")
 
     view = get_hconfig_view(config)
@@ -133,7 +133,7 @@ def test_enabled_true() -> None:
 
 def test_enabled_false() -> None:
     """Test enabled returns False when disabled (covers line 69)."""
-    config = get_hconfig(Platform.HP_PROCURVE)
+    config = HConfig.from_text(Platform.HP_PROCURVE)
     config.add_children_deep(("interface 1/1", "disable"))
 
     view = get_hconfig_view(config)
@@ -144,7 +144,7 @@ def test_enabled_false() -> None:
 
 def test_has_nac_authenticator() -> None:
     """Test has_nac with authenticator (covers line 74)."""
-    config = get_hconfig(Platform.HP_PROCURVE)
+    config = HConfig.from_text(Platform.HP_PROCURVE)
     config.add_child("interface 1/1")
     config.add_child("aaa port-access authenticator 1/1")
 
@@ -156,7 +156,7 @@ def test_has_nac_authenticator() -> None:
 
 def test_has_nac_mac_based() -> None:
     """Test has_nac with mac-based (covers line 74)."""
-    config = get_hconfig(Platform.HP_PROCURVE)
+    config = HConfig.from_text(Platform.HP_PROCURVE)
     config.add_child("interface 1/1")
     config.add_child("aaa port-access mac-based 1/1")
 
@@ -168,7 +168,7 @@ def test_has_nac_mac_based() -> None:
 
 def test_has_nac_false() -> None:
     """Test has_nac returns False (covers line 74)."""
-    config = get_hconfig(Platform.HP_PROCURVE)
+    config = HConfig.from_text(Platform.HP_PROCURVE)
     config.add_child("interface 1/1")
 
     view = get_hconfig_view(config)
@@ -179,7 +179,7 @@ def test_has_nac_false() -> None:
 
 def test_ipv4_interface_none() -> None:
     """Test ipv4_interface returns None (covers line 84)."""
-    config = get_hconfig(Platform.HP_PROCURVE)
+    config = HConfig.from_text(Platform.HP_PROCURVE)
     config.add_child("interface 1/1")
 
     view = get_hconfig_view(config)
@@ -190,7 +190,7 @@ def test_ipv4_interface_none() -> None:
 
 def test_ipv4_interfaces() -> None:
     """Test ipv4_interfaces returns IP addresses (covers lines 88-93)."""
-    config = get_hconfig(Platform.HP_PROCURVE)
+    config = HConfig.from_text(Platform.HP_PROCURVE)
     config.add_children_deep(("vlan 10", "ip address 10.1.1.1 255.255.255.0"))
 
     view = get_hconfig_view(config)
@@ -204,7 +204,7 @@ def test_ipv4_interfaces() -> None:
 
 def test_ipv4_interfaces_invalid() -> None:
     """Test ipv4_interfaces skips invalid addresses (covers line 93)."""
-    config = get_hconfig(Platform.HP_PROCURVE)
+    config = HConfig.from_text(Platform.HP_PROCURVE)
     config.add_children_deep(("vlan 10", "ip address dhcp-bootp"))
 
     view = get_hconfig_view(config)
@@ -217,7 +217,7 @@ def test_ipv4_interfaces_invalid() -> None:
 
 def test_is_bundle_true() -> None:
     """Test is_bundle returns True (covers line 97)."""
-    config = get_hconfig(Platform.HP_PROCURVE)
+    config = HConfig.from_text(Platform.HP_PROCURVE)
     config.add_child("interface Trk1")
 
     view = get_hconfig_view(config)
@@ -228,7 +228,7 @@ def test_is_bundle_true() -> None:
 
 def test_is_bundle_false() -> None:
     """Test is_bundle returns False (covers line 97)."""
-    config = get_hconfig(Platform.HP_PROCURVE)
+    config = HConfig.from_text(Platform.HP_PROCURVE)
     config.add_child("interface 1/1")
 
     view = get_hconfig_view(config)
@@ -239,7 +239,7 @@ def test_is_bundle_false() -> None:
 
 def test_is_loopback_true() -> None:
     """Test is_loopback returns True (covers line 101)."""
-    config = get_hconfig(Platform.HP_PROCURVE)
+    config = HConfig.from_text(Platform.HP_PROCURVE)
     config.add_child("interface Loopback0")
 
     view = get_hconfig_view(config)
@@ -250,7 +250,7 @@ def test_is_loopback_true() -> None:
 
 def test_is_loopback_false() -> None:
     """Test is_loopback returns False (covers line 101)."""
-    config = get_hconfig(Platform.HP_PROCURVE)
+    config = HConfig.from_text(Platform.HP_PROCURVE)
     config.add_child("interface 1/1")
 
     view = get_hconfig_view(config)
@@ -261,7 +261,7 @@ def test_is_loopback_false() -> None:
 
 def test_is_subinterface_true() -> None:
     """Test is_subinterface returns True (covers line 105)."""
-    config = get_hconfig(Platform.HP_PROCURVE)
+    config = HConfig.from_text(Platform.HP_PROCURVE)
     config.add_child("interface 1/1.100")
 
     view = get_hconfig_view(config)
@@ -272,7 +272,7 @@ def test_is_subinterface_true() -> None:
 
 def test_is_subinterface_false() -> None:
     """Test is_subinterface returns False (covers line 105)."""
-    config = get_hconfig(Platform.HP_PROCURVE)
+    config = HConfig.from_text(Platform.HP_PROCURVE)
     config.add_child("interface 1/1")
 
     view = get_hconfig_view(config)
@@ -283,7 +283,7 @@ def test_is_subinterface_false() -> None:
 
 def test_is_svi_true() -> None:
     """Test is_svi returns True (covers line 109)."""
-    config = get_hconfig(Platform.HP_PROCURVE)
+    config = HConfig.from_text(Platform.HP_PROCURVE)
     vlan = config.add_child("vlan 10")
     vlan.add_child("ip address 10.1.1.1 255.255.255.0")
 
@@ -296,7 +296,7 @@ def test_is_svi_true() -> None:
 
 def test_is_svi_false() -> None:
     """Test is_svi returns False (covers line 109)."""
-    config = get_hconfig(Platform.HP_PROCURVE)
+    config = HConfig.from_text(Platform.HP_PROCURVE)
     config.add_child("interface 1/1")
 
     view = get_hconfig_view(config)
@@ -307,7 +307,7 @@ def test_is_svi_false() -> None:
 
 def test_module_number() -> None:
     """Test module_number returns module (covers lines 113-116)."""
-    config = get_hconfig(Platform.HP_PROCURVE)
+    config = HConfig.from_text(Platform.HP_PROCURVE)
     config.add_child("interface 2/10")
 
     view = get_hconfig_view(config)
@@ -318,7 +318,7 @@ def test_module_number() -> None:
 
 def test_module_number_none() -> None:
     """Test module_number returns None (covers lines 115-116)."""
-    config = get_hconfig(Platform.HP_PROCURVE)
+    config = HConfig.from_text(Platform.HP_PROCURVE)
     config.add_child("interface Trk1")
 
     view = get_hconfig_view(config)
@@ -329,7 +329,7 @@ def test_module_number_none() -> None:
 
 def test_nac_control_direction_in_true() -> None:
     """Test nac_control_direction_in returns True (covers line 121)."""
-    config = get_hconfig(Platform.HP_PROCURVE)
+    config = HConfig.from_text(Platform.HP_PROCURVE)
     config.add_child("interface 1/1")
     config.add_child("aaa port-access 1/1 controlled-direction in")
 
@@ -341,7 +341,7 @@ def test_nac_control_direction_in_true() -> None:
 
 def test_nac_control_direction_in_false() -> None:
     """Test nac_control_direction_in returns False (covers line 121)."""
-    config = get_hconfig(Platform.HP_PROCURVE)
+    config = HConfig.from_text(Platform.HP_PROCURVE)
     config.add_child("interface 1/1")
 
     view = get_hconfig_view(config)
@@ -352,7 +352,7 @@ def test_nac_control_direction_in_false() -> None:
 
 def test_nac_host_mode() -> None:
     """Test nac_host_mode returns None (covers line 130)."""
-    config = get_hconfig(Platform.HP_PROCURVE)
+    config = HConfig.from_text(Platform.HP_PROCURVE)
     config.add_child("interface 1/1")
 
     view = get_hconfig_view(config)
@@ -363,7 +363,7 @@ def test_nac_host_mode() -> None:
 
 def test_nac_mab_first_true() -> None:
     """Test nac_mab_first returns True (covers line 135)."""
-    config = get_hconfig(Platform.HP_PROCURVE)
+    config = HConfig.from_text(Platform.HP_PROCURVE)
     config.add_child("interface 1/1")
     config.add_child("aaa port-access 1/1 auth-order mac-based authenticator")
 
@@ -375,7 +375,7 @@ def test_nac_mab_first_true() -> None:
 
 def test_nac_mab_first_false() -> None:
     """Test nac_mab_first returns False (covers line 135)."""
-    config = get_hconfig(Platform.HP_PROCURVE)
+    config = HConfig.from_text(Platform.HP_PROCURVE)
     config.add_child("interface 1/1")
 
     view = get_hconfig_view(config)
@@ -386,7 +386,7 @@ def test_nac_mab_first_false() -> None:
 
 def test_nac_max_dot1x_clients() -> None:
     """Test nac_max_dot1x_clients returns count (covers lines 144-148)."""
-    config = get_hconfig(Platform.HP_PROCURVE)
+    config = HConfig.from_text(Platform.HP_PROCURVE)
     config.add_child("interface 1/1")
     config.add_child("aaa port-access authenticator 1/1 client-limit 5")
 
@@ -398,7 +398,7 @@ def test_nac_max_dot1x_clients() -> None:
 
 def test_nac_max_dot1x_clients_default() -> None:
     """Test nac_max_dot1x_clients returns default (covers line 148)."""
-    config = get_hconfig(Platform.HP_PROCURVE)
+    config = HConfig.from_text(Platform.HP_PROCURVE)
     config.add_child("interface 1/1")
 
     view = get_hconfig_view(config)
@@ -409,7 +409,7 @@ def test_nac_max_dot1x_clients_default() -> None:
 
 def test_nac_max_mab_clients() -> None:
     """Test nac_max_mab_clients returns count (covers lines 153-157)."""
-    config = get_hconfig(Platform.HP_PROCURVE)
+    config = HConfig.from_text(Platform.HP_PROCURVE)
     config.add_child("interface 1/1")
     config.add_child("aaa port-access mac-based 1/1 addr-limit 10")
 
@@ -421,7 +421,7 @@ def test_nac_max_mab_clients() -> None:
 
 def test_nac_max_mab_clients_default() -> None:
     """Test nac_max_mab_clients returns default (covers line 157)."""
-    config = get_hconfig(Platform.HP_PROCURVE)
+    config = HConfig.from_text(Platform.HP_PROCURVE)
     config.add_child("interface 1/1")
 
     view = get_hconfig_view(config)
@@ -432,7 +432,7 @@ def test_nac_max_mab_clients_default() -> None:
 
 def test_name_with_interface_prefix() -> None:
     """Test name returns interface name (covers lines 161-163)."""
-    config = get_hconfig(Platform.HP_PROCURVE)
+    config = HConfig.from_text(Platform.HP_PROCURVE)
     config.add_child("interface 1/1")
 
     view = get_hconfig_view(config)
@@ -443,7 +443,7 @@ def test_name_with_interface_prefix() -> None:
 
 def test_name_without_interface_prefix() -> None:
     """Test name returns text as-is (covers line 163)."""
-    config = get_hconfig(Platform.HP_PROCURVE)
+    config = HConfig.from_text(Platform.HP_PROCURVE)
     vlan = config.add_child("vlan 10")
     vlan.add_child("ip address 10.1.1.1 255.255.255.0")
 
@@ -456,7 +456,7 @@ def test_name_without_interface_prefix() -> None:
 
 def test_native_vlan() -> None:
     """Test native_vlan returns VLAN ID (covers lines 167-169)."""
-    config = get_hconfig(Platform.HP_PROCURVE)
+    config = HConfig.from_text(Platform.HP_PROCURVE)
     config.add_children_deep(("interface 1/1", "untagged vlan 100"))
 
     view = get_hconfig_view(config)
@@ -467,7 +467,7 @@ def test_native_vlan() -> None:
 
 def test_native_vlan_none() -> None:
     """Test native_vlan returns None (covers line 169)."""
-    config = get_hconfig(Platform.HP_PROCURVE)
+    config = HConfig.from_text(Platform.HP_PROCURVE)
     config.add_child("interface 1/1")
 
     view = get_hconfig_view(config)
@@ -478,7 +478,7 @@ def test_native_vlan_none() -> None:
 
 def test_number() -> None:
     """Test number returns interface number (covers line 173)."""
-    config = get_hconfig(Platform.HP_PROCURVE)
+    config = HConfig.from_text(Platform.HP_PROCURVE)
     config.add_child("interface 1/10")
 
     view = get_hconfig_view(config)
@@ -489,7 +489,7 @@ def test_number() -> None:
 
 def test_parent_name() -> None:
     """Test parent_name returns parent interface (covers lines 177-179)."""
-    config = get_hconfig(Platform.HP_PROCURVE)
+    config = HConfig.from_text(Platform.HP_PROCURVE)
     config.add_child("interface 1/1.100")
 
     view = get_hconfig_view(config)
@@ -500,7 +500,7 @@ def test_parent_name() -> None:
 
 def test_parent_name_none() -> None:
     """Test parent_name returns None (covers line 179)."""
-    config = get_hconfig(Platform.HP_PROCURVE)
+    config = HConfig.from_text(Platform.HP_PROCURVE)
     config.add_child("interface 1/1")
 
     view = get_hconfig_view(config)
@@ -511,7 +511,7 @@ def test_parent_name_none() -> None:
 
 def test_poe_true() -> None:
     """Test poe returns True (covers line 183)."""
-    config = get_hconfig(Platform.HP_PROCURVE)
+    config = HConfig.from_text(Platform.HP_PROCURVE)
     config.add_child("interface 1/1")
 
     view = get_hconfig_view(config)
@@ -522,7 +522,7 @@ def test_poe_true() -> None:
 
 def test_poe_false() -> None:
     """Test poe returns False (covers line 183)."""
-    config = get_hconfig(Platform.HP_PROCURVE)
+    config = HConfig.from_text(Platform.HP_PROCURVE)
     config.add_children_deep(("interface 1/1", "no power-over-ethernet"))
 
     view = get_hconfig_view(config)
@@ -533,7 +533,7 @@ def test_poe_false() -> None:
 
 def test_port_number() -> None:
     """Test port_number returns port number (covers line 187)."""
-    config = get_hconfig(Platform.HP_PROCURVE)
+    config = HConfig.from_text(Platform.HP_PROCURVE)
     config.add_child("interface 2/15")
 
     view = get_hconfig_view(config)
@@ -544,7 +544,7 @@ def test_port_number() -> None:
 
 def test_port_number_with_subinterface() -> None:
     """Test port_number with subinterface (covers line 187)."""
-    config = get_hconfig(Platform.HP_PROCURVE)
+    config = HConfig.from_text(Platform.HP_PROCURVE)
     config.add_child("interface 1/5.100")
 
     view = get_hconfig_view(config)
@@ -555,7 +555,7 @@ def test_port_number_with_subinterface() -> None:
 
 def test_speed_none() -> None:
     """Test speed returns None (covers line 193)."""
-    config = get_hconfig(Platform.HP_PROCURVE)
+    config = HConfig.from_text(Platform.HP_PROCURVE)
     config.add_child("interface 1/1")
 
     view = get_hconfig_view(config)
@@ -566,7 +566,7 @@ def test_speed_none() -> None:
 
 def test_subinterface_number() -> None:
     """Test subinterface_number returns number (covers line 197)."""
-    config = get_hconfig(Platform.HP_PROCURVE)
+    config = HConfig.from_text(Platform.HP_PROCURVE)
     config.add_child("interface 1/1.200")
 
     view = get_hconfig_view(config)
@@ -577,7 +577,7 @@ def test_subinterface_number() -> None:
 
 def test_subinterface_number_none() -> None:
     """Test subinterface_number returns None (covers line 197)."""
-    config = get_hconfig(Platform.HP_PROCURVE)
+    config = HConfig.from_text(Platform.HP_PROCURVE)
     config.add_child("interface 1/1")
 
     view = get_hconfig_view(config)
@@ -588,7 +588,7 @@ def test_subinterface_number_none() -> None:
 
 def test_tagged_all_false() -> None:
     """Test tagged_all always returns False (covers line 201)."""
-    config = get_hconfig(Platform.HP_PROCURVE)
+    config = HConfig.from_text(Platform.HP_PROCURVE)
     config.add_child("interface 1/1")
 
     view = get_hconfig_view(config)
@@ -599,7 +599,7 @@ def test_tagged_all_false() -> None:
 
 def test_tagged_vlans() -> None:
     """Test tagged_vlans returns VLAN list (covers line 205)."""
-    config = get_hconfig(Platform.HP_PROCURVE)
+    config = HConfig.from_text(Platform.HP_PROCURVE)
     interface = config.add_child("interface 1/1")
     interface.add_child("tagged vlan 10")
     interface.add_child("tagged vlan 20")
@@ -612,7 +612,7 @@ def test_tagged_vlans() -> None:
 
 def test_tagged_vlans_empty() -> None:
     """Test tagged_vlans returns empty tuple (covers line 205)."""
-    config = get_hconfig(Platform.HP_PROCURVE)
+    config = HConfig.from_text(Platform.HP_PROCURVE)
     config.add_child("interface 1/1")
 
     view = get_hconfig_view(config)
@@ -623,7 +623,7 @@ def test_tagged_vlans_empty() -> None:
 
 def test_vrf_empty() -> None:
     """Test vrf always returns empty string (covers line 212)."""
-    config = get_hconfig(Platform.HP_PROCURVE)
+    config = HConfig.from_text(Platform.HP_PROCURVE)
     config.add_child("interface 1/1")
 
     view = get_hconfig_view(config)
@@ -634,7 +634,7 @@ def test_vrf_empty() -> None:
 
 def test_bundle_prefix() -> None:
     """Test _bundle_prefix returns 'trk' (covers line 216)."""
-    config = get_hconfig(Platform.HP_PROCURVE)
+    config = HConfig.from_text(Platform.HP_PROCURVE)
     config.add_child("interface Trk1")
 
     view = get_hconfig_view(config)
@@ -645,7 +645,7 @@ def test_bundle_prefix() -> None:
 
 def test_hostname() -> None:
     """Test hostname returns hostname (covers lines 247-249)."""
-    config = get_hconfig(Platform.HP_PROCURVE)
+    config = HConfig.from_text(Platform.HP_PROCURVE)
     config.add_child('hostname "SWITCH01"')
 
     view = get_hconfig_view(config)
@@ -654,7 +654,7 @@ def test_hostname() -> None:
 
 def test_hostname_none() -> None:
     """Test hostname returns None (covers line 249)."""
-    config = get_hconfig(Platform.HP_PROCURVE)
+    config = HConfig.from_text(Platform.HP_PROCURVE)
 
     view = get_hconfig_view(config)
     assert view.hostname is None
@@ -662,7 +662,7 @@ def test_hostname_none() -> None:
 
 def test_interface_names_mentioned() -> None:
     """Test interface_names_mentioned includes all interfaces (covers lines 253-266)."""
-    config = get_hconfig(Platform.HP_PROCURVE)
+    config = HConfig.from_text(Platform.HP_PROCURVE)
     config.add_child("interface 1/1")
     config.add_child("interface 2/5")
     config.add_child("aaa port-access authenticator 1/10")
@@ -681,7 +681,7 @@ def test_interface_names_mentioned() -> None:
 
 def test_interface_views() -> None:
     """Test interface_views yields interface views (covers lines 270-274)."""
-    config = get_hconfig(Platform.HP_PROCURVE)
+    config = HConfig.from_text(Platform.HP_PROCURVE)
     config.add_child("interface 1/1")
     config.add_children_deep(("vlan 10", "ip address 10.1.1.1 255.255.255.0"))
 
@@ -695,7 +695,7 @@ def test_interface_views() -> None:
 
 def test_interfaces() -> None:
     """Test interfaces returns interface children (covers line 278)."""
-    config = get_hconfig(Platform.HP_PROCURVE)
+    config = HConfig.from_text(Platform.HP_PROCURVE)
     config.add_child("interface 1/1")
     config.add_child("interface 2/2")
 
@@ -707,7 +707,7 @@ def test_interfaces() -> None:
 
 def test_ipv4_default_gw() -> None:
     """Test ipv4_default_gw returns gateway IP (covers lines 282-284)."""
-    config = get_hconfig(Platform.HP_PROCURVE)
+    config = HConfig.from_text(Platform.HP_PROCURVE)
     config.add_child("ip default-gateway 192.168.1.1")
 
     view = get_hconfig_view(config)
@@ -716,7 +716,7 @@ def test_ipv4_default_gw() -> None:
 
 def test_ipv4_default_gw_none() -> None:
     """Test ipv4_default_gw returns None (covers line 284)."""
-    config = get_hconfig(Platform.HP_PROCURVE)
+    config = HConfig.from_text(Platform.HP_PROCURVE)
 
     view = get_hconfig_view(config)
     assert view.ipv4_default_gw is None
@@ -724,7 +724,7 @@ def test_ipv4_default_gw_none() -> None:
 
 def test_location() -> None:
     """Test location returns location string (covers lines 288-290)."""
-    config = get_hconfig(Platform.HP_PROCURVE)
+    config = HConfig.from_text(Platform.HP_PROCURVE)
     config.add_child('snmp-server location "Building A, Floor 2"')
 
     view = get_hconfig_view(config)
@@ -733,7 +733,7 @@ def test_location() -> None:
 
 def test_location_empty() -> None:
     """Test location returns empty string (covers line 290)."""
-    config = get_hconfig(Platform.HP_PROCURVE)
+    config = HConfig.from_text(Platform.HP_PROCURVE)
 
     view = get_hconfig_view(config)
     assert not view.location
@@ -741,7 +741,7 @@ def test_location_empty() -> None:
 
 def test_stack_members() -> None:
     """Test stack_members yields stack members (covers lines 301-309)."""
-    config = get_hconfig(Platform.HP_PROCURVE)
+    config = HConfig.from_text(Platform.HP_PROCURVE)
     stacking = config.add_child("stacking")
     stacking.add_child('member 1 type "JL123" mac-address abc123-def456')
     stacking.add_child('member 2 type "JL456" mac-address xyz789-uvw012')
@@ -760,7 +760,7 @@ def test_stack_members() -> None:
 
 def test_stack_members_no_stacking() -> None:
     """Test stack_members returns empty when no stacking (covers line 301)."""
-    config = get_hconfig(Platform.HP_PROCURVE)
+    config = HConfig.from_text(Platform.HP_PROCURVE)
 
     view = get_hconfig_view(config)
     members = list(view.stack_members)
@@ -770,7 +770,7 @@ def test_stack_members_no_stacking() -> None:
 
 def test_vlans_explicit() -> None:
     """Test vlans yields explicitly defined VLANs (covers lines 318-346)."""
-    config = get_hconfig(Platform.HP_PROCURVE)
+    config = HConfig.from_text(Platform.HP_PROCURVE)
     config.add_children_deep(("vlan 10", 'name "Data"'))
     config.add_children_deep(("vlan 20", 'name "Voice"'))
 
@@ -784,7 +784,7 @@ def test_vlans_explicit() -> None:
 
 def test_vlans_range() -> None:
     """Test vlans expands VLAN ranges (covers lines 318-346)."""
-    config = get_hconfig(Platform.HP_PROCURVE)
+    config = HConfig.from_text(Platform.HP_PROCURVE)
     config.add_child("vlan 10-12")
 
     view = get_hconfig_view(config)
@@ -798,7 +798,7 @@ def test_vlans_range() -> None:
 
 def test_vlans_from_interfaces() -> None:
     """Test vlans includes VLANs from interfaces (covers lines 318-346)."""
-    config = get_hconfig(Platform.HP_PROCURVE)
+    config = HConfig.from_text(Platform.HP_PROCURVE)
     interface = config.add_child("interface 1/1")
     interface.add_child("tagged vlan 100")
     interface.add_child("untagged vlan 50")

--- a/tests/unit/platforms/views/test_hp_procurve.py
+++ b/tests/unit/platforms/views/test_hp_procurve.py
@@ -5,20 +5,31 @@ from ipaddress import IPv4Address, IPv4Interface
 import pytest
 
 from hier_config import HConfig, Platform, get_hconfig_view
+from hier_config.platforms.hp_procurve.view import ConfigViewInterfaceHPProcurve
 from hier_config.platforms.models import InterfaceDuplex, StackMember
 
 
-def test_bundle_id_not_implemented() -> None:
-    """Test bundle_id raises NotImplementedError (covers line 26)."""
+def test_bundle_id() -> None:
+    """Test bundle_id returns the trunk number of a bundle member."""
     config = HConfig.from_text(Platform.HP_PROCURVE)
-    config.add_child("interface Trk1")
+    config.add_child("interface 1/45")
+    config.add_child("trunk 1/45,2/45 trk1 trunk")
 
     view = get_hconfig_view(config)
-    interface_view = view.interface_view_by_name("Trk1")
-    assert interface_view is not None
+    interface_view = view.interface_view_by_name("1/45")
+    assert isinstance(interface_view, ConfigViewInterfaceHPProcurve)
+    assert interface_view.bundle_id == "1"
 
-    with pytest.raises(NotImplementedError):
-        _ = interface_view.bundle_id
+
+def test_bundle_id_none() -> None:
+    """Test bundle_id returns None when the interface is not a bundle member."""
+    config = HConfig.from_text(Platform.HP_PROCURVE)
+    config.add_child("interface 1/1")
+
+    view = get_hconfig_view(config)
+    interface_view = view.interface_view_by_name("1/1")
+    assert isinstance(interface_view, ConfigViewInterfaceHPProcurve)
+    assert interface_view.bundle_id is None
 
 
 def test_bundle_member_interfaces() -> None:
@@ -29,7 +40,7 @@ def test_bundle_member_interfaces() -> None:
 
     view = get_hconfig_view(config)
     interface_view = view.interface_view_by_name("Trk1")
-    assert interface_view is not None
+    assert isinstance(interface_view, ConfigViewInterfaceHPProcurve)
 
     members = list(interface_view.bundle_member_interfaces)
     assert "1/45" in members
@@ -43,7 +54,7 @@ def test_bundle_member_interfaces_bundle_not_found_error() -> None:
 
     view = get_hconfig_view(config)
     interface_view = view.interface_view_by_name("Trk1")
-    assert interface_view is not None
+    assert isinstance(interface_view, ConfigViewInterfaceHPProcurve)
 
     with pytest.raises(
         TypeError, match="Interface is a bundle but bundle config was not found"
@@ -58,7 +69,7 @@ def test_bundle_member_interfaces_value_error() -> None:
 
     view = get_hconfig_view(config)
     interface_view = view.interface_view_by_name("1/1")
-    assert interface_view is not None
+    assert isinstance(interface_view, ConfigViewInterfaceHPProcurve)
 
     with pytest.raises(ValueError, match="The bundle config line couldn't be found"):
         _ = list(interface_view.bundle_member_interfaces)
@@ -72,7 +83,7 @@ def test_bundle_name() -> None:
 
     view = get_hconfig_view(config)
     interface_view = view.interface_view_by_name("1/1")
-    assert interface_view is not None
+    assert isinstance(interface_view, ConfigViewInterfaceHPProcurve)
     assert interface_view.bundle_name == "Trk1"
 
 
@@ -83,7 +94,7 @@ def test_bundle_name_none() -> None:
 
     view = get_hconfig_view(config)
     interface_view = view.interface_view_by_name("1/1")
-    assert interface_view is not None
+    assert isinstance(interface_view, ConfigViewInterfaceHPProcurve)
     assert interface_view.bundle_name is None
 
 
@@ -94,7 +105,7 @@ def test_description() -> None:
 
     view = get_hconfig_view(config)
     interface_view = view.interface_view_by_name("1/1")
-    assert interface_view is not None
+    assert isinstance(interface_view, ConfigViewInterfaceHPProcurve)
     assert interface_view.description == "uplink port"
 
 
@@ -105,7 +116,7 @@ def test_description_empty() -> None:
 
     view = get_hconfig_view(config)
     interface_view = view.interface_view_by_name("1/1")
-    assert interface_view is not None
+    assert isinstance(interface_view, ConfigViewInterfaceHPProcurve)
     assert not interface_view.description
 
 
@@ -116,7 +127,7 @@ def test_duplex_auto() -> None:
 
     view = get_hconfig_view(config)
     interface_view = view.interface_view_by_name("1/1")
-    assert interface_view is not None
+    assert isinstance(interface_view, ConfigViewInterfaceHPProcurve)
     assert interface_view.duplex == InterfaceDuplex.AUTO
 
 
@@ -127,7 +138,7 @@ def test_enabled_true() -> None:
 
     view = get_hconfig_view(config)
     interface_view = view.interface_view_by_name("1/1")
-    assert interface_view is not None
+    assert isinstance(interface_view, ConfigViewInterfaceHPProcurve)
     assert interface_view.enabled is True
 
 
@@ -138,7 +149,7 @@ def test_enabled_false() -> None:
 
     view = get_hconfig_view(config)
     interface_view = view.interface_view_by_name("1/1")
-    assert interface_view is not None
+    assert isinstance(interface_view, ConfigViewInterfaceHPProcurve)
     assert interface_view.enabled is False
 
 
@@ -150,7 +161,7 @@ def test_has_nac_authenticator() -> None:
 
     view = get_hconfig_view(config)
     interface_view = view.interface_view_by_name("1/1")
-    assert interface_view is not None
+    assert isinstance(interface_view, ConfigViewInterfaceHPProcurve)
     assert interface_view.has_nac is True
 
 
@@ -162,7 +173,7 @@ def test_has_nac_mac_based() -> None:
 
     view = get_hconfig_view(config)
     interface_view = view.interface_view_by_name("1/1")
-    assert interface_view is not None
+    assert isinstance(interface_view, ConfigViewInterfaceHPProcurve)
     assert interface_view.has_nac is True
 
 
@@ -173,7 +184,7 @@ def test_has_nac_false() -> None:
 
     view = get_hconfig_view(config)
     interface_view = view.interface_view_by_name("1/1")
-    assert interface_view is not None
+    assert isinstance(interface_view, ConfigViewInterfaceHPProcurve)
     assert interface_view.has_nac is False
 
 
@@ -184,7 +195,7 @@ def test_ipv4_interface_none() -> None:
 
     view = get_hconfig_view(config)
     interface_view = view.interface_view_by_name("1/1")
-    assert interface_view is not None
+    assert isinstance(interface_view, ConfigViewInterfaceHPProcurve)
     assert interface_view.ipv4_interface is None
 
 
@@ -195,7 +206,7 @@ def test_ipv4_interfaces() -> None:
 
     view = get_hconfig_view(config)
     interface_view = view.interface_view_by_name("vlan 10")
-    assert interface_view is not None
+    assert isinstance(interface_view, ConfigViewInterfaceHPProcurve)
 
     ips = list(interface_view.ipv4_interfaces)
     assert len(ips) == 1
@@ -209,7 +220,7 @@ def test_ipv4_interfaces_invalid() -> None:
 
     view = get_hconfig_view(config)
     interface_view = view.interface_view_by_name("vlan 10")
-    assert interface_view is not None
+    assert isinstance(interface_view, ConfigViewInterfaceHPProcurve)
 
     ips = list(interface_view.ipv4_interfaces)
     assert len(ips) == 0
@@ -222,7 +233,7 @@ def test_is_bundle_true() -> None:
 
     view = get_hconfig_view(config)
     interface_view = view.interface_view_by_name("Trk1")
-    assert interface_view is not None
+    assert isinstance(interface_view, ConfigViewInterfaceHPProcurve)
     assert interface_view.is_bundle is True
 
 
@@ -233,7 +244,7 @@ def test_is_bundle_false() -> None:
 
     view = get_hconfig_view(config)
     interface_view = view.interface_view_by_name("1/1")
-    assert interface_view is not None
+    assert isinstance(interface_view, ConfigViewInterfaceHPProcurve)
     assert interface_view.is_bundle is False
 
 
@@ -244,7 +255,7 @@ def test_is_loopback_true() -> None:
 
     view = get_hconfig_view(config)
     interface_view = view.interface_view_by_name("Loopback0")
-    assert interface_view is not None
+    assert isinstance(interface_view, ConfigViewInterfaceHPProcurve)
     assert interface_view.is_loopback is True
 
 
@@ -255,7 +266,7 @@ def test_is_loopback_false() -> None:
 
     view = get_hconfig_view(config)
     interface_view = view.interface_view_by_name("1/1")
-    assert interface_view is not None
+    assert isinstance(interface_view, ConfigViewInterfaceHPProcurve)
     assert interface_view.is_loopback is False
 
 
@@ -266,7 +277,7 @@ def test_is_subinterface_true() -> None:
 
     view = get_hconfig_view(config)
     interface_view = view.interface_view_by_name("1/1.100")
-    assert interface_view is not None
+    assert isinstance(interface_view, ConfigViewInterfaceHPProcurve)
     assert interface_view.is_subinterface is True
 
 
@@ -277,7 +288,7 @@ def test_is_subinterface_false() -> None:
 
     view = get_hconfig_view(config)
     interface_view = view.interface_view_by_name("1/1")
-    assert interface_view is not None
+    assert isinstance(interface_view, ConfigViewInterfaceHPProcurve)
     assert interface_view.is_subinterface is False
 
 
@@ -301,7 +312,7 @@ def test_is_svi_false() -> None:
 
     view = get_hconfig_view(config)
     interface_view = view.interface_view_by_name("1/1")
-    assert interface_view is not None
+    assert isinstance(interface_view, ConfigViewInterfaceHPProcurve)
     assert interface_view.is_svi is False
 
 
@@ -312,7 +323,7 @@ def test_module_number() -> None:
 
     view = get_hconfig_view(config)
     interface_view = view.interface_view_by_name("2/10")
-    assert interface_view is not None
+    assert isinstance(interface_view, ConfigViewInterfaceHPProcurve)
     assert interface_view.module_number == 2
 
 
@@ -323,7 +334,7 @@ def test_module_number_none() -> None:
 
     view = get_hconfig_view(config)
     interface_view = view.interface_view_by_name("Trk1")
-    assert interface_view is not None
+    assert isinstance(interface_view, ConfigViewInterfaceHPProcurve)
     assert interface_view.module_number is None
 
 
@@ -335,7 +346,7 @@ def test_nac_control_direction_in_true() -> None:
 
     view = get_hconfig_view(config)
     interface_view = view.interface_view_by_name("1/1")
-    assert interface_view is not None
+    assert isinstance(interface_view, ConfigViewInterfaceHPProcurve)
     assert interface_view.nac_control_direction_in is True
 
 
@@ -346,7 +357,7 @@ def test_nac_control_direction_in_false() -> None:
 
     view = get_hconfig_view(config)
     interface_view = view.interface_view_by_name("1/1")
-    assert interface_view is not None
+    assert isinstance(interface_view, ConfigViewInterfaceHPProcurve)
     assert interface_view.nac_control_direction_in is False
 
 
@@ -357,7 +368,7 @@ def test_nac_host_mode() -> None:
 
     view = get_hconfig_view(config)
     interface_view = view.interface_view_by_name("1/1")
-    assert interface_view is not None
+    assert isinstance(interface_view, ConfigViewInterfaceHPProcurve)
     assert interface_view.nac_host_mode is None
 
 
@@ -369,7 +380,7 @@ def test_nac_mab_first_true() -> None:
 
     view = get_hconfig_view(config)
     interface_view = view.interface_view_by_name("1/1")
-    assert interface_view is not None
+    assert isinstance(interface_view, ConfigViewInterfaceHPProcurve)
     assert interface_view.nac_mab_first is True
 
 
@@ -380,7 +391,7 @@ def test_nac_mab_first_false() -> None:
 
     view = get_hconfig_view(config)
     interface_view = view.interface_view_by_name("1/1")
-    assert interface_view is not None
+    assert isinstance(interface_view, ConfigViewInterfaceHPProcurve)
     assert interface_view.nac_mab_first is False
 
 
@@ -392,7 +403,7 @@ def test_nac_max_dot1x_clients() -> None:
 
     view = get_hconfig_view(config)
     interface_view = view.interface_view_by_name("1/1")
-    assert interface_view is not None
+    assert isinstance(interface_view, ConfigViewInterfaceHPProcurve)
     assert interface_view.nac_max_dot1x_clients == 5
 
 
@@ -403,7 +414,7 @@ def test_nac_max_dot1x_clients_default() -> None:
 
     view = get_hconfig_view(config)
     interface_view = view.interface_view_by_name("1/1")
-    assert interface_view is not None
+    assert isinstance(interface_view, ConfigViewInterfaceHPProcurve)
     assert interface_view.nac_max_dot1x_clients == 1
 
 
@@ -415,7 +426,7 @@ def test_nac_max_mab_clients() -> None:
 
     view = get_hconfig_view(config)
     interface_view = view.interface_view_by_name("1/1")
-    assert interface_view is not None
+    assert isinstance(interface_view, ConfigViewInterfaceHPProcurve)
     assert interface_view.nac_max_mab_clients == 10
 
 
@@ -426,7 +437,7 @@ def test_nac_max_mab_clients_default() -> None:
 
     view = get_hconfig_view(config)
     interface_view = view.interface_view_by_name("1/1")
-    assert interface_view is not None
+    assert isinstance(interface_view, ConfigViewInterfaceHPProcurve)
     assert interface_view.nac_max_mab_clients == 1
 
 
@@ -437,7 +448,7 @@ def test_name_with_interface_prefix() -> None:
 
     view = get_hconfig_view(config)
     interface_view = view.interface_view_by_name("1/1")
-    assert interface_view is not None
+    assert isinstance(interface_view, ConfigViewInterfaceHPProcurve)
     assert interface_view.name == "1/1"
 
 
@@ -461,7 +472,7 @@ def test_native_vlan() -> None:
 
     view = get_hconfig_view(config)
     interface_view = view.interface_view_by_name("1/1")
-    assert interface_view is not None
+    assert isinstance(interface_view, ConfigViewInterfaceHPProcurve)
     assert interface_view.native_vlan == 100
 
 
@@ -472,7 +483,7 @@ def test_native_vlan_none() -> None:
 
     view = get_hconfig_view(config)
     interface_view = view.interface_view_by_name("1/1")
-    assert interface_view is not None
+    assert isinstance(interface_view, ConfigViewInterfaceHPProcurve)
     assert interface_view.native_vlan is None
 
 
@@ -483,7 +494,7 @@ def test_number() -> None:
 
     view = get_hconfig_view(config)
     interface_view = view.interface_view_by_name("1/10")
-    assert interface_view is not None
+    assert isinstance(interface_view, ConfigViewInterfaceHPProcurve)
     assert interface_view.number == "1/10"
 
 
@@ -494,7 +505,7 @@ def test_parent_name() -> None:
 
     view = get_hconfig_view(config)
     interface_view = view.interface_view_by_name("1/1.100")
-    assert interface_view is not None
+    assert isinstance(interface_view, ConfigViewInterfaceHPProcurve)
     assert interface_view.parent_name == "1/1"
 
 
@@ -505,7 +516,7 @@ def test_parent_name_none() -> None:
 
     view = get_hconfig_view(config)
     interface_view = view.interface_view_by_name("1/1")
-    assert interface_view is not None
+    assert isinstance(interface_view, ConfigViewInterfaceHPProcurve)
     assert interface_view.parent_name is None
 
 
@@ -516,7 +527,7 @@ def test_poe_true() -> None:
 
     view = get_hconfig_view(config)
     interface_view = view.interface_view_by_name("1/1")
-    assert interface_view is not None
+    assert isinstance(interface_view, ConfigViewInterfaceHPProcurve)
     assert interface_view.poe is True
 
 
@@ -527,7 +538,7 @@ def test_poe_false() -> None:
 
     view = get_hconfig_view(config)
     interface_view = view.interface_view_by_name("1/1")
-    assert interface_view is not None
+    assert isinstance(interface_view, ConfigViewInterfaceHPProcurve)
     assert interface_view.poe is False
 
 
@@ -538,7 +549,7 @@ def test_port_number() -> None:
 
     view = get_hconfig_view(config)
     interface_view = view.interface_view_by_name("2/15")
-    assert interface_view is not None
+    assert isinstance(interface_view, ConfigViewInterfaceHPProcurve)
     assert interface_view.port_number == 15
 
 
@@ -549,7 +560,7 @@ def test_port_number_with_subinterface() -> None:
 
     view = get_hconfig_view(config)
     interface_view = view.interface_view_by_name("1/5.100")
-    assert interface_view is not None
+    assert isinstance(interface_view, ConfigViewInterfaceHPProcurve)
     assert interface_view.port_number == 5
 
 
@@ -560,7 +571,7 @@ def test_speed_none() -> None:
 
     view = get_hconfig_view(config)
     interface_view = view.interface_view_by_name("1/1")
-    assert interface_view is not None
+    assert isinstance(interface_view, ConfigViewInterfaceHPProcurve)
     assert interface_view.speed is None
 
 
@@ -571,7 +582,7 @@ def test_subinterface_number() -> None:
 
     view = get_hconfig_view(config)
     interface_view = view.interface_view_by_name("1/1.200")
-    assert interface_view is not None
+    assert isinstance(interface_view, ConfigViewInterfaceHPProcurve)
     assert interface_view.subinterface_number == 200
 
 
@@ -582,7 +593,7 @@ def test_subinterface_number_none() -> None:
 
     view = get_hconfig_view(config)
     interface_view = view.interface_view_by_name("1/1")
-    assert interface_view is not None
+    assert isinstance(interface_view, ConfigViewInterfaceHPProcurve)
     assert interface_view.subinterface_number is None
 
 
@@ -593,7 +604,7 @@ def test_tagged_all_false() -> None:
 
     view = get_hconfig_view(config)
     interface_view = view.interface_view_by_name("1/1")
-    assert interface_view is not None
+    assert isinstance(interface_view, ConfigViewInterfaceHPProcurve)
     assert interface_view.tagged_all is False
 
 
@@ -606,7 +617,7 @@ def test_tagged_vlans() -> None:
 
     view = get_hconfig_view(config)
     interface_view = view.interface_view_by_name("1/1")
-    assert interface_view is not None
+    assert isinstance(interface_view, ConfigViewInterfaceHPProcurve)
     assert interface_view.tagged_vlans == (10, 20)
 
 
@@ -617,7 +628,7 @@ def test_tagged_vlans_empty() -> None:
 
     view = get_hconfig_view(config)
     interface_view = view.interface_view_by_name("1/1")
-    assert interface_view is not None
+    assert isinstance(interface_view, ConfigViewInterfaceHPProcurve)
     assert interface_view.tagged_vlans == ()
 
 
@@ -628,7 +639,7 @@ def test_vrf_empty() -> None:
 
     view = get_hconfig_view(config)
     interface_view = view.interface_view_by_name("1/1")
-    assert interface_view is not None
+    assert isinstance(interface_view, ConfigViewInterfaceHPProcurve)
     assert not interface_view.vrf
 
 
@@ -639,7 +650,7 @@ def test_bundle_prefix() -> None:
 
     view = get_hconfig_view(config)
     interface_view = view.interface_view_by_name("Trk1")
-    assert interface_view is not None
+    assert isinstance(interface_view, ConfigViewInterfaceHPProcurve)
     assert interface_view.is_bundle
 
 

--- a/tests/unit/platforms/views/test_interface.py
+++ b/tests/unit/platforms/views/test_interface.py
@@ -1,4 +1,4 @@
-from hier_config import get_hconfig, get_hconfig_view
+from hier_config import HConfig, get_hconfig_view
 from hier_config.models import Platform
 from hier_config.platforms.hp_procurve.functions import hp_procurve_expand_range
 
@@ -34,7 +34,7 @@ def test_hp_procurve_expand_range() -> None:
 
 
 def test_bundle_name() -> None:
-    config = get_hconfig(Platform.CISCO_IOS)
+    config = HConfig.from_text(Platform.CISCO_IOS)
     config.add_children_deep(("interface GigabitEthernet1/1/3", "channel-group 1"))
     config.add_child("interface Port-channel1")
 

--- a/tests/unit/platforms/views/test_interface.py
+++ b/tests/unit/platforms/views/test_interface.py
@@ -1,5 +1,6 @@
 from hier_config import HConfig, get_hconfig_view
 from hier_config.models import Platform
+from hier_config.platforms.cisco_ios.view import ConfigViewInterfaceCiscoIOS
 from hier_config.platforms.hp_procurve.functions import hp_procurve_expand_range
 
 
@@ -41,5 +42,5 @@ def test_bundle_name() -> None:
     interface_view = get_hconfig_view(config).interface_view_by_name(
         "GigabitEthernet1/1/3"
     )
-    assert interface_view is not None
+    assert isinstance(interface_view, ConfigViewInterfaceCiscoIOS)
     assert interface_view.bundle_name == "Port-channel1"

--- a/tests/unit/platforms/views/test_view.py
+++ b/tests/unit/platforms/views/test_view.py
@@ -1,6 +1,7 @@
 """Tests for view_base.py ConfigViewInterfaceBase and HConfigViewBase classes."""
 
 from hier_config import HConfig, Platform, get_hconfig_view
+from hier_config.platforms.cisco_ios.view import ConfigViewInterfaceCiscoIOS
 from hier_config.platforms.models import InterfaceDot1qMode
 from hier_config.platforms.view_base import (
     ConfigViewInterfaceBase,
@@ -245,3 +246,27 @@ def test_dot1q_mode_from_vlans_available_on_all_views() -> None:
     ):
         view = get_hconfig_view(HConfig.from_text(platform))
         assert view.dot1q_mode_from_vlans(untagged_vlan=1) == InterfaceDot1qMode.ACCESS
+
+
+def test_bundle_mixin_without_membership_prefix_is_inert() -> None:
+    """An unset _bundle_membership_prefix must not match arbitrary children (#278).
+
+    get_child(startswith="") matches any first child, so the defaults must
+    short-circuit rather than return garbage for a platform that inherits the
+    bundle mixin without declaring its membership command prefix.
+    """
+    config = HConfig.from_text(
+        Platform.CISCO_IOS,
+        "interface Port-channel10\n description not-a-bundle-command\n",
+    )
+    interface = config.get_child(startswith="interface ")
+    assert interface is not None
+
+    class PrefixlessBundleView(ConfigViewInterfaceCiscoIOS):
+        """IOS view with the membership prefix unset."""
+
+        _bundle_membership_prefix = ""
+
+    view = PrefixlessBundleView(interface)
+    assert view.bundle_id is None
+    assert not tuple(view.bundle_member_interfaces)

--- a/tests/unit/platforms/views/test_view.py
+++ b/tests/unit/platforms/views/test_view.py
@@ -1,13 +1,13 @@
 """Tests for view_base.py ConfigViewInterfaceBase and HConfigViewBase classes."""
 
-from hier_config import Platform, get_hconfig, get_hconfig_view
+from hier_config import HConfig, Platform, get_hconfig_view
 from hier_config.platforms.models import InterfaceDot1qMode
 from hier_config.platforms.view_base import ConfigViewInterfaceBase, HConfigViewBase
 
 
 def test_interface_dot1q_mode_tagged() -> None:
     """Test dot1q_mode returns TAGGED (covers view_base.py line 45)."""
-    config = get_hconfig(Platform.CISCO_IOS)
+    config = HConfig.from_text(Platform.CISCO_IOS)
     config.add_children_deep(("interface GigabitEthernet0/0", "switchport mode trunk"))
     config.add_children_deep(
         ("interface GigabitEthernet0/0", "switchport trunk allowed vlan 10,20")
@@ -21,7 +21,7 @@ def test_interface_dot1q_mode_tagged() -> None:
 
 def test_interface_dot1q_mode_access() -> None:
     """Test dot1q_mode returns ACCESS (covers view_base.py line 47)."""
-    config = get_hconfig(Platform.CISCO_IOS)
+    config = HConfig.from_text(Platform.CISCO_IOS)
     config.add_children_deep(
         ("interface GigabitEthernet0/0", "switchport", "switchport mode access")
     )
@@ -34,7 +34,7 @@ def test_interface_dot1q_mode_access() -> None:
 
 def test_interface_dot1q_mode_none() -> None:
     """Test dot1q_mode returns None (covers view_base.py line 49)."""
-    config = get_hconfig(Platform.CISCO_IOS)
+    config = HConfig.from_text(Platform.CISCO_IOS)
     config.add_children_deep(("interface GigabitEthernet0/0", "no switchport"))
 
     view = get_hconfig_view(config)
@@ -45,7 +45,7 @@ def test_interface_dot1q_mode_none() -> None:
 
 def test_interface_ipv4_interface_none() -> None:
     """Test ipv4_interface returns None when no IP (covers view_base.py line 69)."""
-    config = get_hconfig(Platform.CISCO_IOS)
+    config = HConfig.from_text(Platform.CISCO_IOS)
     config.add_child("interface GigabitEthernet0/0")
 
     view = get_hconfig_view(config)
@@ -56,7 +56,7 @@ def test_interface_ipv4_interface_none() -> None:
 
 def test_interface_is_subinterface_true() -> None:
     """Test is_subinterface returns True (covers view_base.py line 89)."""
-    config = get_hconfig(Platform.CISCO_IOS)
+    config = HConfig.from_text(Platform.CISCO_IOS)
     config.add_child("interface GigabitEthernet0/0.100")
 
     view = get_hconfig_view(config)
@@ -67,7 +67,7 @@ def test_interface_is_subinterface_true() -> None:
 
 def test_hconfig_view_interface_view_by_name_none() -> None:
     """Test interface_view_by_name returns None (covers view_base.py line 221)."""
-    config = get_hconfig(Platform.CISCO_IOS)
+    config = HConfig.from_text(Platform.CISCO_IOS)
     config.add_child("interface GigabitEthernet0/0")
 
     view = get_hconfig_view(config)
@@ -78,7 +78,7 @@ def test_hconfig_view_interface_view_by_name_none() -> None:
 
 def test_hconfig_view_interfaces_names() -> None:
     """Test interfaces_names property (covers view_base.py line 236)."""
-    config = get_hconfig(Platform.CISCO_IOS)
+    config = HConfig.from_text(Platform.CISCO_IOS)
     config.add_child("interface GigabitEthernet0/0")
     config.add_child("interface GigabitEthernet0/1")
     config.add_child("interface Port-channel1")
@@ -94,7 +94,7 @@ def test_hconfig_view_interfaces_names() -> None:
 
 def test_hconfig_view_module_numbers_none() -> None:
     """Test module_numbers when module_number is None (covers view_base.py line 250)."""
-    config = get_hconfig(Platform.CISCO_IOS)
+    config = HConfig.from_text(Platform.CISCO_IOS)
     config.add_child("interface Port-channel1")
     config.add_child("interface Loopback0")
 
@@ -106,7 +106,7 @@ def test_hconfig_view_module_numbers_none() -> None:
 
 def test_hconfig_view_module_numbers_duplicate() -> None:
     """Test module_numbers skips duplicates (covers view_base.py lines 251-252)."""
-    config = get_hconfig(Platform.CISCO_IOS)
+    config = HConfig.from_text(Platform.CISCO_IOS)
     config.add_child("interface GigabitEthernet1/0/1")
     config.add_child("interface GigabitEthernet1/0/2")
     config.add_child("interface GigabitEthernet2/0/1")
@@ -121,7 +121,7 @@ def test_hconfig_view_module_numbers_duplicate() -> None:
 
 def test_hconfig_view_module_numbers_yield() -> None:
     """Test module_numbers yields values (covers view_base.py lines 253-254)."""
-    config = get_hconfig(Platform.CISCO_IOS)
+    config = HConfig.from_text(Platform.CISCO_IOS)
     config.add_child("interface GigabitEthernet1/0/1")
     config.add_child("interface GigabitEthernet2/0/1")
     config.add_child("interface GigabitEthernet3/0/1")
@@ -134,7 +134,7 @@ def test_hconfig_view_module_numbers_yield() -> None:
 
 def test_hconfig_view_vlan_ids() -> None:
     """Test vlan_ids property (covers view_base.py line 266)."""
-    config = get_hconfig(Platform.CISCO_IOS)
+    config = HConfig.from_text(Platform.CISCO_IOS)
     config.add_child("vlan 10")
     config.add_child("vlan 20")
     config.add_child("vlan 30")
@@ -175,7 +175,7 @@ def test_interface_view_abstract_properties_coverage() -> None:
 
 def test_dot1q_mode_from_vlans_tagged_all() -> None:
     """tagged_all wins over any other VLAN data (#228)."""
-    view = get_hconfig_view(get_hconfig(Platform.CISCO_IOS))
+    view = get_hconfig_view(HConfig.from_text(Platform.CISCO_IOS))
     assert (
         view.dot1q_mode_from_vlans(
             untagged_vlan=10, tagged_vlans=(20,), tagged_all=True
@@ -186,7 +186,7 @@ def test_dot1q_mode_from_vlans_tagged_all() -> None:
 
 def test_dot1q_mode_from_vlans_tagged() -> None:
     """Explicit tagged VLANs mean TAGGED mode (#228)."""
-    view = get_hconfig_view(get_hconfig(Platform.CISCO_IOS))
+    view = get_hconfig_view(HConfig.from_text(Platform.CISCO_IOS))
     assert (
         view.dot1q_mode_from_vlans(tagged_vlans=(20, 30)) == InterfaceDot1qMode.TAGGED
     )
@@ -198,13 +198,13 @@ def test_dot1q_mode_from_vlans_tagged() -> None:
 
 def test_dot1q_mode_from_vlans_access() -> None:
     """An untagged VLAN alone means ACCESS mode (#228)."""
-    view = get_hconfig_view(get_hconfig(Platform.CISCO_IOS))
+    view = get_hconfig_view(HConfig.from_text(Platform.CISCO_IOS))
     assert view.dot1q_mode_from_vlans(untagged_vlan=10) == InterfaceDot1qMode.ACCESS
 
 
 def test_dot1q_mode_from_vlans_none() -> None:
     """No VLAN data means no 802.1Q mode (#228)."""
-    view = get_hconfig_view(get_hconfig(Platform.CISCO_IOS))
+    view = get_hconfig_view(HConfig.from_text(Platform.CISCO_IOS))
     assert view.dot1q_mode_from_vlans() is None
 
 
@@ -217,5 +217,5 @@ def test_dot1q_mode_from_vlans_available_on_all_views() -> None:
         Platform.CISCO_XR,
         Platform.HP_PROCURVE,
     ):
-        view = get_hconfig_view(get_hconfig(platform))
+        view = get_hconfig_view(HConfig.from_text(platform))
         assert view.dot1q_mode_from_vlans(untagged_vlan=1) == InterfaceDot1qMode.ACCESS

--- a/tests/unit/platforms/views/test_view.py
+++ b/tests/unit/platforms/views/test_view.py
@@ -2,7 +2,14 @@
 
 from hier_config import HConfig, Platform, get_hconfig_view
 from hier_config.platforms.models import InterfaceDot1qMode
-from hier_config.platforms.view_base import ConfigViewInterfaceBase, HConfigViewBase
+from hier_config.platforms.view_base import (
+    ConfigViewInterfaceBase,
+    HConfigViewBase,
+    InterfaceBundleViewMixin,
+    InterfaceNACViewMixin,
+    InterfacePhysicalViewMixin,
+    InterfaceVlanViewMixin,
+)
 
 
 def test_interface_dot1q_mode_tagged() -> None:
@@ -15,7 +22,7 @@ def test_interface_dot1q_mode_tagged() -> None:
 
     view = get_hconfig_view(config)
     interface_view = view.interface_view_by_name("GigabitEthernet0/0")
-    assert interface_view is not None
+    assert isinstance(interface_view, InterfaceVlanViewMixin)
     assert interface_view.dot1q_mode == InterfaceDot1qMode.TAGGED
 
 
@@ -28,7 +35,7 @@ def test_interface_dot1q_mode_access() -> None:
 
     view = get_hconfig_view(config)
     interface_view = view.interface_view_by_name("GigabitEthernet0/0")
-    assert interface_view is not None
+    assert isinstance(interface_view, InterfaceVlanViewMixin)
     assert interface_view.dot1q_mode == InterfaceDot1qMode.ACCESS
 
 
@@ -39,7 +46,7 @@ def test_interface_dot1q_mode_none() -> None:
 
     view = get_hconfig_view(config)
     interface_view = view.interface_view_by_name("GigabitEthernet0/0")
-    assert interface_view is not None
+    assert isinstance(interface_view, InterfaceVlanViewMixin)
     assert interface_view.dot1q_mode is None
 
 
@@ -146,20 +153,39 @@ def test_hconfig_view_vlan_ids() -> None:
 
 
 def test_interface_view_abstract_properties_coverage() -> None:
-    """Test that abstract properties are properly defined (covers view_base.py lines 184, 205, 210, 226, 231, 235, 241, 246, 256)."""
-    assert hasattr(ConfigViewInterfaceBase, "bundle_id")
-    assert hasattr(ConfigViewInterfaceBase, "bundle_member_interfaces")
-    assert hasattr(ConfigViewInterfaceBase, "bundle_name")
+    """Test that abstract properties are defined on the base and the mixins."""
     assert hasattr(ConfigViewInterfaceBase, "description")
-    assert hasattr(ConfigViewInterfaceBase, "duplex")
     assert hasattr(ConfigViewInterfaceBase, "enabled")
-    assert hasattr(ConfigViewInterfaceBase, "has_nac")
     assert hasattr(ConfigViewInterfaceBase, "ipv4_interfaces")
-    assert hasattr(ConfigViewInterfaceBase, "is_bundle")
     assert hasattr(ConfigViewInterfaceBase, "is_loopback")
     assert hasattr(ConfigViewInterfaceBase, "is_svi")
-    assert hasattr(ConfigViewInterfaceBase, "module_number")
-    assert hasattr(ConfigViewInterfaceBase, "_bundle_prefix")
+    assert hasattr(ConfigViewInterfaceBase, "name")
+    assert hasattr(ConfigViewInterfaceBase, "number")
+    assert hasattr(ConfigViewInterfaceBase, "port_number")
+    assert hasattr(ConfigViewInterfaceBase, "vrf")
+
+    assert hasattr(InterfaceBundleViewMixin, "bundle_id")
+    assert hasattr(InterfaceBundleViewMixin, "bundle_member_interfaces")
+    assert hasattr(InterfaceBundleViewMixin, "bundle_name")
+    assert hasattr(InterfaceBundleViewMixin, "is_bundle")
+    assert hasattr(InterfaceBundleViewMixin, "_bundle_prefix")
+
+    assert hasattr(InterfaceVlanViewMixin, "dot1q_mode")
+    assert hasattr(InterfaceVlanViewMixin, "native_vlan")
+    assert hasattr(InterfaceVlanViewMixin, "tagged_all")
+    assert hasattr(InterfaceVlanViewMixin, "tagged_vlans")
+
+    assert hasattr(InterfaceNACViewMixin, "has_nac")
+    assert hasattr(InterfaceNACViewMixin, "nac_control_direction_in")
+    assert hasattr(InterfaceNACViewMixin, "nac_host_mode")
+    assert hasattr(InterfaceNACViewMixin, "nac_mab_first")
+    assert hasattr(InterfaceNACViewMixin, "nac_max_dot1x_clients")
+    assert hasattr(InterfaceNACViewMixin, "nac_max_mab_clients")
+
+    assert hasattr(InterfacePhysicalViewMixin, "duplex")
+    assert hasattr(InterfacePhysicalViewMixin, "module_number")
+    assert hasattr(InterfacePhysicalViewMixin, "poe")
+    assert hasattr(InterfacePhysicalViewMixin, "speed")
 
     # Verify HConfigViewBase has the expected abstract methods/properties
     assert hasattr(HConfigViewBase, "dot1q_mode_from_vlans")

--- a/tests/unit/test_child.py
+++ b/tests/unit/test_child.py
@@ -5,21 +5,18 @@ import types
 
 import pytest
 
-from hier_config import (
-    HConfigChild,
-    get_hconfig,
-)
+from hier_config import HConfig, HConfigChild
 from hier_config.exceptions import DuplicateChildError
 from hier_config.models import IdempotentCommandsRule, Instance, MatchRule, Platform
 from hier_config.platforms.cisco_ios.driver import HConfigDriverCiscoIOS
 
 
 def test_add_ancestor_copy_of(platform_a: Platform) -> None:
-    source_config = get_hconfig(platform_a)
+    source_config = HConfig.from_text(platform_a)
     ipv4_address = source_config.add_children_deep(
         ("interface Vlan2", "ip address 192.168.1.0/24")
     )
-    destination_config = get_hconfig(platform_a)
+    destination_config = HConfig.from_text(platform_a)
     destination_config.add_ancestor_copy_of(ipv4_address)
 
     assert len(tuple(destination_config.all_children())) == 2
@@ -27,14 +24,14 @@ def test_add_ancestor_copy_of(platform_a: Platform) -> None:
 
 
 def test_depth(platform_a: Platform) -> None:
-    ip_address = get_hconfig(platform_a).add_children_deep(
+    ip_address = HConfig.from_text(platform_a).add_children_deep(
         ("interface Vlan2", "ip address 192.168.1.1 255.255.255.0"),
     )
     assert ip_address.depth == 2
 
 
 def test_get_child(platform_a: Platform) -> None:
-    hier = get_hconfig(platform_a)
+    hier = HConfig.from_text(platform_a)
     hier.add_child("interface Vlan2")
     child = hier.get_child(equals="interface Vlan2")
     assert child is not None
@@ -42,7 +39,7 @@ def test_get_child(platform_a: Platform) -> None:
 
 
 def test_get_child_deep(platform_a: Platform) -> None:
-    hier = get_hconfig(platform_a)
+    hier = HConfig.from_text(platform_a)
     interface1 = hier.add_child("interface Vlan1")
     interface1.add_children(
         ("ip address 192.168.1.1 255.255.255.0", "description asdf1"),
@@ -87,7 +84,7 @@ def test_get_child_deep(platform_a: Platform) -> None:
 
 
 def test_child_deep2() -> None:
-    config = get_hconfig(Platform.CISCO_IOS)
+    config = HConfig.from_text(Platform.CISCO_IOS)
 
     config.add_children_deep(("a", "b"))
     config.add_children_deep(("a", "b1"))
@@ -117,7 +114,7 @@ def test_child_deep2() -> None:
 
 
 def test_get_children(platform_a: Platform) -> None:
-    hier = get_hconfig(platform_a)
+    hier = HConfig.from_text(platform_a)
     hier.add_child("interface Vlan2")
     hier.add_child("interface Vlan3")
     children = tuple(hier.get_children(startswith="interface"))
@@ -127,13 +124,13 @@ def test_get_children(platform_a: Platform) -> None:
 
 
 def test_move(platform_a: Platform, platform_b: Platform) -> None:
-    hier1 = get_hconfig(platform_a)
+    hier1 = HConfig.from_text(platform_a)
     interface1 = hier1.add_child("interface Vlan2")
     interface1.add_child("192.168.0.1/30")
 
     assert len(tuple(hier1.all_children())) == 2
 
-    hier2 = get_hconfig(platform_b)
+    hier2 = HConfig.from_text(platform_b)
 
     assert not tuple(hier2.all_children())
 
@@ -144,7 +141,7 @@ def test_move(platform_a: Platform, platform_b: Platform) -> None:
 
 
 def test_del_child_by_text(platform_a: Platform) -> None:
-    hier = get_hconfig(platform_a)
+    hier = HConfig.from_text(platform_a)
     hier.add_child("interface Vlan2")
     hier.children.delete("interface Vlan2")
 
@@ -152,7 +149,7 @@ def test_del_child_by_text(platform_a: Platform) -> None:
 
 
 def test_del_child(platform_a: Platform) -> None:
-    hier1 = get_hconfig(platform_a)
+    hier1 = HConfig.from_text(platform_a)
     hier1.add_child("interface Vlan2")
 
     assert len(tuple(hier1.all_children())) == 1
@@ -169,14 +166,14 @@ def test_add_children(platform_a: Platform) -> None:
         "description switch-mgmt 192.168.1.0/24",
         "ip address 192.168.1.1/24",
     )
-    hier1 = get_hconfig(platform_a)
+    hier1 = HConfig.from_text(platform_a)
     interface1 = hier1.add_child("interface Vlan2")
     interface1.add_children(interface_items1)
 
     assert len(tuple(hier1.all_children())) == 3
 
     interface_items2 = ("description switch-mgmt 192.168.1.0/24",)
-    hier2 = get_hconfig(platform_a)
+    hier2 = HConfig.from_text(platform_a)
     interface2 = hier2.add_child("interface Vlan2")
     interface2.add_children(interface_items2)
 
@@ -184,7 +181,7 @@ def test_add_children(platform_a: Platform) -> None:
 
 
 def test_add_child(platform_a: Platform) -> None:
-    config = get_hconfig(platform_a)
+    config = HConfig.from_text(platform_a)
     interface = config.add_child("interface Vlan2")
     assert interface.depth == 1
     assert interface.text == "interface Vlan2"
@@ -194,12 +191,12 @@ def test_add_child(platform_a: Platform) -> None:
 
 
 def test_add_deep_copy_of(platform_a: Platform, platform_b: Platform) -> None:
-    interface1 = get_hconfig(platform_a).add_child("interface Vlan2")
+    interface1 = HConfig.from_text(platform_a).add_child("interface Vlan2")
     interface1.add_children(
         ("description switch-mgmt-192.168.1.0/24", "ip address 192.168.1.0/24"),
     )
 
-    hier2 = get_hconfig(platform_b)
+    hier2 = HConfig.from_text(platform_b)
     hier2.add_deep_copy_of(interface1)
 
     assert len(tuple(hier2.all_children())) == 3
@@ -207,13 +204,13 @@ def test_add_deep_copy_of(platform_a: Platform, platform_b: Platform) -> None:
 
 
 def test_path(platform_a: Platform) -> None:
-    config_aaa = get_hconfig(platform_a).add_children_deep(("a", "aa", "aaa"))
+    config_aaa = HConfig.from_text(platform_a).add_children_deep(("a", "aa", "aaa"))
     assert tuple(config_aaa.path()) == ("a", "aa", "aaa")
 
 
 def test_indented_text(platform_a: Platform) -> None:
     ip_address = (
-        get_hconfig(platform_a)
+        HConfig.from_text(platform_a)
         .add_child("interface Vlan2")
         .add_child("ip address 192.168.1.1 255.255.255.0")
     )
@@ -223,7 +220,7 @@ def test_indented_text(platform_a: Platform) -> None:
 
 
 def test_all_children_sorted_by_tags(platform_a: Platform) -> None:
-    config = get_hconfig(platform_a)
+    config = HConfig.from_text(platform_a)
     config_a = config.add_child("a")
     config_aa = config_a.add_child("aa")
     config_a.add_child("ab")
@@ -253,35 +250,35 @@ def test_all_children_sorted_by_tags(platform_a: Platform) -> None:
 
 
 def test_all_children_sorted(platform_a: Platform) -> None:
-    hier = get_hconfig(platform_a)
+    hier = HConfig.from_text(platform_a)
     interface = hier.add_child("interface Vlan2")
     interface.add_child("standby 1 ip 10.15.11.1")
     assert len(tuple(hier.all_children_sorted())) == 2
 
 
 def test_all_children(platform_a: Platform) -> None:
-    hier = get_hconfig(platform_a)
+    hier = HConfig.from_text(platform_a)
     interface = hier.add_child("interface Vlan2")
     interface.add_child("standby 1 ip 10.15.11.1")
     assert len(tuple(hier.all_children())) == 2
 
 
 def test_delete(platform_a: Platform) -> None:
-    hier = get_hconfig(platform_a)
+    hier = HConfig.from_text(platform_a)
     config_a = hier.add_child("a")
     config_a.delete()
     assert not hier.children
 
 
 def test_set_order_weight(platform_a: Platform) -> None:
-    hier = get_hconfig(platform_a)
+    hier = HConfig.from_text(platform_a)
     child = hier.add_child("no vlan filter")
     hier.set_order_weight()
     assert child.order_weight == 200
 
 
 def test_add_tags(platform_a: Platform) -> None:
-    interface = get_hconfig(platform_a).add_child("interface Vlan2")
+    interface = HConfig.from_text(platform_a).add_child("interface Vlan2")
     ip_address = interface.add_child("ip address 192.168.1.1/24")
     assert not interface.tags
     assert not ip_address.tags
@@ -297,7 +294,7 @@ def test_add_tags(platform_a: Platform) -> None:
 
 
 def test_append_tags(platform_a: Platform) -> None:
-    config = get_hconfig(platform_a)
+    config = HConfig.from_text(platform_a)
     interface = config.add_child("interface Vlan2")
     ip_address = interface.add_child("ip address 192.168.1.1/24")
     ip_address.add_tags("test_tag")
@@ -307,7 +304,7 @@ def test_append_tags(platform_a: Platform) -> None:
 
 
 def test_remove_tags(platform_a: Platform) -> None:
-    config = get_hconfig(platform_a)
+    config = HConfig.from_text(platform_a)
     interface = config.add_child("interface Vlan2")
     ip_address = interface.add_child("ip address 192.168.1.1/24")
     ip_address.add_tags("test_tag")
@@ -321,7 +318,7 @@ def test_remove_tags(platform_a: Platform) -> None:
 
 
 def test_negate(platform_a: Platform) -> None:
-    config = get_hconfig(platform_a)
+    config = HConfig.from_text(platform_a)
     interface = config.add_child("interface Vlan2")
     interface.negate()
     assert interface.text == "no interface Vlan2"
@@ -329,9 +326,9 @@ def test_negate(platform_a: Platform) -> None:
 
 
 def test_add_shallow_copy_of(platform_a: Platform) -> None:
-    base_config = get_hconfig(platform_a)
+    base_config = HConfig.from_text(platform_a)
 
-    interface_a = get_hconfig(platform_a).add_child("interface Vlan2")
+    interface_a = HConfig.from_text(platform_a).add_child("interface Vlan2")
     interface_a.add_tags(frozenset(("ta", "tb")))
     interface_a.comments.add("ca")
     interface_a.order_weight = 200
@@ -350,7 +347,7 @@ def test_add_shallow_copy_of(platform_a: Platform) -> None:
 
 
 def test_line_inclusion_test(platform_a: Platform) -> None:
-    ip_address_ab = get_hconfig(platform_a).add_children_deep(
+    ip_address_ab = HConfig.from_text(platform_a).add_children_deep(
         ("interface Vlan2", "ip address 192.168.2.1/24"),
     )
     ip_address_ab.add_tags(frozenset(("a", "b")))
@@ -364,7 +361,7 @@ def test_line_inclusion_test(platform_a: Platform) -> None:
 def test_add_child_with_empty_text() -> None:
     """Test that add_child raises ValueError when text is empty."""
     platform = Platform.CISCO_IOS
-    config = get_hconfig(platform)
+    config = HConfig.from_text(platform)
 
     with pytest.raises(ValueError, match="text was empty"):
         config.add_child("")
@@ -373,7 +370,7 @@ def test_add_child_with_empty_text() -> None:
 def test_add_child_duplicate_error() -> None:
     """Test DuplicateChildError when adding duplicate child."""
     platform = Platform.CISCO_IOS
-    config = get_hconfig(platform)
+    config = HConfig.from_text(platform)
     config.add_child("interface GigabitEthernet0/0")
 
     with pytest.raises(DuplicateChildError, match="Found a duplicate section"):
@@ -387,7 +384,7 @@ def test_add_child_duplicate_error() -> None:
 def test_add_child_return_if_present() -> None:
     """Test return_if_present option in add_child."""
     platform = Platform.CISCO_IOS
-    config = get_hconfig(platform)
+    config = HConfig.from_text(platform)
     child1 = config.add_child("interface GigabitEthernet0/0")
     child2 = config.add_child("interface GigabitEthernet0/0", return_if_present=True)
 
@@ -397,7 +394,7 @@ def test_add_child_return_if_present() -> None:
 def test_child_repr() -> None:
     """Test HConfigChild __repr__ method."""
     platform = Platform.CISCO_IOS
-    config = get_hconfig(platform)
+    config = HConfig.from_text(platform)
     child = config.add_child("interface GigabitEthernet0/0")
     subchild = child.add_child("description test")
     repr_str = repr(child)
@@ -412,7 +409,7 @@ def test_child_repr() -> None:
 def test_child_ne() -> None:
     """Test HConfigChild __ne__ method."""
     platform = Platform.CISCO_IOS
-    config = get_hconfig(platform)
+    config = HConfig.from_text(platform)
     child1 = config.add_child("interface GigabitEthernet0/0")
     child2 = config.add_child("interface GigabitEthernet0/1")
 
@@ -422,7 +419,7 @@ def test_child_ne() -> None:
 def test_indented_text_with_comments() -> None:
     """Test indented_text with comments."""
     platform = Platform.CISCO_IOS
-    config = get_hconfig(platform)
+    config = HConfig.from_text(platform)
     child = config.add_child("interface GigabitEthernet0/0")
     child.comments.add("test comment")
     child.comments.add("another comment")
@@ -449,7 +446,7 @@ def test_indented_text_with_comments() -> None:
 def test_child_sectional_exit_no_exit_text() -> None:
     """Test sectional_exit when rule returns None."""
     platform = Platform.CISCO_IOS
-    config = get_hconfig(platform)
+    config = HConfig.from_text(platform)
     child = config.add_child("hostname test")
 
     assert child.sectional_exit is None
@@ -458,7 +455,7 @@ def test_child_sectional_exit_no_exit_text() -> None:
 def test_child_is_match_endswith() -> None:
     """Test is_match with endswith filter."""
     platform = Platform.CISCO_IOS
-    config = get_hconfig(platform)
+    config = HConfig.from_text(platform)
     interface = config.add_child("interface GigabitEthernet0/0")
 
     assert interface.is_match(endswith="Ethernet0/0")
@@ -468,7 +465,7 @@ def test_child_is_match_endswith() -> None:
 def test_child_is_match_contains_single() -> None:
     """Test is_match with single contains filter."""
     platform = Platform.CISCO_IOS
-    config = get_hconfig(platform)
+    config = HConfig.from_text(platform)
     interface = config.add_child("interface GigabitEthernet0/0")
 
     assert interface.is_match(contains="Gigabit")
@@ -478,7 +475,7 @@ def test_child_is_match_contains_single() -> None:
 def test_child_is_match_contains_tuple() -> None:
     """Test is_match with tuple contains filter."""
     platform = Platform.CISCO_IOS
-    config = get_hconfig(platform)
+    config = HConfig.from_text(platform)
     interface = config.add_child("interface GigabitEthernet0/0")
 
     assert interface.is_match(contains=("Gigabit", "FastEthernet"))
@@ -488,7 +485,7 @@ def test_child_is_match_contains_tuple() -> None:
 def test_child_use_default_for_negation() -> None:
     """Test use_default_for_negation."""
     platform = Platform.CISCO_IOS
-    config = get_hconfig(platform)
+    config = HConfig.from_text(platform)
     interface = config.add_child("interface GigabitEthernet0/0")
     description = interface.add_child("description test")
     uses_default = description.use_default_for_negation(description)
@@ -499,7 +496,7 @@ def test_child_use_default_for_negation() -> None:
 def test_child_remove_tags_leaf_iterable() -> None:
     """Test remove_tags on leaf with iterable."""
     platform = Platform.CISCO_IOS
-    config = get_hconfig(platform)
+    config = HConfig.from_text(platform)
     interface = config.add_child("interface GigabitEthernet0/0")
     description = interface.add_child("description test")
     description.add_tags(frozenset(["tag1", "tag2", "tag3"]))
@@ -513,7 +510,7 @@ def test_child_remove_tags_leaf_iterable() -> None:
 def test_child_tags_setter_on_branch() -> None:
     """Test tags setter on branch node."""
     platform = Platform.CISCO_IOS
-    config = get_hconfig(platform)
+    config = HConfig.from_text(platform)
     interface = config.add_child("interface GigabitEthernet0/0")
     description = interface.add_child("description test")
     interface.tags = frozenset(["production", "critical"])
@@ -525,7 +522,7 @@ def test_child_tags_setter_on_branch() -> None:
 def test_child_is_idempotent_command_avoid() -> None:
     """Test is_idempotent_command with avoid rule."""
     platform = Platform.CISCO_IOS
-    config = get_hconfig(platform)
+    config = HConfig.from_text(platform)
     interface = config.add_child("interface GigabitEthernet0/0")
     ip_address = interface.add_child("ip address 192.168.1.1 255.255.255.0")
     other_children: list[HConfigChild] = []
@@ -537,7 +534,7 @@ def test_child_is_idempotent_command_avoid() -> None:
 def test_child_is_idempotent_command_with_avoid_rule() -> None:
     """Test is_idempotent_command with avoid rule match."""
     platform = Platform.CISCO_IOS
-    config = get_hconfig(platform)
+    config = HConfig.from_text(platform)
     interface = config.add_child("interface GigabitEthernet0/0")
     ip_access_group = interface.add_child("ip access-group test in")
     result = ip_access_group.is_idempotent_command([])
@@ -548,13 +545,13 @@ def test_child_is_idempotent_command_with_avoid_rule() -> None:
 def test_child_overwrite_with_negate_else_branch() -> None:
     """Test overwrite_with when negated child doesn't exist."""
     platform = Platform.CISCO_IOS
-    running_config = get_hconfig(platform)
+    running_config = HConfig.from_text(platform)
     running_interface = running_config.add_child("interface GigabitEthernet0/0")
     running_interface.add_child("description old")
-    generated_config = get_hconfig(platform)
+    generated_config = HConfig.from_text(platform)
     generated_interface = generated_config.add_child("interface GigabitEthernet0/0")
     generated_interface.add_child("description new")
-    delta_config = get_hconfig(platform)
+    delta_config = HConfig.from_text(platform)
     running_interface.overwrite_with(generated_interface, delta_config, negate=True)
     delta_interface = delta_config.get_child(equals="interface GigabitEthernet0/0")
 
@@ -564,13 +561,13 @@ def test_child_overwrite_with_negate_else_branch() -> None:
 def test_child_overwrite_with_existing_negated() -> None:
     """Test overwrite_with when negated child exists in delta."""
     platform = Platform.CISCO_IOS
-    running_config = get_hconfig(platform)
+    running_config = HConfig.from_text(platform)
     running_interface = running_config.add_child("interface GigabitEthernet0/0")
     running_interface.add_child("description old")
-    generated_config = get_hconfig(platform)
+    generated_config = HConfig.from_text(platform)
     generated_interface = generated_config.add_child("interface GigabitEthernet0/0")
     generated_interface.add_child("description new")
-    delta_config = get_hconfig(platform)
+    delta_config = HConfig.from_text(platform)
     delta_config.add_child("interface GigabitEthernet0/0")
     running_interface.overwrite_with(generated_interface, delta_config, negate=True)
     delta_interface = delta_config.get_child(equals="interface GigabitEthernet0/0")
@@ -581,7 +578,7 @@ def test_child_overwrite_with_existing_negated() -> None:
 def test_child_remove_tags_branch() -> None:
     """Test remove_tags on branch node."""
     platform = Platform.CISCO_IOS
-    config = get_hconfig(platform)
+    config = HConfig.from_text(platform)
     interface = config.add_child("interface GigabitEthernet0/0")
     description = interface.add_child("description test")
     description.add_tags("test_tag")
@@ -593,7 +590,7 @@ def test_child_remove_tags_branch() -> None:
 def test_child_add_children_deep() -> None:
     """Test add_children_deep method."""
     platform = Platform.CISCO_IOS
-    config = get_hconfig(platform)
+    config = HConfig.from_text(platform)
     interface = config.add_child("interface GigabitEthernet0/0")
     result = interface.add_children_deep(
         ["ip access-group test in", "description test"]
@@ -606,7 +603,7 @@ def test_child_add_children_deep() -> None:
 def test_child_default_method() -> None:
     """Test _default method."""
     platform = Platform.CISCO_IOS
-    config = get_hconfig(platform)
+    config = HConfig.from_text(platform)
     interface = config.add_child("interface GigabitEthernet0/0")
     description = interface.add_child("description test")
     description._default()  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
@@ -617,7 +614,7 @@ def test_child_default_method() -> None:
 def test_abstract_methods_coverage() -> None:
     """Test coverage of abstract method implementations."""
     platform = Platform.CISCO_IOS
-    config = get_hconfig(platform)
+    config = HConfig.from_text(platform)
     interface = config.add_child("interface GigabitEthernet0/0")
     desc = interface.add_child("description test")
 
@@ -646,7 +643,7 @@ def test_abstract_methods_coverage() -> None:
 def test_get_child_deep_none() -> None:
     """Test get_child_deep returns None when no match."""
     platform = Platform.CISCO_IOS
-    config = get_hconfig(platform)
+    config = HConfig.from_text(platform)
     config.add_child("interface GigabitEthernet0/0")
     result = config.get_child_deep((MatchRule(equals="interface GigabitEthernet0/1"),))
 
@@ -656,13 +653,13 @@ def test_get_child_deep_none() -> None:
 def test_child_eq_comparison() -> None:
     """Test HConfigChild __eq__ returns False for different text."""
     platform = Platform.CISCO_IOS
-    config = get_hconfig(platform)
+    config = HConfig.from_text(platform)
     child1 = config.add_child("interface GigabitEthernet0/0")
     child2 = config.add_child("interface GigabitEthernet0/1")
 
     assert child1 != child2
 
-    config2 = get_hconfig(platform)
+    config2 = HConfig.from_text(platform)
     child3 = config2.add_child("interface GigabitEthernet0/0")
     assert child1 == child3
 
@@ -670,7 +667,7 @@ def test_child_eq_comparison() -> None:
 def test_child_hash_consistency() -> None:
     """Test HConfigChild __hash__."""
     platform = Platform.CISCO_IOS
-    config = get_hconfig(platform)
+    config = HConfig.from_text(platform)
     child = config.add_child("interface GigabitEthernet0/0")
     child.add_child("description test")
     hash1 = hash(child)
@@ -682,7 +679,7 @@ def test_child_hash_consistency() -> None:
 def test_with_tags_recursive() -> None:
     """Test _with_tags recursion."""
     platform = Platform.CISCO_IOS
-    config = get_hconfig(platform)
+    config = HConfig.from_text(platform)
     interface = config.add_child("interface GigabitEthernet0/0")
     interface.tags = frozenset(["production"])
     desc = interface.add_child("description test")
@@ -700,7 +697,7 @@ def test_with_tags_recursive() -> None:
 def test_child_sectional_exit_with_exit_text() -> None:
     """Test sectional_exit when rule has exit_text."""
     platform = Platform.CISCO_IOS
-    config = get_hconfig(platform)
+    config = HConfig.from_text(platform)
     interface = config.add_child("interface GigabitEthernet0/0")
     interface.add_child("description test")
     exit_text = interface.sectional_exit
@@ -711,7 +708,7 @@ def test_child_sectional_exit_with_exit_text() -> None:
 def test_child_use_default_for_negation_true() -> None:
     """Test use_default_for_negation returns True."""
     platform = Platform.CISCO_IOS
-    config = get_hconfig(platform)
+    config = HConfig.from_text(platform)
     interface = config.add_child("interface GigabitEthernet0/0")
     description = interface.add_child("description test")
     result = description.use_default_for_negation(description)
@@ -722,7 +719,7 @@ def test_child_use_default_for_negation_true() -> None:
 def test_child_lt_comparison() -> None:
     """Test HConfigChild __lt__ for ordering."""
     platform = Platform.CISCO_IOS
-    config = get_hconfig(platform)
+    config = HConfig.from_text(platform)
     child1 = config.add_child("interface GigabitEthernet0/0")
     child2 = config.add_child("interface GigabitEthernet0/1")
     child1.order_weight = 100
@@ -735,7 +732,7 @@ def test_child_lt_comparison() -> None:
 def test_add_child_with_duplicates_allowed() -> None:
     """Test add_child when duplicates are allowed."""
     platform = Platform.CISCO_XR
-    config = get_hconfig(platform)
+    config = HConfig.from_text(platform)
     route_policy = config.add_child("route-policy test")
     child1 = route_policy.add_child("if destination in test then")
     child2 = route_policy.add_child("if destination in test then")
@@ -747,7 +744,7 @@ def test_add_child_with_duplicates_allowed() -> None:
 def test_get_children_with_duplicates() -> None:
     """Test get_children when duplicates are allowed."""
     platform = Platform.CISCO_XR
-    config = get_hconfig(platform)
+    config = HConfig.from_text(platform)
     route_policy = config.add_child("route-policy test")
     route_policy.add_child("if destination in test then")
     route_policy.add_child("if destination in test then")
@@ -769,7 +766,7 @@ def test_idempotency_key_with_equals_string() -> None:
 
     config_raw = """logging console
 """
-    config = get_hconfig(driver, config_raw)
+    config = HConfig.from_text(driver, config_raw)
     child = next(iter(config.children))
 
     # Test the idempotency with equals string
@@ -783,7 +780,7 @@ def test_idempotency_key_with_equals_frozenset() -> None:
 
     config_raw = """logging console
 """
-    config = get_hconfig(driver, config_raw)
+    config = HConfig.from_text(driver, config_raw)
     child = next(iter(config.children))
 
     # Test the idempotency with equals frozenset (should fall back to text)
@@ -799,7 +796,7 @@ def test_idempotency_key_no_match_rules() -> None:
 
     config_raw = """some command
 """
-    config = get_hconfig(driver, config_raw)
+    config = HConfig.from_text(driver, config_raw)
     child = next(iter(config.children))
 
     # Empty MatchRule should fall back to text
@@ -813,7 +810,7 @@ def test_idempotency_key_prefix_no_match() -> None:
 
     config_raw = """logging console
 """
-    config = get_hconfig(driver, config_raw)
+    config = HConfig.from_text(driver, config_raw)
     child = next(iter(config.children))
 
     # Prefix that doesn't match should fall back to text
@@ -827,7 +824,7 @@ def test_idempotency_key_suffix_no_match() -> None:
 
     config_raw = """logging console
 """
-    config = get_hconfig(driver, config_raw)
+    config = HConfig.from_text(driver, config_raw)
     child = next(iter(config.children))
 
     # Suffix that doesn't match should fall back to text
@@ -841,7 +838,7 @@ def test_idempotency_key_contains_no_match() -> None:
 
     config_raw = """logging console
 """
-    config = get_hconfig(driver, config_raw)
+    config = HConfig.from_text(driver, config_raw)
     child = next(iter(config.children))
 
     # Contains that doesn't match should fall back to text
@@ -855,7 +852,7 @@ def test_idempotency_key_regex_no_match() -> None:
 
     config_raw = """logging console
 """
-    config = get_hconfig(driver, config_raw)
+    config = HConfig.from_text(driver, config_raw)
     child = next(iter(config.children))
 
     # Regex that doesn't match should fall back to text
@@ -869,7 +866,7 @@ def test_idempotency_key_prefix_tuple_no_match() -> None:
 
     config_raw = """logging console
 """
-    config = get_hconfig(driver, config_raw)
+    config = HConfig.from_text(driver, config_raw)
     child = next(iter(config.children))
 
     # Tuple of prefixes that don't match should fall back to text
@@ -885,7 +882,7 @@ def test_idempotency_key_prefix_tuple_match() -> None:
 
     config_raw = """logging console
 """
-    config = get_hconfig(driver, config_raw)
+    config = HConfig.from_text(driver, config_raw)
     child = next(iter(config.children))
 
     # Tuple of prefixes with one matching - should return longest match
@@ -901,7 +898,7 @@ def test_idempotency_key_suffix_tuple_no_match() -> None:
 
     config_raw = """logging console
 """
-    config = get_hconfig(driver, config_raw)
+    config = HConfig.from_text(driver, config_raw)
     child = next(iter(config.children))
 
     # Tuple of suffixes that don't match should fall back to text
@@ -917,7 +914,7 @@ def test_idempotency_key_suffix_tuple_match() -> None:
 
     config_raw = """logging console
 """
-    config = get_hconfig(driver, config_raw)
+    config = HConfig.from_text(driver, config_raw)
     child = next(iter(config.children))
 
     # Tuple of suffixes with one matching - should return longest match
@@ -933,7 +930,7 @@ def test_idempotency_key_contains_tuple_no_match() -> None:
 
     config_raw = """logging console
 """
-    config = get_hconfig(driver, config_raw)
+    config = HConfig.from_text(driver, config_raw)
     child = next(iter(config.children))
 
     # Tuple of contains that don't match should fall back to text
@@ -949,7 +946,7 @@ def test_idempotency_key_contains_tuple_match() -> None:
 
     config_raw = """logging console
 """
-    config = get_hconfig(driver, config_raw)
+    config = HConfig.from_text(driver, config_raw)
     child = next(iter(config.children))
 
     # Tuple of contains with matches - should return longest match
@@ -966,7 +963,7 @@ def test_idempotency_key_regex_with_groups() -> None:
     config_raw = """router bgp 1
   neighbor 10.1.1.1 description peer1
 """
-    config = get_hconfig(driver, config_raw)
+    config = HConfig.from_text(driver, config_raw)
     bgp_child = next(iter(config.children))
     neighbor_child = next(iter(bgp_child.children))
 
@@ -987,7 +984,7 @@ def test_idempotency_key_regex_with_empty_groups() -> None:
 
     config_raw = """logging console
 """
-    config = get_hconfig(driver, config_raw)
+    config = HConfig.from_text(driver, config_raw)
     child = next(iter(config.children))
 
     # Regex with empty/None groups should fall back to match result
@@ -1004,7 +1001,7 @@ def test_idempotency_key_regex_greedy_pattern() -> None:
 
     config_raw = """logging console emergency
 """
-    config = get_hconfig(driver, config_raw)
+    config = HConfig.from_text(driver, config_raw)
     child = next(iter(config.children))
 
     # Regex with .* should be trimmed
@@ -1018,7 +1015,7 @@ def test_idempotency_key_regex_greedy_pattern_with_dollar() -> None:
 
     config_raw = """logging console emergency
 """
-    config = get_hconfig(driver, config_raw)
+    config = HConfig.from_text(driver, config_raw)
     child = next(iter(config.children))
 
     # Regex with .*$ should be trimmed
@@ -1032,7 +1029,7 @@ def test_idempotency_key_regex_only_greedy() -> None:
 
     config_raw = """logging console
 """
-    config = get_hconfig(driver, config_raw)
+    config = HConfig.from_text(driver, config_raw)
     child = next(iter(config.children))
 
     # Regex that is only .* should not trim to empty
@@ -1048,7 +1045,7 @@ def test_idempotency_key_lineage_mismatch() -> None:
     config_raw = """interface GigabitEthernet1/1
   description test
 """
-    config = get_hconfig(driver, config_raw)
+    config = HConfig.from_text(driver, config_raw)
     interface_child = next(iter(config.children))
     desc_child = next(iter(interface_child.children))
 
@@ -1064,7 +1061,7 @@ def test_idempotency_key_negated_command() -> None:
 
     config_raw = """no logging console
 """
-    config = get_hconfig(driver, config_raw)
+    config = HConfig.from_text(driver, config_raw)
     child = next(iter(config.children))
 
     # Negated command should strip 'no ' prefix for matching
@@ -1078,7 +1075,7 @@ def test_idempotency_key_regex_fallback_to_original() -> None:
 
     config_raw = """no logging console
 """
-    config = get_hconfig(driver, config_raw)
+    config = HConfig.from_text(driver, config_raw)
     child = next(iter(config.children))
 
     # Regex that matches original but not normalized (tests lines 328-329)
@@ -1092,7 +1089,7 @@ def test_idempotency_key_suffix_single_match() -> None:
 
     config_raw = """logging console
 """
-    config = get_hconfig(driver, config_raw)
+    config = HConfig.from_text(driver, config_raw)
     child = next(iter(config.children))
 
     # Single suffix that matches (tests line 359)
@@ -1106,7 +1103,7 @@ def test_idempotency_key_contains_single_match() -> None:
 
     config_raw = """logging console emergency
 """
-    config = get_hconfig(driver, config_raw)
+    config = HConfig.from_text(driver, config_raw)
     child = next(iter(config.children))
 
     # Single contains that matches (tests line 372)
@@ -1120,7 +1117,7 @@ def test_idempotency_key_regex_greedy_with_plus() -> None:
 
     config_raw = """interface GigabitEthernet1
 """
-    config = get_hconfig(driver, config_raw)
+    config = HConfig.from_text(driver, config_raw)
     child = next(iter(config.children))
 
     # Regex with .+ should be trimmed similar to .*
@@ -1136,7 +1133,7 @@ def test_idempotency_key_regex_trimmed_to_no_match() -> None:
 
     config_raw = """logging console
 """
-    config = get_hconfig(driver, config_raw)
+    config = HConfig.from_text(driver, config_raw)
     child = next(iter(config.children))
 
     # Regex "interface.*" matches nothing, but after trimming .* we get "interface"
@@ -1154,9 +1151,9 @@ def test_child_hash_eq_consistency_new_in_config() -> None:
     violating the Python invariant that a == b implies hash(a) == hash(b).
     """
     platform = Platform.CISCO_IOS
-    config = get_hconfig(platform)
+    config = HConfig.from_text(platform)
     child1 = config.add_child("interface GigabitEthernet0/0")
-    config2 = get_hconfig(platform)
+    config2 = HConfig.from_text(platform)
     child2 = config2.add_child("interface GigabitEthernet0/0")
 
     child1.new_in_config = False
@@ -1175,9 +1172,9 @@ def test_child_hash_eq_consistency_order_weight() -> None:
     violating the Python invariant that a == b implies hash(a) == hash(b).
     """
     platform = Platform.CISCO_IOS
-    config = get_hconfig(platform)
+    config = HConfig.from_text(platform)
     child1 = config.add_child("interface GigabitEthernet0/0")
-    config2 = get_hconfig(platform)
+    config2 = HConfig.from_text(platform)
     child2 = config2.add_child("interface GigabitEthernet0/0")
 
     child1.order_weight = 0
@@ -1198,9 +1195,9 @@ def test_child_hash_eq_consistency_tags() -> None:
     tags should be part of the hash.
     """
     platform = Platform.CISCO_IOS
-    config = get_hconfig(platform)
+    config = HConfig.from_text(platform)
     child1 = config.add_child("interface GigabitEthernet0/0")
-    config2 = get_hconfig(platform)
+    config2 = HConfig.from_text(platform)
     child2 = config2.add_child("interface GigabitEthernet0/0")
 
     child1.tags = frozenset({"safe"})
@@ -1223,9 +1220,9 @@ def test_child_set_deduplication_with_new_in_config() -> None:
     two logically equal children occupy different set buckets, causing duplicates.
     """
     platform = Platform.CISCO_IOS
-    config = get_hconfig(platform)
+    config = HConfig.from_text(platform)
     child1 = config.add_child("interface GigabitEthernet0/0")
-    config2 = get_hconfig(platform)
+    config2 = HConfig.from_text(platform)
     child2 = config2.add_child("interface GigabitEthernet0/0")
 
     child1.new_in_config = False
@@ -1243,9 +1240,9 @@ def test_child_dict_key_lookup_with_order_weight() -> None:
     logically equal child cannot be found as a dict key.
     """
     platform = Platform.CISCO_IOS
-    config = get_hconfig(platform)
+    config = HConfig.from_text(platform)
     child1 = config.add_child("interface GigabitEthernet0/0")
-    config2 = get_hconfig(platform)
+    config2 = HConfig.from_text(platform)
     child2 = config2.add_child("interface GigabitEthernet0/0")
 
     child1.order_weight = 0
@@ -1260,7 +1257,7 @@ def test_child_dict_key_lookup_with_order_weight() -> None:
 def test_indented_text_style_literal_values() -> None:
     """Test that indented_text accepts each valid TextStyle literal value."""
     platform = Platform.CISCO_IOS
-    config = get_hconfig(platform)
+    config = HConfig.from_text(platform)
     child = config.add_child("interface GigabitEthernet0/0")
     child.comments.add("a comment")
 

--- a/tests/unit/test_child.py
+++ b/tests/unit/test_child.py
@@ -482,15 +482,14 @@ def test_child_is_match_contains_tuple() -> None:
     assert not interface.is_match(contains=("TenGigabit", "FastEthernet"))
 
 
-def test_child_use_default_for_negation() -> None:
-    """Test use_default_for_negation."""
-    platform = Platform.CISCO_IOS
+def test_child_negate_default_strategy() -> None:
+    """A DEFAULT-strategy negation rule rewrites to the default form (#220)."""
+    platform = Platform.ARISTA_EOS
     config = HConfig.from_text(platform)
-    interface = config.add_child("interface GigabitEthernet0/0")
-    description = interface.add_child("description test")
-    uses_default = description.use_default_for_negation(description)
+    interface = config.add_child("interface Ethernet1")
+    logging_event = interface.add_child("logging event link-status")
 
-    assert isinstance(uses_default, bool)
+    assert logging_event.negate().text == "default logging event link-status"
 
 
 def test_child_remove_tags_leaf_iterable() -> None:
@@ -705,15 +704,14 @@ def test_child_sectional_exit_with_exit_text() -> None:
     assert exit_text == "exit"
 
 
-def test_child_use_default_for_negation_true() -> None:
-    """Test use_default_for_negation returns True."""
+def test_child_negate_swap_fallback() -> None:
+    """A command matching no negation rule falls back to swap_negation (#220)."""
     platform = Platform.CISCO_IOS
     config = HConfig.from_text(platform)
     interface = config.add_child("interface GigabitEthernet0/0")
     description = interface.add_child("description test")
-    result = description.use_default_for_negation(description)
 
-    assert isinstance(result, bool)
+    assert description.negate().text == "no description test"
 
 
 def test_child_lt_comparison() -> None:

--- a/tests/unit/test_child.py
+++ b/tests/unit/test_child.py
@@ -605,7 +605,7 @@ def test_child_default_method() -> None:
     config = HConfig.from_text(platform)
     interface = config.add_child("interface GigabitEthernet0/0")
     description = interface.add_child("description test")
-    description._default()  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
+    description._default()  # ruff:ignore[private-member-access]  # pyright: ignore[reportPrivateUsage]
 
     assert description.text == "default description test"
 
@@ -768,7 +768,7 @@ def test_idempotency_key_with_equals_string() -> None:
     child = next(iter(config.children))
 
     # Test the idempotency with equals string
-    key = driver._idempotency_key(child, (MatchRule(equals="logging console"),))  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
+    key = driver._idempotency_key(child, (MatchRule(equals="logging console"),))  # ruff:ignore[private-member-access]  # pyright: ignore[reportPrivateUsage]
     assert key == ("equals|logging console",)
 
 
@@ -782,7 +782,7 @@ def test_idempotency_key_with_equals_frozenset() -> None:
     child = next(iter(config.children))
 
     # Test the idempotency with equals frozenset (should fall back to text)
-    key = driver._idempotency_key(  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
+    key = driver._idempotency_key(  # ruff:ignore[private-member-access]  # pyright: ignore[reportPrivateUsage]
         child, (MatchRule(equals=frozenset(["logging console", "other"])),)
     )
     assert key == ("equals|logging console",)
@@ -798,7 +798,7 @@ def test_idempotency_key_no_match_rules() -> None:
     child = next(iter(config.children))
 
     # Empty MatchRule should fall back to text
-    key = driver._idempotency_key(child, (MatchRule(),))  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
+    key = driver._idempotency_key(child, (MatchRule(),))  # ruff:ignore[private-member-access]  # pyright: ignore[reportPrivateUsage]
     assert key == ("text|some command",)
 
 
@@ -812,7 +812,7 @@ def test_idempotency_key_prefix_no_match() -> None:
     child = next(iter(config.children))
 
     # Prefix that doesn't match should fall back to text
-    key = driver._idempotency_key(child, (MatchRule(startswith="interface"),))  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
+    key = driver._idempotency_key(child, (MatchRule(startswith="interface"),))  # ruff:ignore[private-member-access]  # pyright: ignore[reportPrivateUsage]
     assert key == ("text|logging console",)
 
 
@@ -826,7 +826,7 @@ def test_idempotency_key_suffix_no_match() -> None:
     child = next(iter(config.children))
 
     # Suffix that doesn't match should fall back to text
-    key = driver._idempotency_key(child, (MatchRule(endswith="emergency"),))  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
+    key = driver._idempotency_key(child, (MatchRule(endswith="emergency"),))  # ruff:ignore[private-member-access]  # pyright: ignore[reportPrivateUsage]
     assert key == ("text|logging console",)
 
 
@@ -840,7 +840,7 @@ def test_idempotency_key_contains_no_match() -> None:
     child = next(iter(config.children))
 
     # Contains that doesn't match should fall back to text
-    key = driver._idempotency_key(child, (MatchRule(contains="interface"),))  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
+    key = driver._idempotency_key(child, (MatchRule(contains="interface"),))  # ruff:ignore[private-member-access]  # pyright: ignore[reportPrivateUsage]
     assert key == ("text|logging console",)
 
 
@@ -854,7 +854,7 @@ def test_idempotency_key_regex_no_match() -> None:
     child = next(iter(config.children))
 
     # Regex that doesn't match should fall back to text
-    key = driver._idempotency_key(child, (MatchRule(re_search="^interface"),))  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
+    key = driver._idempotency_key(child, (MatchRule(re_search="^interface"),))  # ruff:ignore[private-member-access]  # pyright: ignore[reportPrivateUsage]
     assert key == ("text|logging console",)
 
 
@@ -868,7 +868,7 @@ def test_idempotency_key_prefix_tuple_no_match() -> None:
     child = next(iter(config.children))
 
     # Tuple of prefixes that don't match should fall back to text
-    key = driver._idempotency_key(  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
+    key = driver._idempotency_key(  # ruff:ignore[private-member-access]  # pyright: ignore[reportPrivateUsage]
         child, (MatchRule(startswith=("interface", "router", "vlan")),)
     )
     assert key == ("text|logging console",)
@@ -884,7 +884,7 @@ def test_idempotency_key_prefix_tuple_match() -> None:
     child = next(iter(config.children))
 
     # Tuple of prefixes with one matching - should return longest match
-    key = driver._idempotency_key(  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
+    key = driver._idempotency_key(  # ruff:ignore[private-member-access]  # pyright: ignore[reportPrivateUsage]
         child, (MatchRule(startswith=("log", "logging", "logging console")),)
     )
     assert key == ("startswith|logging console",)
@@ -900,7 +900,7 @@ def test_idempotency_key_suffix_tuple_no_match() -> None:
     child = next(iter(config.children))
 
     # Tuple of suffixes that don't match should fall back to text
-    key = driver._idempotency_key(  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
+    key = driver._idempotency_key(  # ruff:ignore[private-member-access]  # pyright: ignore[reportPrivateUsage]
         child, (MatchRule(endswith=("emergency", "alert", "critical")),)
     )
     assert key == ("text|logging console",)
@@ -916,7 +916,7 @@ def test_idempotency_key_suffix_tuple_match() -> None:
     child = next(iter(config.children))
 
     # Tuple of suffixes with one matching - should return longest match
-    key = driver._idempotency_key(  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
+    key = driver._idempotency_key(  # ruff:ignore[private-member-access]  # pyright: ignore[reportPrivateUsage]
         child, (MatchRule(endswith=("ole", "sole", "console")),)
     )
     assert key == ("endswith|console",)
@@ -932,7 +932,7 @@ def test_idempotency_key_contains_tuple_no_match() -> None:
     child = next(iter(config.children))
 
     # Tuple of contains that don't match should fall back to text
-    key = driver._idempotency_key(  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
+    key = driver._idempotency_key(  # ruff:ignore[private-member-access]  # pyright: ignore[reportPrivateUsage]
         child, (MatchRule(contains=("interface", "router", "vlan")),)
     )
     assert key == ("text|logging console",)
@@ -948,7 +948,7 @@ def test_idempotency_key_contains_tuple_match() -> None:
     child = next(iter(config.children))
 
     # Tuple of contains with matches - should return longest match
-    key = driver._idempotency_key(  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
+    key = driver._idempotency_key(  # ruff:ignore[private-member-access]  # pyright: ignore[reportPrivateUsage]
         child, (MatchRule(contains=("log", "console", "logging console")),)
     )
     assert key == ("contains|logging console",)
@@ -966,7 +966,7 @@ def test_idempotency_key_regex_with_groups() -> None:
     neighbor_child = next(iter(bgp_child.children))
 
     # Regex with capture groups should use groups
-    key = driver._idempotency_key(  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
+    key = driver._idempotency_key(  # ruff:ignore[private-member-access]  # pyright: ignore[reportPrivateUsage]
         neighbor_child,
         (
             MatchRule(startswith="router bgp"),
@@ -986,7 +986,7 @@ def test_idempotency_key_regex_with_empty_groups() -> None:
     child = next(iter(config.children))
 
     # Regex with empty/None groups should fall back to match result
-    key = driver._idempotency_key(  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
+    key = driver._idempotency_key(  # ruff:ignore[private-member-access]  # pyright: ignore[reportPrivateUsage]
         child, (MatchRule(re_search=r"logging ()?(console)"),)
     )
     # Group 1 is empty, group 2 has "console", so should use groups
@@ -1003,7 +1003,7 @@ def test_idempotency_key_regex_greedy_pattern() -> None:
     child = next(iter(config.children))
 
     # Regex with .* should be trimmed
-    key = driver._idempotency_key(child, (MatchRule(re_search=r"logging console.*"),))  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
+    key = driver._idempotency_key(child, (MatchRule(re_search=r"logging console.*"),))  # ruff:ignore[private-member-access]  # pyright: ignore[reportPrivateUsage]
     assert key == ("re|logging console",)
 
 
@@ -1017,7 +1017,7 @@ def test_idempotency_key_regex_greedy_pattern_with_dollar() -> None:
     child = next(iter(config.children))
 
     # Regex with .*$ should be trimmed
-    key = driver._idempotency_key(child, (MatchRule(re_search=r"logging console.*$"),))  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
+    key = driver._idempotency_key(child, (MatchRule(re_search=r"logging console.*$"),))  # ruff:ignore[private-member-access]  # pyright: ignore[reportPrivateUsage]
     assert key == ("re|logging console",)
 
 
@@ -1031,7 +1031,7 @@ def test_idempotency_key_regex_only_greedy() -> None:
     child = next(iter(config.children))
 
     # Regex that is only .* should not trim to empty
-    key = driver._idempotency_key(child, (MatchRule(re_search=r".*"),))  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
+    key = driver._idempotency_key(child, (MatchRule(re_search=r".*"),))  # ruff:ignore[private-member-access]  # pyright: ignore[reportPrivateUsage]
     # Should use the full match result
     assert key == ("re|logging console",)
 
@@ -1048,7 +1048,7 @@ def test_idempotency_key_lineage_mismatch() -> None:
     desc_child = next(iter(interface_child.children))
 
     # Try to match with wrong number of rules (desc has 2 lineage levels, only 1 rule)
-    key = driver._idempotency_key(desc_child, (MatchRule(startswith="description"),))  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
+    key = driver._idempotency_key(desc_child, (MatchRule(startswith="description"),))  # ruff:ignore[private-member-access]  # pyright: ignore[reportPrivateUsage]
     # Should return empty tuple when lineage length != match_rules length
     assert not key
 
@@ -1063,7 +1063,7 @@ def test_idempotency_key_negated_command() -> None:
     child = next(iter(config.children))
 
     # Negated command should strip 'no ' prefix for matching
-    key = driver._idempotency_key(child, (MatchRule(startswith="logging"),))  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
+    key = driver._idempotency_key(child, (MatchRule(startswith="logging"),))  # ruff:ignore[private-member-access]  # pyright: ignore[reportPrivateUsage]
     assert key == ("startswith|logging",)
 
 
@@ -1077,7 +1077,7 @@ def test_idempotency_key_regex_fallback_to_original() -> None:
     child = next(iter(config.children))
 
     # Regex that matches original but not normalized (tests lines 328-329)
-    key = driver._idempotency_key(child, (MatchRule(re_search=r"^no logging"),))  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
+    key = driver._idempotency_key(child, (MatchRule(re_search=r"^no logging"),))  # ruff:ignore[private-member-access]  # pyright: ignore[reportPrivateUsage]
     assert "re|no logging" in key[0]
 
 
@@ -1091,7 +1091,7 @@ def test_idempotency_key_suffix_single_match() -> None:
     child = next(iter(config.children))
 
     # Single suffix that matches (tests line 359)
-    key = driver._idempotency_key(child, (MatchRule(endswith="console"),))  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
+    key = driver._idempotency_key(child, (MatchRule(endswith="console"),))  # ruff:ignore[private-member-access]  # pyright: ignore[reportPrivateUsage]
     assert key == ("endswith|console",)
 
 
@@ -1105,7 +1105,7 @@ def test_idempotency_key_contains_single_match() -> None:
     child = next(iter(config.children))
 
     # Single contains that matches (tests line 372)
-    key = driver._idempotency_key(child, (MatchRule(contains="console"),))  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
+    key = driver._idempotency_key(child, (MatchRule(contains="console"),))  # ruff:ignore[private-member-access]  # pyright: ignore[reportPrivateUsage]
     assert key == ("contains|console",)
 
 
@@ -1120,7 +1120,7 @@ def test_idempotency_key_regex_greedy_with_plus() -> None:
 
     # Regex with .+ should be trimmed similar to .*
     # Tests the .+ branch in line 389
-    key = driver._idempotency_key(child, (MatchRule(re_search=r"interface .+"),))  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
+    key = driver._idempotency_key(child, (MatchRule(re_search=r"interface .+"),))  # ruff:ignore[private-member-access]  # pyright: ignore[reportPrivateUsage]
     # Should trim to just "interface " and use that
     assert key == ("re|interface",)
 
@@ -1137,7 +1137,7 @@ def test_idempotency_key_regex_trimmed_to_no_match() -> None:
     # Regex "interface.*" matches nothing, but after trimming .* we get "interface"
     # which also doesn't match "logging console", so we fall back to full match result
     # This should hit the break at line 399 because trimmed_match is None
-    key = driver._idempotency_key(child, (MatchRule(re_search=r"interface.*"),))  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
+    key = driver._idempotency_key(child, (MatchRule(re_search=r"interface.*"),))  # ruff:ignore[private-member-access]  # pyright: ignore[reportPrivateUsage]
     # Since "interface.*" doesn't match "logging console", should fall back to text
     assert key == ("text|logging console",)
 

--- a/tests/unit/test_children.py
+++ b/tests/unit/test_children.py
@@ -1,11 +1,11 @@
 """Unit tests for HConfigChildren."""
 
-from hier_config import get_hconfig
+from hier_config import HConfig
 from hier_config.models import Platform
 
 
 def test_rebuild_children_dict(platform_a: Platform) -> None:
-    hier1 = get_hconfig(platform_a)
+    hier1 = HConfig.from_text(platform_a)
     interface = hier1.add_child("interface Vlan2")
     interface.add_children(
         ("description switch-mgmt-192.168.1.0/24", "ip address 192.168.1.0/24"),
@@ -20,7 +20,7 @@ def test_rebuild_children_dict(platform_a: Platform) -> None:
 def test_hconfig_children_setitem() -> None:
     """Test HConfigChildren __setitem__."""
     platform = Platform.CISCO_IOS
-    config = get_hconfig(platform)
+    config = HConfig.from_text(platform)
     config.add_child("interface GigabitEthernet0/0")
     child2_text = "interface GigabitEthernet0/1"
     config.add_child(child2_text)
@@ -35,7 +35,7 @@ def test_hconfig_children_setitem() -> None:
 def test_hconfig_children_contains() -> None:
     """Test HConfigChildren __contains__."""
     platform = Platform.CISCO_IOS
-    config = get_hconfig(platform)
+    config = HConfig.from_text(platform)
     config.add_child("interface GigabitEthernet0/0")
 
     assert "interface GigabitEthernet0/0" in config.children
@@ -45,8 +45,8 @@ def test_hconfig_children_contains() -> None:
 def test_hconfig_children_eq_fast_fail() -> None:
     """Test HConfigChildren __eq__ fast fail."""
     platform = Platform.CISCO_IOS
-    config1 = get_hconfig(platform)
-    config2 = get_hconfig(platform)
+    config1 = HConfig.from_text(platform)
+    config2 = HConfig.from_text(platform)
 
     config1.add_child("interface GigabitEthernet0/0")
     config2.add_child("interface GigabitEthernet0/0")
@@ -58,8 +58,8 @@ def test_hconfig_children_eq_fast_fail() -> None:
 def test_hconfig_children_eq_keys_mismatch() -> None:
     """Test HConfigChildren __eq__ key mismatch."""
     platform = Platform.CISCO_IOS
-    config1 = get_hconfig(platform)
-    config2 = get_hconfig(platform)
+    config1 = HConfig.from_text(platform)
+    config2 = HConfig.from_text(platform)
 
     config1.add_child("interface GigabitEthernet0/0")
     config2.add_child("interface GigabitEthernet0/1")
@@ -70,7 +70,7 @@ def test_hconfig_children_eq_keys_mismatch() -> None:
 def test_hconfig_children_hash() -> None:
     """Test HConfigChildren __hash__."""
     platform = Platform.CISCO_IOS
-    config = get_hconfig(platform)
+    config = HConfig.from_text(platform)
     config.add_child("interface GigabitEthernet0/0")
     hash_val = hash(config.children)
 
@@ -80,7 +80,7 @@ def test_hconfig_children_hash() -> None:
 def test_hconfig_children_getitem_slice() -> None:
     """Test HConfigChildren __getitem__ with slice."""
     platform = Platform.CISCO_IOS
-    config = get_hconfig(platform)
+    config = HConfig.from_text(platform)
     config.add_child("interface GigabitEthernet0/0")
     config.add_child("interface GigabitEthernet0/1")
     config.add_child("interface GigabitEthernet0/2")
@@ -94,7 +94,7 @@ def test_hconfig_children_getitem_slice() -> None:
 def test_children_eq_with_non_children_type() -> None:
     """Test HConfigChildren.__eq__ with non-HConfigChildren object returns NotImplemented."""
     platform = Platform.CISCO_IOS
-    config = get_hconfig(platform)
+    config = HConfig.from_text(platform)
     interface = config.add_child("interface GigabitEthernet0/0")
 
     # Directly call __eq__ to verify it returns NotImplemented for non-HConfigChildren types
@@ -109,7 +109,7 @@ def test_children_eq_with_non_children_type() -> None:
 def test_children_clear() -> None:
     """Test HConfigChildren.clear() method."""
     platform = Platform.CISCO_IOS
-    config = get_hconfig(platform)
+    config = HConfig.from_text(platform)
     interface = config.add_child("interface GigabitEthernet0/0")
     interface.add_child("description test")
     interface.add_child("ip address 192.0.2.1 255.255.255.0")
@@ -129,7 +129,7 @@ def test_children_clear() -> None:
 def test_children_delete_by_child_object() -> None:
     """Test HConfigChildren.delete() with HConfigChild object."""
     platform = Platform.CISCO_IOS
-    config = get_hconfig(platform)
+    config = HConfig.from_text(platform)
     interface = config.add_child("interface GigabitEthernet0/0")
     desc = interface.add_child("description test")
     ip_addr = interface.add_child("ip address 192.0.2.1 255.255.255.0")
@@ -149,7 +149,7 @@ def test_children_delete_by_child_object() -> None:
 def test_children_delete_by_child_object_not_present() -> None:
     """Test HConfigChildren.delete() with HConfigChild object that's not in the collection."""
     platform = Platform.CISCO_IOS
-    config = get_hconfig(platform)
+    config = HConfig.from_text(platform)
     interface = config.add_child("interface GigabitEthernet0/0")
     interface.add_child("description test")
 
@@ -170,7 +170,7 @@ def test_children_delete_by_child_object_not_present() -> None:
 def test_children_extend() -> None:
     """Test HConfigChildren.extend() method."""
     platform = Platform.CISCO_IOS
-    config = get_hconfig(platform)
+    config = HConfig.from_text(platform)
     interface1 = config.add_child("interface GigabitEthernet0/0")
     interface2 = config.add_child("interface GigabitEthernet0/1")
 
@@ -193,8 +193,8 @@ def test_children_extend() -> None:
 def test_children_eq_empty_fast_success() -> None:
     """Test HConfigChildren __eq__ fast success for empty."""
     platform = Platform.CISCO_IOS
-    config1 = get_hconfig(platform)
-    config2 = get_hconfig(platform)
+    config1 = HConfig.from_text(platform)
+    config2 = HConfig.from_text(platform)
 
     assert config1.children == config2.children
 
@@ -202,7 +202,7 @@ def test_children_eq_empty_fast_success() -> None:
 def test_children_hash_with_data() -> None:
     """Test HConfigChildren __hash__ with data."""
     platform = Platform.CISCO_IOS
-    config = get_hconfig(platform)
+    config = HConfig.from_text(platform)
     config.add_child("interface GigabitEthernet0/0")
     config.add_child("interface GigabitEthernet0/1")
     hash1 = hash(config.children)
@@ -215,7 +215,7 @@ def test_children_hash_with_data() -> None:
 def test_children_getitem_with_slice() -> None:
     """Test HConfigChildren __getitem__ with slice."""
     platform = Platform.CISCO_IOS
-    config = get_hconfig(platform)
+    config = HConfig.from_text(platform)
     config.add_child("interface GigabitEthernet0/0")
     config.add_child("interface GigabitEthernet0/1")
     config.add_child("interface GigabitEthernet0/2")

--- a/tests/unit/test_children.py
+++ b/tests/unit/test_children.py
@@ -99,7 +99,7 @@ def test_children_eq_with_non_children_type() -> None:
 
     # Directly call __eq__ to verify it returns NotImplemented for non-HConfigChildren types
     # We must use __eq__ directly here to test the NotImplemented return value
-    result = interface.children.__eq__("not a children object")  # pylint: disable=unnecessary-dunder-call # noqa: PLC2801
+    result = interface.children.__eq__("not a children object")  # pylint: disable=unnecessary-dunder-call # ruff:ignore[unnecessary-dunder-call]
     assert result is NotImplemented
 
     # This allows Python to try the reverse comparison, which results in False

--- a/tests/unit/test_constructors.py
+++ b/tests/unit/test_constructors.py
@@ -448,3 +448,24 @@ interface GigabitEthernet0/1
     for af_child in router_bgp.children:
         if af_child.text.startswith("address-family"):
             assert len(af_child.children) >= 1
+
+
+def test_xml_config_raises_invalid_config_error() -> None:
+    """XML input is detected and rejected with a clear message (#232)."""
+    xml_text = '<?xml version="1.0"?><config><system><name>r1</name></system></config>'
+    with pytest.raises(InvalidConfigError, match="appears to be XML"):
+        HConfig.from_text(Platform.CISCO_IOS, xml_text)
+
+
+def test_json_config_raises_invalid_config_error() -> None:
+    """JSON input is detected and rejected with a clear message (#232)."""
+    json_text = '{"system": {"config": {"hostname": "r1"}}}'
+    with pytest.raises(InvalidConfigError, match="appears to be JSON"):
+        HConfig.from_text(Platform.CISCO_IOS, json_text)
+
+
+def test_curly_brace_junos_config_still_parses() -> None:
+    """Junos hierarchical (curly-brace) config is not misdetected as JSON (#232)."""
+    junos_text = "system {\n    host-name r1;\n}\n"
+    config = HConfig.from_text(Platform.JUNIPER_JUNOS, junos_text)
+    assert config.get_child(equals="set system host-name r1") is not None

--- a/tests/unit/test_constructors.py
+++ b/tests/unit/test_constructors.py
@@ -10,9 +10,9 @@ from hier_config import (
     get_hconfig_view,
 )
 from hier_config.constructors import (
-    _adjust_indent,
-    _config_from_string_lines_end_of_banner_test,
-    _load_from_string_lines,
+    _adjust_indent,  # pyright: ignore[reportPrivateUsage]
+    _config_from_string_lines_end_of_banner_test,  # pyright: ignore[reportPrivateUsage]
+    _load_from_string_lines,  # pyright: ignore[reportPrivateUsage]
 )
 from hier_config.exceptions import DriverNotFoundError, InvalidConfigError
 from hier_config.models import Platform
@@ -30,7 +30,7 @@ def test_get_hconfig_driver_unsupported_platform() -> None:
     with pytest.raises(
         DriverNotFoundError, match="Unsupported platform: invalid_platform"
     ):
-        get_hconfig_driver("invalid_platform")  # type: ignore[arg-type]
+        get_hconfig_driver("invalid_platform")
 
 
 def test_get_hconfig_view_unsupported_platform() -> None:

--- a/tests/unit/test_constructors.py
+++ b/tests/unit/test_constructors.py
@@ -6,17 +6,13 @@ from tempfile import NamedTemporaryFile
 import pytest
 
 from hier_config import (
-    get_hconfig,
     get_hconfig_driver,
-    get_hconfig_fast_load,
-    get_hconfig_from_dump,
     get_hconfig_view,
 )
 from hier_config.constructors import (
-    _adjust_indent,  # pyright: ignore[reportPrivateUsage]
-    _config_from_string_lines_end_of_banner_test,  # pyright: ignore[reportPrivateUsage]
-    _load_from_string_lines,  # pyright: ignore[reportPrivateUsage]
-    get_hconfig_fast_generic_load,
+    _adjust_indent,
+    _config_from_string_lines_end_of_banner_test,
+    _load_from_string_lines,
 )
 from hier_config.exceptions import DriverNotFoundError, InvalidConfigError
 from hier_config.models import Platform
@@ -102,7 +98,7 @@ def test_get_hconfig_from_path() -> None:
         path = Path(tmpfile.name)
 
     driver = get_hconfig_driver(Platform.CISCO_IOS)
-    result = get_hconfig(driver, path)
+    result = HConfig.from_text(driver, path)
     hostname_child = result.get_child(startswith="hostname")
     try:
         assert hostname_child is not None
@@ -120,11 +116,11 @@ interface GigabitEthernet0/0
  no shutdown
 """
     driver = get_hconfig_driver(Platform.CISCO_IOS)
-    hconfig = get_hconfig(driver, config)
+    hconfig = HConfig.from_text(driver, config)
 
     dump = hconfig.dump()
 
-    restored = get_hconfig_from_dump(driver, dump)
+    restored = HConfig.from_dump(driver, dump)
     hostname_child = restored.get_child(startswith="hostname")
     assert hostname_child is not None
 
@@ -148,7 +144,7 @@ def test_get_hconfig_fast_generic_load_with_string_conversion() -> None:
         "interface GigabitEthernet0/0",
         " description test",
     ]
-    result = get_hconfig_fast_generic_load(config_lines)
+    result = HConfig.from_lines(Platform.GENERIC, config_lines)
     hostname_child = result.get_child(startswith="hostname")
     assert hostname_child is not None
     assert len(result.children) > 0
@@ -162,7 +158,7 @@ def test_get_hconfig_fast_load_with_string_conversion() -> None:
         " description test",
     ]
     driver = get_hconfig_driver(Platform.CISCO_IOS)
-    result = get_hconfig_fast_load(driver, config_lines)
+    result = HConfig.from_lines(driver, config_lines)
     hostname_child = result.get_child(startswith="hostname")
     assert hostname_child is not None
     assert len(result.children) > 0
@@ -341,10 +337,10 @@ router bgp 65000
   neighbor 10.0.0.2 activate
 """
     driver = get_hconfig_driver(Platform.CISCO_IOS)
-    hconfig = get_hconfig(driver, config)
+    hconfig = HConfig.from_text(driver, config)
 
     dump = hconfig.dump()
-    restored = get_hconfig_from_dump(driver, dump)
+    restored = HConfig.from_dump(driver, dump)
 
     router_bgp = None
     for child in restored.children:
@@ -432,11 +428,11 @@ interface GigabitEthernet0/1
  description another
 """
     driver = get_hconfig_driver(Platform.CISCO_IOS)
-    hconfig = get_hconfig(driver, config)
+    hconfig = HConfig.from_text(driver, config)
 
     dump = hconfig.dump()
 
-    restored = get_hconfig_from_dump(driver, dump)
+    restored = HConfig.from_dump(driver, dump)
 
     assert len(restored.children) > 0
 

--- a/tests/unit/test_constructors.py
+++ b/tests/unit/test_constructors.py
@@ -469,3 +469,10 @@ def test_curly_brace_junos_config_still_parses() -> None:
     junos_text = "system {\n    host-name r1;\n}\n"
     config = HConfig.from_text(Platform.JUNIPER_JUNOS, junos_text)
     assert config.get_child(equals="set system host-name r1") is not None
+
+
+def test_json_via_from_lines_str_raises() -> None:
+    """The str form of from_lines gets the same format guard as from_text (#232)."""
+    json_text = '{"system": {"config": {"hostname": "r1"}}}'
+    with pytest.raises(InvalidConfigError, match="appears to be JSON"):
+        HConfig.from_lines(Platform.CISCO_IOS, json_text)

--- a/tests/unit/test_exceptions.py
+++ b/tests/unit/test_exceptions.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from hier_config import Platform, WorkflowRemediation, get_hconfig, get_hconfig_driver
+from hier_config import HConfig, Platform, WorkflowRemediation, get_hconfig_driver
 from hier_config.exceptions import (
     DriverNotFoundError,
     DuplicateChildError,
@@ -26,7 +26,7 @@ def test_hier_config_error_is_catchable_as_exception() -> None:
 
 
 def test_duplicate_child_error_on_duplicate_section() -> None:
-    config = get_hconfig(Platform.CISCO_IOS, "interface Loopback0")
+    config = HConfig.from_text(Platform.CISCO_IOS, "interface Loopback0")
     with pytest.raises(DuplicateChildError, match="Found a duplicate section"):
         config.add_child("interface Loopback0")
 
@@ -39,8 +39,8 @@ def test_driver_not_found_error_invalid_platform() -> None:
 
 def test_incompatible_driver_error_mismatched_drivers() -> None:
     """WorkflowRemediation raises IncompatibleDriverError for mismatched drivers."""
-    running = get_hconfig(Platform.CISCO_IOS)
-    generated = get_hconfig(Platform.ARISTA_EOS)
+    running = HConfig.from_text(Platform.CISCO_IOS)
+    generated = HConfig.from_text(Platform.ARISTA_EOS)
     with pytest.raises(IncompatibleDriverError, match="same driver"):
         WorkflowRemediation(running, generated)
 
@@ -49,4 +49,4 @@ def test_invalid_config_error_banner_parsing() -> None:
     """Malformed banner config raises InvalidConfigError."""
     config_text = "banner motd ^C\nthis banner never ends"
     with pytest.raises(InvalidConfigError, match="banner"):
-        get_hconfig(Platform.CISCO_IOS, config_text)
+        HConfig.from_text(Platform.CISCO_IOS, config_text)

--- a/tests/unit/test_exceptions.py
+++ b/tests/unit/test_exceptions.py
@@ -34,7 +34,7 @@ def test_duplicate_child_error_on_duplicate_section() -> None:
 def test_driver_not_found_error_invalid_platform() -> None:
     """get_hconfig_driver raises DriverNotFoundError for unsupported platforms."""
     with pytest.raises(DriverNotFoundError, match="Unsupported platform"):
-        get_hconfig_driver("bogus_platform")  # type: ignore[arg-type]
+        get_hconfig_driver("bogus_platform")
 
 
 def test_incompatible_driver_error_mismatched_drivers() -> None:

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -1,0 +1,44 @@
+"""Tests for hier_config/models.py."""
+
+import pytest
+from pydantic import ValidationError
+
+from hier_config.models import MatchRule, NegationRule, NegationStrategy
+
+
+def test_negation_rule_replace_requires_use() -> None:
+    """A REPLACE-strategy rule without `use` is a misconfiguration (#278 review)."""
+    with pytest.raises(ValidationError, match="REPLACE strategy requires `use`"):
+        NegationRule(
+            match_rules=(MatchRule(startswith="logging console"),),
+            strategy=NegationStrategy.REPLACE,
+        )
+
+
+def test_negation_rule_regex_sub_requires_search() -> None:
+    """A REGEX_SUB-strategy rule without `search` is a misconfiguration (#278 review)."""
+    with pytest.raises(ValidationError, match="REGEX_SUB strategy requires `search`"):
+        NegationRule(
+            match_rules=(MatchRule(startswith="snmp-server user"),),
+            strategy=NegationStrategy.REGEX_SUB,
+        )
+
+
+def test_negation_rule_regex_sub_allows_empty_replace() -> None:
+    """REGEX_SUB with an empty `replace` is valid (deletion-style substitution)."""
+    rule = NegationRule(
+        match_rules=(MatchRule(startswith="snmp-server user"),),
+        strategy=NegationStrategy.REGEX_SUB,
+        search=r"(no snmp-server user \S+).*",
+    )
+    assert not rule.replace
+
+
+def test_negation_rule_default_requires_no_extra_fields() -> None:
+    """A DEFAULT-strategy rule is valid with only match_rules."""
+    rule = NegationRule(
+        match_rules=(MatchRule(startswith="interface"),),
+        strategy=NegationStrategy.DEFAULT,
+    )
+    assert not rule.use
+    assert not rule.search

--- a/tests/unit/test_registry.py
+++ b/tests/unit/test_registry.py
@@ -1,0 +1,106 @@
+"""Tests for the driver registration system (#226, #229)."""
+
+import pytest
+
+from hier_config import (
+    HConfig,
+    HConfigDriverBase,
+    HConfigDriverRules,
+    Platform,
+    get_hconfig_driver,
+    get_hconfig_view,
+    get_registered_platforms,
+    register_driver,
+    unregister_driver,
+)
+from hier_config.exceptions import DriverNotFoundError
+from hier_config.platforms.cisco_ios.driver import HConfigDriverCiscoIOS
+from hier_config.platforms.cisco_ios.view import HConfigViewCiscoIOS
+
+
+class _CustomDriver(HConfigDriverBase):
+    """A user-defined driver for a custom platform."""
+
+    @staticmethod
+    def _instantiate_rules() -> HConfigDriverRules:
+        return HConfigDriverRules()
+
+
+def test_register_custom_platform() -> None:
+    """A registered string platform works with driver lookup and constructors."""
+    register_driver("MY_NOS", _CustomDriver)
+    try:
+        driver = get_hconfig_driver("MY_NOS")
+        assert isinstance(driver, _CustomDriver)
+
+        config = HConfig.from_text("MY_NOS", "hostname test\n")
+        assert config.get_child(equals="hostname test") is not None
+    finally:
+        unregister_driver("MY_NOS")
+
+
+def test_register_custom_platform_is_case_insensitive() -> None:
+    """Custom platform names are normalized to uppercase."""
+    register_driver("my_nos", _CustomDriver)
+    try:
+        assert isinstance(get_hconfig_driver("MY_NOS"), _CustomDriver)
+        assert isinstance(get_hconfig_driver("my_nos"), _CustomDriver)
+    finally:
+        unregister_driver("MY_NOS")
+
+
+def test_override_builtin_driver() -> None:
+    """Registering an existing Platform overrides the built-in driver."""
+
+    class CustomIOSDriver(HConfigDriverCiscoIOS):
+        """Override of the built-in IOS driver."""
+
+    register_driver(Platform.CISCO_IOS, CustomIOSDriver)
+    try:
+        assert isinstance(get_hconfig_driver(Platform.CISCO_IOS), CustomIOSDriver)
+    finally:
+        unregister_driver(Platform.CISCO_IOS)
+
+    # Unregistering an overridden built-in restores the default driver.
+    driver = get_hconfig_driver(Platform.CISCO_IOS)
+    assert type(driver) is HConfigDriverCiscoIOS
+
+
+def test_registered_driver_view_follows_driver() -> None:
+    """A custom driver's view_class works through get_hconfig_view (#229)."""
+
+    class CustomIOSDriver(HConfigDriverCiscoIOS):
+        """Override with the inherited IOS view."""
+
+    register_driver("CUSTOM_IOS", CustomIOSDriver)
+    try:
+        config = HConfig.from_text("CUSTOM_IOS", "hostname test\n")
+        view = get_hconfig_view(config)
+        assert isinstance(view, HConfigViewCiscoIOS)
+    finally:
+        unregister_driver("CUSTOM_IOS")
+
+
+def test_get_registered_platforms_contains_builtins() -> None:
+    """All built-in platforms are registered at import time."""
+    registered = get_registered_platforms()
+    for platform in Platform:
+        assert platform in registered
+
+
+def test_unknown_platform_raises() -> None:
+    """Looking up an unregistered platform raises DriverNotFoundError."""
+    with pytest.raises(DriverNotFoundError, match="Unsupported platform"):
+        get_hconfig_driver("NOT_REGISTERED")
+
+
+def test_unregister_unknown_platform_raises() -> None:
+    """Unregistering a platform that is not registered raises."""
+    with pytest.raises(DriverNotFoundError, match="Unsupported platform"):
+        unregister_driver("NOT_REGISTERED")
+
+
+def test_unregister_builtin_without_override_raises() -> None:
+    """A built-in platform without an override cannot be unregistered."""
+    with pytest.raises(DriverNotFoundError, match="not overridden"):
+        unregister_driver(Platform.CISCO_XR)

--- a/tests/unit/test_registry.py
+++ b/tests/unit/test_registry.py
@@ -26,25 +26,33 @@ class _CustomDriver(HConfigDriverBase):
         return HConfigDriverRules()
 
 
+def _assert_custom_platform_works() -> None:
+    driver = get_hconfig_driver("MY_NOS")
+    assert isinstance(driver, _CustomDriver)
+
+    config = HConfig.from_text("MY_NOS", "hostname test\n")
+    assert config.get_child(equals="hostname test") is not None
+
+
 def test_register_custom_platform() -> None:
     """A registered string platform works with driver lookup and constructors."""
     register_driver("MY_NOS", _CustomDriver)
     try:
-        driver = get_hconfig_driver("MY_NOS")
-        assert isinstance(driver, _CustomDriver)
-
-        config = HConfig.from_text("MY_NOS", "hostname test\n")
-        assert config.get_child(equals="hostname test") is not None
+        _assert_custom_platform_works()
     finally:
         unregister_driver("MY_NOS")
+
+
+def _assert_case_insensitive_lookup() -> None:
+    assert isinstance(get_hconfig_driver("MY_NOS"), _CustomDriver)
+    assert isinstance(get_hconfig_driver("my_nos"), _CustomDriver)
 
 
 def test_register_custom_platform_is_case_insensitive() -> None:
     """Custom platform names are normalized to uppercase."""
     register_driver("my_nos", _CustomDriver)
     try:
-        assert isinstance(get_hconfig_driver("MY_NOS"), _CustomDriver)
-        assert isinstance(get_hconfig_driver("my_nos"), _CustomDriver)
+        _assert_case_insensitive_lookup()
     finally:
         unregister_driver("MY_NOS")
 
@@ -63,7 +71,13 @@ def test_override_builtin_driver() -> None:
 
     # Unregistering an overridden built-in restores the default driver.
     driver = get_hconfig_driver(Platform.CISCO_IOS)
-    assert type(driver) is HConfigDriverCiscoIOS
+    assert driver.__class__ is HConfigDriverCiscoIOS
+
+
+def _assert_custom_view_resolves() -> None:
+    config = HConfig.from_text("CUSTOM_IOS", "hostname test\n")
+    view = get_hconfig_view(config)
+    assert isinstance(view, HConfigViewCiscoIOS)
 
 
 def test_registered_driver_view_follows_driver() -> None:
@@ -74,9 +88,7 @@ def test_registered_driver_view_follows_driver() -> None:
 
     register_driver("CUSTOM_IOS", CustomIOSDriver)
     try:
-        config = HConfig.from_text("CUSTOM_IOS", "hostname test\n")
-        view = get_hconfig_view(config)
-        assert isinstance(view, HConfigViewCiscoIOS)
+        _assert_custom_view_resolves()
     finally:
         unregister_driver("CUSTOM_IOS")
 

--- a/tests/unit/test_reporting.py
+++ b/tests/unit/test_reporting.py
@@ -15,7 +15,6 @@ from hier_config import (
     RemediationReporter,
     TagRule,
     WorkflowRemediation,
-    get_hconfig,
 )
 from hier_config.models import ChangeDetail, ReportSummary
 
@@ -23,7 +22,7 @@ from hier_config.models import ChangeDetail, ReportSummary
 @pytest.fixture
 def sample_remediation_1() -> tuple[HConfig, str]:
     """Create a sample remediation configuration for device 1."""
-    running = get_hconfig(
+    running = HConfig.from_text(
         Platform.CISCO_IOS,
         """interface Vlan2
  ip address 10.0.0.1 255.255.255.0
@@ -32,7 +31,7 @@ line vty 0 4
 ntp server 10.1.1.1""",
     )
 
-    generated = get_hconfig(
+    generated = HConfig.from_text(
         Platform.CISCO_IOS,
         """interface Vlan2
  ip address 10.0.0.2 255.255.255.0
@@ -50,7 +49,7 @@ snmp-server community public RO""",
 @pytest.fixture
 def sample_remediation_2() -> tuple[HConfig, str]:
     """Create a sample remediation configuration for device 2."""
-    running = get_hconfig(
+    running = HConfig.from_text(
         Platform.CISCO_IOS,
         """interface Vlan3
  ip address 10.0.1.1 255.255.255.0
@@ -59,7 +58,7 @@ line vty 0 4
 ntp server 10.1.1.1""",
     )
 
-    generated = get_hconfig(
+    generated = HConfig.from_text(
         Platform.CISCO_IOS,
         """interface Vlan3
  ip address 10.0.1.2 255.255.255.0
@@ -77,14 +76,14 @@ snmp-server community public RO""",
 @pytest.fixture
 def sample_remediation_3() -> tuple[HConfig, str]:
     """Create a sample remediation configuration for device 3."""
-    running = get_hconfig(
+    running = HConfig.from_text(
         Platform.CISCO_IOS,
         """interface Vlan4
  ip address 10.0.2.1 255.255.255.0
 ntp server 10.1.1.1""",
     )
 
-    generated = get_hconfig(
+    generated = HConfig.from_text(
         Platform.CISCO_IOS,
         """interface Vlan4
  ip address 10.0.2.2 255.255.255.0
@@ -153,7 +152,7 @@ def test_from_merged_config(
     rem2, _ = sample_remediation_2
 
     # Create a merged config manually
-    merged = get_hconfig(Platform.CISCO_IOS)
+    merged = HConfig.from_text(Platform.CISCO_IOS)
     merged.merge([rem1, rem2])
 
     reporter = RemediationReporter.from_merged_config(merged)
@@ -686,7 +685,7 @@ def test_empty_reporter() -> None:
 
 def test_reporter_with_empty_remediation() -> None:
     """Test reporter with empty remediation config."""
-    empty_config = get_hconfig(Platform.CISCO_IOS)
+    empty_config = HConfig.from_text(Platform.CISCO_IOS)
 
     reporter = RemediationReporter()
     reporter.add_remediation(empty_config)

--- a/tests/unit/test_root.py
+++ b/tests/unit/test_root.py
@@ -6,7 +6,8 @@ from pathlib import Path
 import pytest
 
 from hier_config import HConfig, get_hconfig_driver
-from hier_config.models import Platform
+from hier_config.exceptions import DuplicateChildError
+from hier_config.models import ParentAllowsDuplicateChildRule, Platform
 
 
 def test_bool(platform_a: Platform) -> None:
@@ -200,3 +201,25 @@ def test_len_counts_all_descendants() -> None:
 
     assert len(config) == 4
     assert len(interface) == 2
+
+
+def test_root_duplicate_children_allowed_by_rule() -> None:
+    """A ParentAllowsDuplicateChildRule with empty match_rules applies to the root (#215)."""
+    driver = get_hconfig_driver(Platform.GENERIC)
+    driver.rules.parent_allows_duplicate_child.append(
+        ParentAllowsDuplicateChildRule(match_rules=())
+    )
+    config = HConfig.from_text(driver)
+    child1 = config.add_child("ip prefix-list PL seq 10 permit 10.0.0.0/8")
+    child2 = config.add_child("ip prefix-list PL seq 10 permit 10.0.0.0/8")
+
+    assert child1 is not child2
+    assert len(config.children) == 2
+
+
+def test_root_duplicate_children_denied_by_default() -> None:
+    """Without a root rule, duplicate root children still raise (#215)."""
+    config = HConfig.from_text(Platform.CISCO_IOS)
+    config.add_child("hostname router1")
+    with pytest.raises(DuplicateChildError):
+        config.add_child("hostname router1")

--- a/tests/unit/test_root.py
+++ b/tests/unit/test_root.py
@@ -5,29 +5,24 @@ from pathlib import Path
 
 import pytest
 
-from hier_config import (
-    get_hconfig,
-    get_hconfig_driver,
-    get_hconfig_fast_load,
-    get_hconfig_from_dump,
-)
+from hier_config import HConfig, get_hconfig_driver
 from hier_config.models import Platform
 
 
 def test_bool(platform_a: Platform) -> None:
-    config = get_hconfig(platform_a)
+    config = HConfig.from_text(platform_a)
     assert config
 
 
 def test_hash(platform_a: Platform) -> None:
-    config = get_hconfig_fast_load(platform_a, ("interface 1/1", "  untagged vlan 5"))
+    config = HConfig.from_lines(platform_a, ("interface 1/1", "  untagged vlan 5"))
     assert hash(config)
 
 
 def test_merge(platform_a: Platform, platform_b: Platform) -> None:
-    hier1 = get_hconfig(platform_a)
+    hier1 = HConfig.from_text(platform_a)
     hier1.add_child("interface Vlan2")
-    hier2 = get_hconfig(platform_b)
+    hier2 = HConfig.from_text(platform_b)
     hier2.add_child("interface Vlan3")
 
     assert len(tuple(hier1.all_children())) == 1
@@ -49,7 +44,7 @@ def test_load_from_file(platform_a: Platform) -> None:
         myfile.file.write(config)
         myfile.file.flush()
         myfile.close()
-        hier = get_hconfig(get_hconfig_driver(platform_a), Path(myfile.name))
+        hier = HConfig.from_text(get_hconfig_driver(platform_a), Path(myfile.name))
         Path(myfile.name).unlink()
 
     assert len(tuple(hier.all_children())) == 2
@@ -57,12 +52,12 @@ def test_load_from_file(platform_a: Platform) -> None:
 
 def test_load_from_config_text(platform_a: Platform) -> None:
     config = "interface Vlan2\n ip address 1.1.1.1 255.255.255.0"
-    hier = get_hconfig(get_hconfig_driver(platform_a), config)
+    hier = HConfig.from_text(get_hconfig_driver(platform_a), config)
     assert len(tuple(hier.all_children())) == 2
 
 
 def test_dump_and_load_from_dump_and_compare(platform_a: Platform) -> None:
-    hier_pre_dump = get_hconfig(platform_a)
+    hier_pre_dump = HConfig.from_text(platform_a)
     b2 = hier_pre_dump.add_children_deep(("a1", "b2"))
 
     b2.order_weight = 400
@@ -71,7 +66,7 @@ def test_dump_and_load_from_dump_and_compare(platform_a: Platform) -> None:
     b2.new_in_config = True
 
     dump = hier_pre_dump.dump()
-    hier_post_dump = get_hconfig_from_dump(hier_pre_dump.driver, dump)
+    hier_post_dump = HConfig.from_dump(hier_pre_dump.driver, dump)
 
     assert hier_pre_dump == hier_post_dump
 
@@ -79,8 +74,8 @@ def test_dump_and_load_from_dump_and_compare(platform_a: Platform) -> None:
 def test_unified_diff() -> None:
     platform = Platform.CISCO_IOS
 
-    config_a = get_hconfig(platform)
-    config_b = get_hconfig(platform)
+    config_a = HConfig.from_text(platform)
+    config_b = HConfig.from_text(platform)
     # deep differences
     config_a.add_children_deep(("a", "aa", "aaa", "aaaa"))
     config_b.add_children_deep(("a", "aa", "aab", "aaba"))
@@ -108,7 +103,7 @@ def test_unified_diff() -> None:
 def test_hconfig_str() -> None:
     """Test HConfig __str__ method."""
     platform = Platform.CISCO_IOS
-    config = get_hconfig(platform)
+    config = HConfig.from_text(platform)
     config.add_child("hostname router1")
     config.add_child("interface GigabitEthernet0/0")
     str_output = str(config)
@@ -121,7 +116,7 @@ def test_hconfig_str() -> None:
 def test_hconfig_eq_not_hconfig() -> None:
     """Test HConfig __eq__ with non-HConfig object."""
     platform = Platform.CISCO_IOS
-    config = get_hconfig(platform)
+    config = HConfig.from_text(platform)
     result = config == "not an HConfig"
 
     assert not result
@@ -130,7 +125,7 @@ def test_hconfig_eq_not_hconfig() -> None:
 def test_hconfig_real_indent_level() -> None:
     """Test HConfig real_indent_level property."""
     platform = Platform.CISCO_IOS
-    config = get_hconfig(platform)
+    config = HConfig.from_text(platform)
 
     assert config.real_indent_level == -1
 
@@ -138,7 +133,7 @@ def test_hconfig_real_indent_level() -> None:
 def test_hconfig_parent_property() -> None:
     """Test HConfig parent property returns self."""
     platform = Platform.CISCO_IOS
-    config = get_hconfig(platform)
+    config = HConfig.from_text(platform)
 
     assert config.parent is config
 
@@ -146,7 +141,7 @@ def test_hconfig_parent_property() -> None:
 def test_hconfig_is_leaf() -> None:
     """Test HConfig is_leaf property."""
     platform = Platform.CISCO_IOS
-    config = get_hconfig(platform)
+    config = HConfig.from_text(platform)
 
     assert config.is_leaf is False
 
@@ -154,7 +149,7 @@ def test_hconfig_is_leaf() -> None:
 def test_hconfig_tags_setter() -> None:
     """Test HConfig tags setter."""
     platform = Platform.CISCO_IOS
-    config = get_hconfig(platform)
+    config = HConfig.from_text(platform)
     interface = config.add_child("interface GigabitEthernet0/0")
     desc = interface.add_child("description test")
     config.tags = frozenset(["production", "core"])
@@ -166,7 +161,7 @@ def test_hconfig_tags_setter() -> None:
 def test_hconfig_add_children_deep_typeerror() -> None:
     """Test HConfig add_children_deep raises TypeError."""
     platform = Platform.CISCO_IOS
-    config = get_hconfig(platform)
+    config = HConfig.from_text(platform)
 
     with pytest.raises(TypeError, match="base was an HConfig object"):
         config.add_children_deep([])
@@ -175,7 +170,7 @@ def test_hconfig_add_children_deep_typeerror() -> None:
 def test_hconfig_deep_copy() -> None:
     """Test HConfig deep_copy method)."""
     platform = Platform.CISCO_IOS
-    config = get_hconfig(platform)
+    config = HConfig.from_text(platform)
     interface = config.add_child("interface GigabitEthernet0/0")
     interface.add_child("description test")
     config.add_child("hostname router1")
@@ -195,7 +190,7 @@ def test_hconfig_deep_copy() -> None:
 
 def test_len_counts_all_descendants() -> None:
     """__len__ counts every descendant node, not just direct children (#188)."""
-    config = get_hconfig(Platform.CISCO_IOS)
+    config = HConfig.from_text(Platform.CISCO_IOS)
     assert len(config) == 0
 
     interface = config.add_child("interface GigabitEthernet0/0")

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -6,7 +6,7 @@ import yaml
 from pydantic import ValidationError
 
 from hier_config import Platform
-from hier_config.models import MatchRule, TagRule
+from hier_config.models import MatchRule, NegationStrategy, TagRule
 from hier_config.utils import (
     _set_match_rule,  # pyright: ignore[reportPrivateUsage]
     load_driver_rules,
@@ -190,14 +190,13 @@ def test_load_driver_rules(platform_generic: Platform) -> None:
     assert len(driver.rules.idempotent_commands) == 1
     assert driver.rules.idempotent_commands[0].match_rules[0].startswith == "interface"
 
-    # Assert negation_negate_with -> negate_with
-    assert len(driver.rules.negate_with) == 1
-    assert driver.rules.negate_with[0].match_rules[0].startswith == "interface Ethernet"
-    assert (
-        driver.rules.negate_with[0].match_rules[1].startswith
-        == "spanning-tree port type"
-    )
-    assert driver.rules.negate_with[0].use == "no spanning-tree port type"
+    # Assert negation_negate_with -> unified negation rule (REPLACE)
+    assert len(driver.rules.negation) == 1
+    negation_rule = driver.rules.negation[0]
+    assert negation_rule.strategy == NegationStrategy.REPLACE
+    assert negation_rule.match_rules[0].startswith == "interface Ethernet"
+    assert negation_rule.match_rules[1].startswith == "spanning-tree port type"
+    assert negation_rule.use == "no spanning-tree port type"
 
 
 def test_load_tag_rules_valid_input() -> None:

--- a/tests/unit/test_workflows.py
+++ b/tests/unit/test_workflows.py
@@ -1,6 +1,6 @@
 import pytest
 
-from hier_config import HConfig, WorkflowRemediation
+from hier_config import HConfig, RemediationPlugin, WorkflowRemediation
 from hier_config.exceptions import IncompatibleDriverError
 from hier_config.models import Platform, TagRule
 
@@ -72,3 +72,40 @@ def test_rollback_config_reverts_changes(wfr: WorkflowRemediation) -> None:
     )
     expected_text = "no vlan 4\nno interface Vlan4\nvlan 3\n  name switch_mgmt_10.0.4.0/24\ninterface Vlan2\n  no mtu 9000\n  no ip access-group TEST in\n  shutdown\ninterface Vlan3\n  description switch_mgmt_10.0.4.0/24\n  ip address 10.0.4.1 255.255.0.0"
     assert rollback_text == expected_text
+
+
+def test_remediation_transform_callbacks_applied() -> None:
+    """Driver remediation_transform_callbacks run on the remediation config (#180)."""
+    running_config = HConfig.from_text(Platform.CISCO_IOS, "hostname old\n")
+    generated_config = HConfig.from_text(Platform.CISCO_IOS, "hostname new\n")
+
+    def add_marker(remediation: HConfig) -> None:
+        remediation.add_child("end")
+
+    running_config.driver.rules.remediation_transform_callbacks.append(add_marker)
+    workflow = WorkflowRemediation(running_config, generated_config)
+
+    assert workflow.remediation_config.get_child(equals="end") is not None
+
+
+def test_remediation_plugin_applied() -> None:
+    """User plugins transform the remediation config (#181)."""
+
+    class MarkerPlugin(RemediationPlugin):
+        """Adds a marker line to every remediation."""
+
+        @property
+        def name(self) -> str:
+            return "marker"
+
+        def transform(self, remediation: HConfig) -> None:
+            remediation.add_child("end")
+
+    running_config = HConfig.from_text(Platform.CISCO_IOS, "hostname old\n")
+    generated_config = HConfig.from_text(Platform.CISCO_IOS, "hostname new\n")
+    workflow = WorkflowRemediation(
+        running_config, generated_config, plugins=(MarkerPlugin(),)
+    )
+
+    assert workflow.remediation_config.get_child(equals="end") is not None
+    assert workflow.plugins[0].description == ""

--- a/tests/unit/test_workflows.py
+++ b/tests/unit/test_workflows.py
@@ -1,6 +1,6 @@
 import pytest
 
-from hier_config import WorkflowRemediation, get_hconfig
+from hier_config import HConfig, WorkflowRemediation
 from hier_config.exceptions import IncompatibleDriverError
 from hier_config.models import Platform, TagRule
 
@@ -10,8 +10,8 @@ def workflow_remediation(
     running_config: str, generated_config: str
 ) -> WorkflowRemediation:
     return WorkflowRemediation(
-        running_config=get_hconfig(Platform.CISCO_IOS, running_config),
-        generated_config=get_hconfig(Platform.CISCO_IOS, generated_config),
+        running_config=HConfig.from_text(Platform.CISCO_IOS, running_config),
+        generated_config=HConfig.from_text(Platform.CISCO_IOS, generated_config),
     )
 
 
@@ -47,8 +47,8 @@ def test_remediation_config_filtered_text(
 
 def test_remediation_config_driver_mismatch() -> None:
     # Test to ensure ValueError is raised for mismatched drivers
-    running_config = get_hconfig(Platform.CISCO_IOS, "dummy_config")
-    generated_config = get_hconfig(Platform.JUNIPER_JUNOS, "dummy_config")
+    running_config = HConfig.from_text(Platform.CISCO_IOS, "dummy_config")
+    generated_config = HConfig.from_text(Platform.JUNIPER_JUNOS, "dummy_config")
 
     with pytest.raises(
         IncompatibleDriverError,

--- a/tests/unit/test_workflows.py
+++ b/tests/unit/test_workflows.py
@@ -98,7 +98,7 @@ def test_remediation_plugin_applied() -> None:
         def name(self) -> str:
             return "marker"
 
-        def transform(self, remediation: HConfig) -> None:
+        def transform(self, remediation: HConfig) -> None:  # noqa: PLR6301
             remediation.add_child("end")
 
     running_config = HConfig.from_text(Platform.CISCO_IOS, "hostname old\n")
@@ -108,4 +108,4 @@ def test_remediation_plugin_applied() -> None:
     )
 
     assert workflow.remediation_config.get_child(equals="end") is not None
-    assert workflow.plugins[0].description == ""
+    assert not workflow.plugins[0].description

--- a/tests/unit/test_workflows.py
+++ b/tests/unit/test_workflows.py
@@ -98,14 +98,28 @@ def test_remediation_plugin_applied() -> None:
         def name(self) -> str:
             return "marker"
 
-        def transform(self, remediation: HConfig) -> None:  # noqa: PLR6301
+        def transform(self, remediation: HConfig) -> None:  # ruff:ignore[no-self-use]
             remediation.add_child("end")
 
     running_config = HConfig.from_text(Platform.CISCO_IOS, "hostname old\n")
     generated_config = HConfig.from_text(Platform.CISCO_IOS, "hostname new\n")
+    plugin = MarkerPlugin()
+    workflow = WorkflowRemediation(running_config, generated_config, plugins=(plugin,))
+
+    assert workflow.remediation_config.get_child(equals="end") is not None
+    assert not plugin.description
+
+
+def test_plain_callable_plugin_applied() -> None:
+    """plugins= accepts bare callables, not just RemediationPlugin instances."""
+    running_config = HConfig.from_text(Platform.CISCO_IOS, "hostname old\n")
+    generated_config = HConfig.from_text(Platform.CISCO_IOS, "hostname new\n")
+
+    def add_marker(remediation: HConfig) -> None:
+        remediation.add_child("end")
+
     workflow = WorkflowRemediation(
-        running_config, generated_config, plugins=(MarkerPlugin(),)
+        running_config, generated_config, plugins=(add_marker,)
     )
 
     assert workflow.remediation_config.get_child(equals="end") is not None
-    assert not workflow.plugins[0].description


### PR DESCRIPTION
## Summary

One large PR completing the remaining v4 work. Each issue was re-evaluated on its merits; where the issue's proposed approach wasn't the best fit, the deviation is explained below and in `CHANGELOG.md`.

Closes #226, closes #229, closes #218, closes #220, closes #215, closes #217, closes #186, closes #180, closes #181, closes #232, closes #227, closes #230, closes #222, closes #223, closes #224.

### Implemented

- **#226 Driver registration** — new `hier_config.registry`: `register_driver()`, `unregister_driver()`, `get_registered_platforms()`. Custom platforms register by string name (case-insensitive, usable anywhere a `Platform` is accepted); built-in drivers can be overridden and restored. `HConfigDriverBase`/`HConfigDriverRules` are public API. *Re-evaluation:* runtime `Platform` enum mutation (the issue's sketch) is fragile; a registry keyed by `Platform | str` delivers the same capability safely.
- **#229 View registration** — registered drivers carry their view via `view_class` (built on #275); custom platforms get views with zero extra wiring.
- **#218 Constructors** — `HConfig.from_text()/from_lines()/from_dump()` classmethods replace `get_hconfig()`, `get_hconfig_fast_load()`, `get_hconfig_from_dump()`, `get_hconfig_fast_generic_load()`. `get_hconfig_driver()`/`get_hconfig_view()` remain standalone. All call sites, docs, and CLAUDE.md migrated.
- **#220 Unified negation** — single `NegationRule` model + `NegationStrategy` enum (`REPLACE`/`DEFAULT`/`REGEX_SUB`) in one ordered `negation` list; first match wins. `load_driver_rules()` still accepts the v2 dict keys for Nautobot compatibility.
- **#215 Root duplicates** — a `ParentAllowsDuplicateChildRule` with empty `match_rules` applies to the root (children can never match an empty rule, so the mechanism unifies cleanly).
- **#217 Tree algorithms** — `compute_difference`/`compute_remediation`/`compute_future`/`compute_with_tags` extracted to `hier_config/tree_algorithms.py`; `HConfigBase` keeps thin delegates.
- **#186 Loader refactor** — `_load_from_string_lines()` is now a stateful `_ConfigTextLoader` with focused banner/normalize/hierarchy methods; the `C901` noqa is gone.
- **#180 Transform callbacks** — `remediation_transform_callbacks` on `HConfigDriverRules`, applied in `WorkflowRemediation.remediation_config`.
- **#181 Plugin system** — `RemediationPlugin` ABC (`hier_config.plugins`) + `WorkflowRemediation(plugins=...)`, applied after driver callbacks.
- **#232 Structured formats** — XML/JSON input is detected and rejected with a clear `InvalidConfigError`; set-style is already natively supported (JunOS/VyOS/Nokia SRL preprocessors). Full XML/JSON ingestion is additive and deferred past 4.0 per the issue's own "no breaking change" framing.
- **#227 View mixins** — `ConfigViewInterfaceBase` reduced to a core surface; optional capabilities split into `InterfaceBundleViewMixin`, `InterfaceVlanViewMixin`, `InterfaceNACViewMixin`, `InterfacePhysicalViewMixin` with `isinstance` capability checks. Also fixes IOS `is_bundle` case-sensitivity.
- **#230 View completion** — EOS, NXOS, and XR views completed to core + Bundle + Vlan with real parsers for each platform's syntax; no `NotImplementedError` stubs remain in them.

### Documented decisions (see CHANGELOG "v4 design decisions")

- **#223** — `HConfig.remediation()` stays public: #216 deliberately renamed it as the tree-level primitive, and `WorkflowRemediation` (which already validates driver compatibility with `IncompatibleDriverError`) remains the recommended workflow API.
- **#222** — drivers stay declarative-first with sanctioned imperative hooks: #220 removed the negation override needs; `idempotent_for()`, `negate_with()`, `config_preprocessor()` remain overridable for logic rules cannot express.
- **#224** — trees stay mutable: full immutability would break the callback/plugin mutation model for marginal benefit; a new regression test guarantees `remediation()` never mutates its inputs.

## Test plan

- [x] `poetry run ./scripts/build.py lint-and-test` — ruff, mypy strict, pyright strict, pylint, yamllint, flynt all pass; 660 tests, 98% coverage (≥95% required).
- [x] New unit tests: registry (custom platforms, overrides, restore), classmethod constructors, unified negation strategies, root duplicates, transform callbacks, plugins, format detection, non-mutation guarantee, per-platform view capability + behavior tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)