### PR TITLE
Add JSON/XML config ingestion and rendering (#232)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   error now points at the new constructors. NETCONF `edit-config` operation
   attributes are not yet given remediation semantics.
 
-### Added
-
 - Interface view capability mixins (#227): `ConfigViewInterfaceBase` now
   carries only the core interface properties (`name`, `description`,
   `enabled`, `ipv4_interfaces`, `is_loopback`, `is_svi`, `number`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Structured config ingestion and rendering (#232): `HConfig.from_json()` /
+  `HConfig.from_xml()` build config trees from JSON (e.g. OpenConfig) and XML
+  (e.g. NETCONF payloads), with OpenConfig-style keyed lists identified via
+  `list_keys` (default `("name", "id")`). `HConfig.to_json()` / `to_xml()`
+  invert the mapping, so structured configs can be diffed, predicted with
+  `future()`, and rendered back in their source format. The format-detection
+  error now points at the new constructors. NETCONF `edit-config` operation
+  attributes are not yet given remediation semantics.
+
+### Added
+
 - Interface view capability mixins (#227): `ConfigViewInterfaceBase` now
   carries only the core interface properties (`name`, `description`,
   `enabled`, `ipv4_interfaces`, `is_loopback`, `is_svi`, `number`,

--- a/hier_config/constructors.py
+++ b/hier_config/constructors.py
@@ -11,7 +11,7 @@ from .child import HConfigChild
 from .exceptions import DriverNotFoundError, InvalidConfigError
 from .models import Dump, Platform
 from .platforms.view_base import HConfigViewBase
-from .registry import get_hconfig_driver
+from .registry import resolve_driver
 from .root import HConfig
 
 logger = getLogger(__name__)
@@ -66,7 +66,7 @@ def hconfig_from_text(
 
     _reject_structured_format(config_raw)
 
-    config = HConfig(_get_driver(platform_or_driver))
+    config = HConfig(resolve_driver(platform_or_driver))
     for rule in config.driver.rules.full_text_sub:
         config_raw = sub(rule.search, rule.replace, config_raw)
 
@@ -85,7 +85,7 @@ def hconfig_from_dump(
     platform_or_driver: Platform | str | HConfigDriverBase, dump: Dump
 ) -> HConfig:
     """Load an HConfig dump."""
-    config = HConfig(_get_driver(platform_or_driver))
+    config = HConfig(resolve_driver(platform_or_driver))
     last_item: HConfig | HConfigChild = config
     for item in dump.lines:
         # parent is the root
@@ -113,7 +113,7 @@ def hconfig_from_lines(
     platform_or_driver: Platform | str | HConfigDriverBase,
     lines: list[str] | tuple[str, ...] | str,
 ) -> HConfig:
-    driver = _get_driver(platform_or_driver)
+    driver = resolve_driver(platform_or_driver)
     config = HConfig(driver)
     if isinstance(lines, str):
         _reject_structured_format(lines)
@@ -150,14 +150,6 @@ def hconfig_from_lines(
         callback(config)
 
     return config
-
-
-def _get_driver(
-    platform_or_driver: Platform | str | HConfigDriverBase,
-) -> HConfigDriverBase:
-    if isinstance(platform_or_driver, (Platform, str)):
-        return get_hconfig_driver(platform_or_driver)
-    return platform_or_driver
 
 
 def _analyze_indent(

--- a/hier_config/constructors.py
+++ b/hier_config/constructors.py
@@ -49,10 +49,10 @@ def _detect_structured_format(config_text: str) -> str | None:
 def _reject_structured_format(config_text: str) -> None:
     if detected := _detect_structured_format(config_text):
         message = (
-            f"The config appears to be {detected}, which hier_config does not"
-            " parse. Convert it to the platform's indented CLI text first"
-            " (set-style configs are supported natively by the Juniper JunOS,"
-            " VyOS, and Nokia SRL drivers)."
+            f"The config appears to be {detected}. Use HConfig.from_xml() or"
+            " HConfig.from_json() for structured formats, or convert to the"
+            " platform's indented CLI text (set-style configs are supported"
+            " natively by the Juniper JunOS, VyOS, and Nokia SRL drivers)."
         )
         raise InvalidConfigError(message)
 

--- a/hier_config/formats.py
+++ b/hier_config/formats.py
@@ -23,6 +23,10 @@ Mapping rules (XML):
   element, otherwise a ``#text <json string>`` child leaf
 - empty element -> single-word leaf ``tag``
 
+The ``@``/``#text`` line encoding is an implementation detail of the XML
+mapping and may change in a future release; treat the trees as opaque between
+``hconfig_from_xml`` and ``hconfig_to_xml``.
+
 Both mappings are invertible via ``hconfig_to_json`` / ``hconfig_to_xml``.
 Known caveats: a JSON list of scalars with exactly one item renders back as a
 bare scalar; empty JSON lists are dropped (the tree has no way to represent
@@ -34,50 +38,50 @@ yet given remediation semantics.
 from __future__ import annotations
 
 import xml.etree.ElementTree as ET  # ruff:ignore[suspicious-xml-etree-import]
+from collections import Counter
 from json import JSONDecodeError, dumps, loads
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, TypeAlias, cast
 
 from .exceptions import InvalidConfigError
-from .platforms.driver_base import HConfigDriverBase
-from .registry import get_hconfig_driver
+from .registry import resolve_driver
 from .root import HConfig
 
 if TYPE_CHECKING:
     from .base import HConfigBase
     from .child import HConfigChild
     from .models import Platform
+    from .platforms.driver_base import HConfigDriverBase
 
 DEFAULT_LIST_KEYS = ("name", "id")
 
-
-def _resolve_driver(
-    platform_or_driver: Platform | str | HConfigDriverBase,
-) -> HConfigDriverBase:
-    if isinstance(platform_or_driver, HConfigDriverBase):
-        return platform_or_driver
-    return get_hconfig_driver(platform_or_driver)
+JsonValue: TypeAlias = (
+    "str | int | float | bool | list[JsonValue] | dict[str, JsonValue] | None"
+)
 
 
 def hconfig_from_json(
     platform_or_driver: Platform | str | HConfigDriverBase,
     data: str | dict[str, Any],
     *,
-    list_keys: tuple[str, ...] = DEFAULT_LIST_KEYS,
+    list_keys: tuple[str, ...] | None = None,
 ) -> HConfig:
     """Create an HConfig from a JSON object (or JSON text)."""
-    parsed: object = data
     if isinstance(data, str):
         try:
-            parsed = loads(data)
+            data = loads(data)
         except JSONDecodeError as exc:
             message = f"The config is not valid JSON: {exc}"
             raise InvalidConfigError(message) from exc
-    if not isinstance(parsed, dict):
+    if not isinstance(data, dict):
         message = "The top-level JSON value must be an object"
         raise InvalidConfigError(message)
 
-    config = HConfig(_resolve_driver(platform_or_driver))
-    _json_into(config, cast("dict[str, Any]", parsed), list_keys)
+    config = HConfig(resolve_driver(platform_or_driver))
+    _json_into(
+        config,
+        cast("dict[str, JsonValue]", data),
+        list_keys or DEFAULT_LIST_KEYS,
+    )
     return config
 
 
@@ -90,7 +94,7 @@ def hconfig_from_xml(
     platform_or_driver: Platform | str | HConfigDriverBase,
     source: str,
     *,
-    list_keys: tuple[str, ...] = DEFAULT_LIST_KEYS,
+    list_keys: tuple[str, ...] | None = None,
 ) -> HConfig:
     """Create an HConfig from an XML document."""
     try:
@@ -99,8 +103,8 @@ def hconfig_from_xml(
         message = f"The config is not valid XML: {exc}"
         raise InvalidConfigError(message) from exc
 
-    config = HConfig(_resolve_driver(platform_or_driver))
-    _xml_element_into(config, root_element, "", list_keys)
+    config = HConfig(resolve_driver(platform_or_driver))
+    _xml_element_into(config, root_element, list_keys or DEFAULT_LIST_KEYS)
     return config
 
 
@@ -124,17 +128,15 @@ def _json_key(key: object) -> str:
 
 def _json_into(
     parent: HConfigBase,
-    mapping: dict[str, Any],
+    mapping: dict[str, JsonValue],
     list_keys: tuple[str, ...],
 ) -> None:
     for raw_key, value in mapping.items():
         key = _json_key(raw_key)
         if isinstance(value, dict):
-            value_mapping: dict[str, Any] = value  # pyright: ignore[reportUnknownVariableType]
-            _json_into(parent.add_child(key), value_mapping, list_keys)
+            _json_into(parent.add_child(key), value, list_keys)
         elif isinstance(value, list):
-            value_items: list[Any] = value  # pyright: ignore[reportUnknownVariableType]
-            _json_list_into(parent, key, value_items, list_keys)
+            _json_list_into(parent, key, value, list_keys)
         else:
             parent.add_child(f"{key} {dumps(value)}")
 
@@ -142,13 +144,12 @@ def _json_into(
 def _json_list_into(
     parent: HConfigBase,
     key: str,
-    items: list[Any],
+    items: list[JsonValue],
     list_keys: tuple[str, ...],
 ) -> None:
     for item in items:
         if isinstance(item, dict):
-            entry_mapping: dict[str, Any] = item  # pyright: ignore[reportUnknownVariableType]
-            identity_key = next((k for k in list_keys if k in entry_mapping), None)
+            identity_key = next((k for k in list_keys if k in item), None)
             if identity_key is None:
                 message = (
                     f"List entries under {key!r} need one of {list_keys} to"
@@ -156,8 +157,8 @@ def _json_list_into(
                     " member"
                 )
                 raise InvalidConfigError(message)
-            entry = parent.add_child(f"{key} {dumps(entry_mapping[identity_key])}")
-            _json_into(entry, entry_mapping, list_keys)
+            entry = parent.add_child(f"{key} {dumps(item[identity_key])}")
+            _json_into(entry, item, list_keys)
         elif isinstance(item, list):
             message = f"Nested JSON arrays are not supported (under {key!r})"
             raise InvalidConfigError(message)
@@ -165,26 +166,24 @@ def _json_list_into(
             parent.add_child(f"{key} {dumps(item)}")
 
 
-def _leaf_value(raw: str | None) -> object:
-    if raw is None:
-        return None
+def _leaf_value(raw: str) -> JsonValue:
     try:
-        return loads(raw)
+        return cast("JsonValue", loads(raw))
     except JSONDecodeError:
         return raw
 
 
 def _store_json_member(
-    result: dict[str, Any],
+    result: dict[str, JsonValue],
     key: str,
-    value: object,
+    value: JsonValue,
     *,
     force_list: bool,
 ) -> None:
     if key in result:
         existing = result[key]
         if isinstance(existing, list):
-            cast("list[object]", existing).append(value)
+            existing.append(value)
         else:
             result[key] = [existing, value]
     elif force_list:
@@ -193,8 +192,8 @@ def _store_json_member(
         result[key] = value
 
 
-def _node_to_json_object(node: HConfigBase) -> dict[str, Any]:
-    result: dict[str, Any] = {}
+def _node_to_json_object(node: HConfigBase) -> dict[str, JsonValue]:
+    result: dict[str, JsonValue] = {}
     for child in node.children:
         words = child.text.split(maxsplit=1)
         key = words[0]
@@ -215,20 +214,6 @@ def _node_to_json_object(node: HConfigBase) -> dict[str, Any]:
     return result
 
 
-def _xml_element_into(
-    parent: HConfigBase,
-    element: ET.Element,
-    node_suffix: str,
-    list_keys: tuple[str, ...],
-) -> None:
-    node = parent.add_child(f"{element.tag}{node_suffix}")
-    for name, value in element.attrib.items():
-        node.add_child(f"@{name} {dumps(value)}")
-    if text := (element.text or "").strip():
-        node.add_child(f"#text {dumps(text)}")
-    _xml_children_into(node, element, list_keys)
-
-
 def _xml_identity_suffix(
     element: ET.Element,
     list_keys: tuple[str, ...],
@@ -244,27 +229,33 @@ def _xml_identity_suffix(
     raise InvalidConfigError(message)
 
 
-def _xml_children_into(
-    node: HConfigChild,
+def _xml_element_into(
+    parent: HConfigBase,
     element: ET.Element,
     list_keys: tuple[str, ...],
+    *,
+    node_suffix: str = "",
 ) -> None:
-    tag_counts: dict[str, int] = {}
-    for child in element:
-        tag_counts[child.tag] = tag_counts.get(child.tag, 0) + 1
+    node = parent.add_child(f"{element.tag}{node_suffix}")
+    for name, value in element.attrib.items():
+        node.add_child(f"@{name} {dumps(value)}")
+    if text := (element.text or "").strip():
+        node.add_child(f"#text {dumps(text)}")
 
+    tag_counts = Counter(child.tag for child in element)
     for child in element:
-        is_leaf = not (len(child) or child.attrib)
-        if is_leaf:
-            text = (child.text or "").strip()
-            node.add_child(f"{child.tag} {dumps(text)}" if text else child.tag)
+        if not (len(child) or child.attrib):
+            child_text = (child.text or "").strip()
+            node.add_child(
+                f"{child.tag} {dumps(child_text)}" if child_text else child.tag
+            )
         else:
             suffix = (
                 _xml_identity_suffix(child, list_keys)
                 if tag_counts[child.tag] > 1
                 else ""
             )
-            _xml_element_into(node, child, suffix, list_keys)
+            _xml_element_into(node, child, list_keys, node_suffix=suffix)
 
 
 def _node_to_xml_element(node: HConfigChild) -> ET.Element:
@@ -276,11 +267,13 @@ def _node_to_xml_element(node: HConfigChild) -> ET.Element:
             element.text = value if isinstance(value, str) else words[1]
         return element
     for child in node.children:
-        child_words = child.text.split(maxsplit=1)
-        if child_words[0].startswith("@") and not child.children:
-            element.set(child_words[0][1:], str(_leaf_value(child_words[1])))
-        elif child_words[0] == "#text" and not child.children:
-            element.text = str(_leaf_value(child_words[1]))
+        if child.children:
+            element.append(_node_to_xml_element(child))
+        elif child.text.startswith("@"):
+            name, _, raw = child.text.partition(" ")
+            element.set(name[1:], str(_leaf_value(raw)))
+        elif child.text.startswith("#text "):
+            element.text = str(_leaf_value(child.text[len("#text ") :]))
         else:
             element.append(_node_to_xml_element(child))
     return element

--- a/hier_config/formats.py
+++ b/hier_config/formats.py
@@ -1,0 +1,281 @@
+"""Structured config format ingestion and rendering (#232).
+
+Maps JSON (e.g. OpenConfig) and XML (e.g. NETCONF payloads) onto the same
+`HConfig` tree used by the rest of the library, so structured configs can be
+diffed and predicted like CLI text, and renders trees back to those formats.
+
+Mapping rules (JSON):
+
+- object key + scalar   -> leaf ``key <json-encoded scalar>``
+- object key + object   -> node ``key`` with the object's members as children
+- object key + list of scalars -> one leaf per item, ``key <json item>``
+- object key + list of objects -> one node per entry, ``key <json identity>``,
+  where the identity is the value of the first ``list_keys`` member present in
+  the entry (OpenConfig-style keyed lists); all entry members, including the
+  identity leaf, become children.
+
+Mapping rules (XML):
+
+- element -> node ``tag``, or ``tag <json identity>`` when the tag repeats
+  among its siblings (identity from the first ``list_keys`` child element)
+- attribute -> leaf ``@name <json string>``
+- text content -> leaf ``tag <json string>`` for a childless, attribute-less
+  element, otherwise a ``#text <json string>`` child leaf
+- empty element -> single-word leaf ``tag``
+
+Both mappings are invertible via ``hconfig_to_json`` / ``hconfig_to_xml``.
+Known caveat: a JSON list of scalars with exactly one item renders back as a
+bare scalar. NETCONF ``edit-config`` operation attributes are not yet given
+remediation semantics.
+"""
+
+from __future__ import annotations
+
+import xml.etree.ElementTree as ET  # ruff:ignore[suspicious-xml-etree-import]
+from json import JSONDecodeError, dumps, loads
+from typing import TYPE_CHECKING, Any, cast
+
+from .exceptions import InvalidConfigError
+from .platforms.driver_base import HConfigDriverBase
+from .registry import get_hconfig_driver
+from .root import HConfig
+
+if TYPE_CHECKING:
+    from .base import HConfigBase
+    from .child import HConfigChild
+    from .models import Platform
+
+DEFAULT_LIST_KEYS = ("name", "id")
+
+
+def _resolve_driver(
+    platform_or_driver: Platform | str | HConfigDriverBase,
+) -> HConfigDriverBase:
+    if isinstance(platform_or_driver, HConfigDriverBase):
+        return platform_or_driver
+    return get_hconfig_driver(platform_or_driver)
+
+
+def hconfig_from_json(
+    platform_or_driver: Platform | str | HConfigDriverBase,
+    data: str | dict[str, Any],
+    *,
+    list_keys: tuple[str, ...] = DEFAULT_LIST_KEYS,
+) -> HConfig:
+    """Create an HConfig from a JSON object (or JSON text)."""
+    parsed: object = data
+    if isinstance(data, str):
+        try:
+            parsed = loads(data)
+        except JSONDecodeError as exc:
+            message = f"The config is not valid JSON: {exc}"
+            raise InvalidConfigError(message) from exc
+    if not isinstance(parsed, dict):
+        message = "The top-level JSON value must be an object"
+        raise InvalidConfigError(message)
+
+    config = HConfig(_resolve_driver(platform_or_driver))
+    _json_into(config, cast("dict[str, Any]", parsed), list_keys)
+    return config
+
+
+def hconfig_to_json(config: HConfig, *, indent: int | None = 2) -> str:
+    """Render an HConfig built by `hconfig_from_json` back to JSON text."""
+    return dumps(_node_to_json_object(config), indent=indent)
+
+
+def hconfig_from_xml(
+    platform_or_driver: Platform | str | HConfigDriverBase,
+    source: str,
+    *,
+    list_keys: tuple[str, ...] = DEFAULT_LIST_KEYS,
+) -> HConfig:
+    """Create an HConfig from an XML document."""
+    try:
+        root_element = ET.fromstring(source)  # ruff:ignore[suspicious-xml-element-tree-usage]
+    except ET.ParseError as exc:
+        message = f"The config is not valid XML: {exc}"
+        raise InvalidConfigError(message) from exc
+
+    config = HConfig(_resolve_driver(platform_or_driver))
+    _xml_element_into(config, root_element, "", list_keys)
+    return config
+
+
+def hconfig_to_xml(config: HConfig) -> str:
+    """Render an HConfig built by `hconfig_from_xml` back to XML text."""
+    if len(config.children) != 1:
+        message = "XML rendering requires a single root node"
+        raise InvalidConfigError(message)
+    root_node = next(iter(config.children))
+    element = _node_to_xml_element(root_node)
+    ET.indent(element)
+    return ET.tostring(element, encoding="unicode")
+
+
+def _json_key(key: object) -> str:
+    if not isinstance(key, str) or not key or any(char.isspace() for char in key):
+        message = f"Unsupported JSON key: {key!r} (keys must be non-empty strings without whitespace)"
+        raise InvalidConfigError(message)
+    return key
+
+
+def _json_into(
+    parent: HConfigBase,
+    mapping: dict[str, Any],
+    list_keys: tuple[str, ...],
+) -> None:
+    for raw_key, value in mapping.items():
+        key = _json_key(raw_key)
+        if isinstance(value, dict):
+            value_mapping: dict[str, Any] = value  # pyright: ignore[reportUnknownVariableType]
+            _json_into(parent.add_child(key), value_mapping, list_keys)
+        elif isinstance(value, list):
+            value_items: list[Any] = value  # pyright: ignore[reportUnknownVariableType]
+            _json_list_into(parent, key, value_items, list_keys)
+        else:
+            parent.add_child(f"{key} {dumps(value)}")
+
+
+def _json_list_into(
+    parent: HConfigBase,
+    key: str,
+    items: list[Any],
+    list_keys: tuple[str, ...],
+) -> None:
+    for item in items:
+        if isinstance(item, dict):
+            entry_mapping: dict[str, Any] = item  # pyright: ignore[reportUnknownVariableType]
+            identity_key = next((k for k in list_keys if k in entry_mapping), None)
+            if identity_key is None:
+                message = (
+                    f"List entries under {key!r} need one of {list_keys} to"
+                    " identify them; pass list_keys= to name the identifying"
+                    " member"
+                )
+                raise InvalidConfigError(message)
+            entry = parent.add_child(f"{key} {dumps(entry_mapping[identity_key])}")
+            _json_into(entry, entry_mapping, list_keys)
+        elif isinstance(item, list):
+            message = f"Nested JSON arrays are not supported (under {key!r})"
+            raise InvalidConfigError(message)
+        else:
+            parent.add_child(f"{key} {dumps(item)}")
+
+
+def _leaf_value(raw: str | None) -> object:
+    if raw is None:
+        return None
+    try:
+        return loads(raw)
+    except JSONDecodeError:
+        return raw
+
+
+def _store_json_member(
+    result: dict[str, Any],
+    key: str,
+    value: object,
+    *,
+    force_list: bool,
+) -> None:
+    if key in result:
+        existing = result[key]
+        if isinstance(existing, list):
+            cast("list[object]", existing).append(value)
+        else:
+            result[key] = [existing, value]
+    elif force_list:
+        result[key] = [value]
+    else:
+        result[key] = value
+
+
+def _node_to_json_object(node: HConfigBase) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for child in node.children:
+        words = child.text.split(maxsplit=1)
+        key = words[0]
+        if child.children:
+            # A multi-word branch is a keyed list entry; grouped into a list.
+            _store_json_member(
+                result,
+                key,
+                _node_to_json_object(child),
+                force_list=len(words) > 1,
+            )
+        else:
+            raw = words[1] if len(words) > 1 else None
+            _store_json_member(result, key, _leaf_value(raw), force_list=False)
+    return result
+
+
+def _xml_element_into(
+    parent: HConfigBase,
+    element: ET.Element,
+    node_suffix: str,
+    list_keys: tuple[str, ...],
+) -> None:
+    node = parent.add_child(f"{element.tag}{node_suffix}")
+    for name, value in element.attrib.items():
+        node.add_child(f"@{name} {dumps(value)}")
+    if text := (element.text or "").strip():
+        node.add_child(f"#text {dumps(text)}")
+    _xml_children_into(node, element, list_keys)
+
+
+def _xml_identity_suffix(
+    element: ET.Element,
+    list_keys: tuple[str, ...],
+) -> str:
+    for key in list_keys:
+        if (identity := element.find(key)) is not None and identity.text:
+            return f" {dumps(identity.text.strip())}"
+    message = (
+        f"Repeated <{element.tag}> elements need a child element named one of"
+        f" {list_keys} to identify them; pass list_keys= to name the"
+        " identifying element"
+    )
+    raise InvalidConfigError(message)
+
+
+def _xml_children_into(
+    node: HConfigChild,
+    element: ET.Element,
+    list_keys: tuple[str, ...],
+) -> None:
+    tag_counts: dict[str, int] = {}
+    for child in element:
+        tag_counts[child.tag] = tag_counts.get(child.tag, 0) + 1
+
+    for child in element:
+        is_leaf = not (len(child) or child.attrib)
+        if is_leaf:
+            text = (child.text or "").strip()
+            node.add_child(f"{child.tag} {dumps(text)}" if text else child.tag)
+        else:
+            suffix = (
+                _xml_identity_suffix(child, list_keys)
+                if tag_counts[child.tag] > 1
+                else ""
+            )
+            _xml_element_into(node, child, suffix, list_keys)
+
+
+def _node_to_xml_element(node: HConfigChild) -> ET.Element:
+    words = node.text.split(maxsplit=1)
+    element = ET.Element(words[0])
+    if not node.children:
+        if len(words) > 1:
+            value = _leaf_value(words[1])
+            element.text = value if isinstance(value, str) else words[1]
+        return element
+    for child in node.children:
+        child_words = child.text.split(maxsplit=1)
+        if child_words[0].startswith("@") and not child.children:
+            element.set(child_words[0][1:], str(_leaf_value(child_words[1])))
+        elif child_words[0] == "#text" and not child.children:
+            element.text = str(_leaf_value(child_words[1]))
+        else:
+            element.append(_node_to_xml_element(child))
+    return element

--- a/hier_config/formats.py
+++ b/hier_config/formats.py
@@ -24,9 +24,11 @@ Mapping rules (XML):
 - empty element -> single-word leaf ``tag``
 
 Both mappings are invertible via ``hconfig_to_json`` / ``hconfig_to_xml``.
-Known caveat: a JSON list of scalars with exactly one item renders back as a
-bare scalar. NETCONF ``edit-config`` operation attributes are not yet given
-remediation semantics.
+Known caveats: a JSON list of scalars with exactly one item renders back as a
+bare scalar; empty JSON lists are dropped (the tree has no way to represent
+them); duplicate list items or duplicate list-entry identities raise
+``DuplicateChildError``; NETCONF ``edit-config`` operation attributes are not
+yet given remediation semantics.
 """
 
 from __future__ import annotations
@@ -204,9 +206,12 @@ def _node_to_json_object(node: HConfigBase) -> dict[str, Any]:
                 _node_to_json_object(child),
                 force_list=len(words) > 1,
             )
+        elif len(words) > 1:
+            _store_json_member(result, key, _leaf_value(words[1]), force_list=False)
         else:
-            raw = words[1] if len(words) > 1 else None
-            _store_json_member(result, key, _leaf_value(raw), force_list=False)
+            # from_json produces a single-word childless node only for an
+            # empty object (scalar leaves always carry a value word).
+            _store_json_member(result, key, {}, force_list=False)
     return result
 
 

--- a/hier_config/registry.py
+++ b/hier_config/registry.py
@@ -85,6 +85,15 @@ def get_registered_platforms() -> tuple[Platform | str, ...]:
     return tuple(_registry)
 
 
+def resolve_driver(
+    platform_or_driver: Platform | str | HConfigDriverBase,
+) -> HConfigDriverBase:
+    """Return the driver for a platform, platform name, or driver instance."""
+    if isinstance(platform_or_driver, HConfigDriverBase):
+        return platform_or_driver
+    return get_hconfig_driver(platform_or_driver)
+
+
 def get_hconfig_driver(platform: Platform | str) -> HConfigDriverBase:
     """Instantiate the driver registered for a platform."""
     driver_class = _registry.get(_normalize(platform))

--- a/hier_config/root.py
+++ b/hier_config/root.py
@@ -81,13 +81,13 @@ class HConfig(HConfigBase):  # ruff:ignore[too-many-public-methods]
         platform_or_driver: Platform | str | HConfigDriverBase,
         data: str | dict[str, Any],
         *,
-        list_keys: tuple[str, ...] = ("name", "id"),
+        list_keys: tuple[str, ...] | None = None,
     ) -> HConfig:
-        """Create an HConfig from a JSON object or JSON text (#232).
+        """Create an HConfig from a JSON object or JSON text.
 
         See `hier_config.formats` for the tree mapping rules. `list_keys`
         names the members that identify entries of keyed lists
-        (OpenConfig-style).
+        (OpenConfig-style); None means `formats.DEFAULT_LIST_KEYS`.
         """
         from .formats import hconfig_from_json
 
@@ -99,25 +99,32 @@ class HConfig(HConfigBase):  # ruff:ignore[too-many-public-methods]
         platform_or_driver: Platform | str | HConfigDriverBase,
         source: str,
         *,
-        list_keys: tuple[str, ...] = ("name", "id"),
+        list_keys: tuple[str, ...] | None = None,
     ) -> HConfig:
-        """Create an HConfig from an XML document (#232).
+        """Create an HConfig from an XML document.
 
         See `hier_config.formats` for the tree mapping rules. `list_keys`
-        names the child elements that identify repeated sibling elements.
+        names the child elements that identify repeated sibling elements;
+        None means `formats.DEFAULT_LIST_KEYS`.
         """
         from .formats import hconfig_from_xml
 
         return hconfig_from_xml(platform_or_driver, source, list_keys=list_keys)
 
     def to_json(self, *, indent: int | None = 2) -> str:
-        """Render a tree built by `from_json` back to JSON text (#232)."""
+        """Render a tree built by `from_json` back to JSON text.
+
+        Output is undefined for trees built by other constructors.
+        """
         from .formats import hconfig_to_json
 
         return hconfig_to_json(self, indent=indent)
 
     def to_xml(self) -> str:
-        """Render a tree built by `from_xml` back to XML text (#232)."""
+        """Render a tree built by `from_xml` back to XML text.
+
+        Output is undefined for trees built by other constructors.
+        """
         from .formats import hconfig_to_xml
 
         return hconfig_to_xml(self)

--- a/hier_config/root.py
+++ b/hier_config/root.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from logging import getLogger
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from .base import HConfigBase
 from .child import HConfigChild
@@ -74,6 +74,53 @@ class HConfig(HConfigBase):  # ruff:ignore[too-many-public-methods]
         )
 
         return hconfig_from_dump(platform_or_driver, dump)
+
+    @classmethod
+    def from_json(
+        cls,
+        platform_or_driver: Platform | str | HConfigDriverBase,
+        data: str | dict[str, Any],
+        *,
+        list_keys: tuple[str, ...] = ("name", "id"),
+    ) -> HConfig:
+        """Create an HConfig from a JSON object or JSON text (#232).
+
+        See `hier_config.formats` for the tree mapping rules. `list_keys`
+        names the members that identify entries of keyed lists
+        (OpenConfig-style).
+        """
+        from .formats import hconfig_from_json
+
+        return hconfig_from_json(platform_or_driver, data, list_keys=list_keys)
+
+    @classmethod
+    def from_xml(
+        cls,
+        platform_or_driver: Platform | str | HConfigDriverBase,
+        source: str,
+        *,
+        list_keys: tuple[str, ...] = ("name", "id"),
+    ) -> HConfig:
+        """Create an HConfig from an XML document (#232).
+
+        See `hier_config.formats` for the tree mapping rules. `list_keys`
+        names the child elements that identify repeated sibling elements.
+        """
+        from .formats import hconfig_from_xml
+
+        return hconfig_from_xml(platform_or_driver, source, list_keys=list_keys)
+
+    def to_json(self, *, indent: int | None = 2) -> str:
+        """Render a tree built by `from_json` back to JSON text (#232)."""
+        from .formats import hconfig_to_json
+
+        return hconfig_to_json(self, indent=indent)
+
+    def to_xml(self) -> str:
+        """Render a tree built by `from_xml` back to XML text (#232)."""
+        from .formats import hconfig_to_xml
+
+        return hconfig_to_xml(self)
 
     def __str__(self) -> str:
         return "\n".join(str(c) for c in sorted(self.children))

--- a/tests/unit/test_formats.py
+++ b/tests/unit/test_formats.py
@@ -5,7 +5,7 @@ import json
 import pytest
 
 from hier_config import HConfig, Platform
-from hier_config.exceptions import InvalidConfigError
+from hier_config.exceptions import DuplicateChildError, InvalidConfigError
 
 OPENCONFIG_STYLE = {
     "system": {
@@ -194,3 +194,20 @@ def test_detection_error_mentions_structured_constructors() -> None:
         HConfig.from_text(Platform.GENERIC, '{"a": 1}')
     with pytest.raises(InvalidConfigError, match="from_xml"):
         HConfig.from_text(Platform.GENERIC, "<config/>")
+
+
+def test_empty_object_round_trips() -> None:
+    """An empty JSON object must not collapse to null (#279 review)."""
+    data: dict[str, object] = {"system": {}, "count": 1, "missing": None}
+    config = HConfig.from_json(Platform.GENERIC, data)
+    assert json.loads(config.to_json()) == data
+
+
+def test_duplicate_list_items_raise_hier_config_error() -> None:
+    """Duplicate scalar items and duplicate identities surface as tree errors."""
+    with pytest.raises(DuplicateChildError):
+        HConfig.from_json(Platform.GENERIC, {"dns": ["192.0.2.1", "192.0.2.1"]})
+    with pytest.raises(DuplicateChildError):
+        HConfig.from_json(
+            Platform.GENERIC, {"interface": [{"name": "e0"}, {"name": "e0"}]}
+        )

--- a/tests/unit/test_formats.py
+++ b/tests/unit/test_formats.py
@@ -1,0 +1,196 @@
+"""Tests for hier_config/formats.py — JSON/XML ingestion and rendering (#232)."""
+
+import json
+
+import pytest
+
+from hier_config import HConfig, Platform
+from hier_config.exceptions import InvalidConfigError
+
+OPENCONFIG_STYLE = {
+    "system": {
+        "config": {
+            "hostname": "router1",
+            "login-banner": "unauthorized access is prohibited",
+        },
+        "ntp": {"enabled": True, "port": 123},
+    },
+    "interfaces": {
+        "interface": [
+            {
+                "name": "eth0",
+                "config": {"description": "uplink", "mtu": 9000},
+            },
+            {
+                "name": "eth1",
+                "config": {"description": "downlink", "mtu": 1500},
+            },
+        ],
+    },
+    "dns-servers": ["192.0.2.1", "192.0.2.2"],
+}
+
+
+def test_from_json_builds_expected_tree() -> None:
+    config = HConfig.from_json(Platform.GENERIC, OPENCONFIG_STYLE)
+
+    system = config.get_child(equals="system")
+    assert system is not None
+    system_config = system.get_child(equals="config")
+    assert system_config is not None
+    assert system_config.get_child(equals='hostname "router1"') is not None
+
+    ntp = system.get_child(equals="ntp")
+    assert ntp is not None
+    assert ntp.get_child(equals="enabled true") is not None
+    assert ntp.get_child(equals="port 123") is not None
+
+    interfaces = config.get_child(equals="interfaces")
+    assert interfaces is not None
+    eth0 = interfaces.get_child(equals='interface "eth0"')
+    assert eth0 is not None
+    assert eth0.get_child(equals='name "eth0"') is not None
+
+    assert config.get_child(equals='dns-servers "192.0.2.1"') is not None
+    assert config.get_child(equals='dns-servers "192.0.2.2"') is not None
+
+
+def test_from_json_accepts_json_text() -> None:
+    config = HConfig.from_json(Platform.GENERIC, json.dumps(OPENCONFIG_STYLE))
+    assert config.get_child(equals="system") is not None
+
+
+def test_json_round_trip() -> None:
+    config = HConfig.from_json(Platform.GENERIC, OPENCONFIG_STYLE)
+    assert json.loads(config.to_json()) == OPENCONFIG_STYLE
+
+
+def test_json_round_trip_via_reparse() -> None:
+    config = HConfig.from_json(Platform.GENERIC, OPENCONFIG_STYLE)
+    reparsed = HConfig.from_json(Platform.GENERIC, config.to_json())
+    assert reparsed == config
+
+
+def test_from_json_invalid_text_raises() -> None:
+    with pytest.raises(InvalidConfigError, match="not valid JSON"):
+        HConfig.from_json(Platform.GENERIC, "{not json")
+
+
+def test_from_json_non_object_root_raises() -> None:
+    with pytest.raises(InvalidConfigError, match="must be an object"):
+        HConfig.from_json(Platform.GENERIC, "[1, 2, 3]")
+
+
+def test_from_json_whitespace_key_raises() -> None:
+    with pytest.raises(InvalidConfigError, match="Unsupported JSON key"):
+        HConfig.from_json(Platform.GENERIC, {"bad key": 1})
+
+
+def test_from_json_unidentified_list_entry_raises() -> None:
+    with pytest.raises(InvalidConfigError, match="identify"):
+        HConfig.from_json(Platform.GENERIC, {"vlans": [{"vid": 100}]})
+
+
+def test_from_json_custom_list_keys() -> None:
+    config = HConfig.from_json(
+        Platform.GENERIC, {"vlans": [{"vid": 100}]}, list_keys=("vid",)
+    )
+    assert config.get_child(equals="vlans 100") is not None
+
+
+def test_json_diff_between_structured_configs() -> None:
+    """Structured configs work with the tree diff engine."""
+    running = HConfig.from_json(
+        Platform.GENERIC, {"system": {"hostname": "old", "domain": "example.com"}}
+    )
+    generated = HConfig.from_json(
+        Platform.GENERIC, {"system": {"hostname": "new", "domain": "example.com"}}
+    )
+    remediation = running.remediation(generated)
+    system = remediation.get_child(equals="system")
+    assert system is not None
+    assert system.get_child(equals='no hostname "old"') is not None
+    assert system.get_child(equals='hostname "new"') is not None
+
+
+def test_json_future_renders_back_to_json() -> None:
+    """future() of a structured config renders back to valid JSON."""
+    running = HConfig.from_json(Platform.GENERIC, {"system": {"hostname": "old"}})
+    generated = HConfig.from_json(Platform.GENERIC, {"system": {"hostname": "new"}})
+    future = running.future(running.remediation(generated))
+    assert json.loads(future.to_json()) == {"system": {"hostname": "new"}}
+
+
+XML_TEXT = (
+    "<config>"
+    '<system foo="bar">'
+    "<hostname>router1</hostname>"
+    "<location/>"
+    "</system>"
+    "<interfaces>"
+    "<interface><name>eth0</name><mtu>9000</mtu></interface>"
+    "<interface><name>eth1</name><mtu>1500</mtu></interface>"
+    "</interfaces>"
+    "</config>"
+)
+
+
+def test_from_xml_builds_expected_tree() -> None:
+    config = HConfig.from_xml(Platform.GENERIC, XML_TEXT)
+
+    root = config.get_child(equals="config")
+    assert root is not None
+    system = root.get_child(equals="system")
+    assert system is not None
+    assert system.get_child(equals='@foo "bar"') is not None
+    assert system.get_child(equals='hostname "router1"') is not None
+    assert system.get_child(equals="location") is not None
+
+    interfaces = root.get_child(equals="interfaces")
+    assert interfaces is not None
+    eth0 = interfaces.get_child(equals='interface "eth0"')
+    assert eth0 is not None
+    assert eth0.get_child(equals='mtu "9000"') is not None
+
+
+def test_xml_round_trip() -> None:
+    config = HConfig.from_xml(Platform.GENERIC, XML_TEXT)
+    reparsed = HConfig.from_xml(Platform.GENERIC, config.to_xml())
+    assert reparsed == config
+
+
+def test_from_xml_invalid_raises() -> None:
+    with pytest.raises(InvalidConfigError, match="not valid XML"):
+        HConfig.from_xml(Platform.GENERIC, "<config><unclosed></config>")
+
+
+def test_from_xml_repeated_elements_without_identity_raises() -> None:
+    xml_text = "<c><item><x>1</x></item><item><x>2</x></item></c>"
+    with pytest.raises(InvalidConfigError, match="identify"):
+        HConfig.from_xml(Platform.GENERIC, xml_text)
+
+
+def test_to_xml_requires_single_root() -> None:
+    config = HConfig.from_json(Platform.GENERIC, {"a": {"x": 1}, "b": {"y": 2}})
+    with pytest.raises(InvalidConfigError, match="single root"):
+        config.to_xml()
+
+
+def test_xml_mixed_text_content() -> None:
+    xml_text = "<c><a>text<b>inner</b></a></c>"
+    config = HConfig.from_xml(Platform.GENERIC, xml_text)
+    outer = config.get_child(equals="c")
+    assert outer is not None
+    element_a = outer.get_child(equals="a")
+    assert element_a is not None
+    assert element_a.get_child(equals='#text "text"') is not None
+    assert element_a.get_child(equals='b "inner"') is not None
+    reparsed = HConfig.from_xml(Platform.GENERIC, config.to_xml())
+    assert reparsed == config
+
+
+def test_detection_error_mentions_structured_constructors() -> None:
+    with pytest.raises(InvalidConfigError, match="from_json"):
+        HConfig.from_text(Platform.GENERIC, '{"a": 1}')
+    with pytest.raises(InvalidConfigError, match="from_xml"):
+        HConfig.from_text(Platform.GENERIC, "<config/>")


### PR DESCRIPTION
## Summary

Completes the remaining scope of #232 (set-style support and graceful XML/JSON rejection shipped in #278; this adds actual ingestion and rendering).

New `hier_config/formats.py` with a documented, invertible tree mapping:

- **`HConfig.from_json(platform, data, list_keys=("name", "id"))`** — JSON objects/text (e.g. OpenConfig). Scalars become `key <json>` leaves, objects become branches, scalar lists become repeated leaves, and keyed lists (OpenConfig-style) become one branch per entry named by its identifying member — so entries diff structurally, exactly what the tree engine needs.
- **`HConfig.from_xml(platform, source, list_keys=...)`** — XML documents (e.g. NETCONF payloads). Attributes map to `@name` leaves, text content to value leaves, repeated sibling elements are identified via `list_keys`, and mixed content uses `#text` leaves.
- **`HConfig.to_json()` / `to_xml()`** — invert the mappings. Structured configs can be diffed with `remediation()`, predicted with `future()`, and the result rendered back in the source format. Round-trip fidelity (`parse → render → reparse == original`) is pinned by tests for both formats.
- The format-detection error from #278 now points users at the new constructors.

Design notes:
- Values are JSON-encoded inside leaf text (`hostname "router1"`, `port 123`) so types survive the round trip.
- `xml.etree.ElementTree` is safe here: it does not resolve external entities (XXE) — the `S405` suppression is annotated.
- Documented limits: a single-item JSON scalar list renders back as a bare scalar; NETCONF `edit-config` operation attributes have no remediation semantics yet (tracked as the final piece of #232).

## Test plan

- [x] 18 new unit tests: tree-shape assertions for both formats, round-trips (structural and reparse-equality), keyed lists incl. custom `list_keys`, error cases (invalid JSON/XML, non-object root, whitespace keys, unidentifiable list entries, multi-root XML), diff and `future()` over structured configs with JSON re-rendering, and detection-message updates.
- [x] `poetry run ./scripts/build.py lint-and-test` — all linters pass (ruff 0.15, mypy strict, pyright strict, pylint), 689 tests, ≥95% coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)