### PR TITLE
Add NETCONF edit-config remediation rendering (#232)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- NETCONF `edit-config` remediation rendering (#232):
+  `WorkflowRemediation.remediation_netconf_xml()` (and
+  `hier_config.formats.hconfig_to_netconf_xml()`) render a remediation
+  between `HConfig.from_xml()` trees as a NETCONF payload — deletions become
+  `nc:operation="delete"` elements (keyed list entries delete by their key
+  leaf, resolved against the running config), additions use the default merge
+  operation, and attribute-level changes raise `InvalidConfigError`.
+
+### Fixed
+
+- XML ingestion keys an element whenever an identifying `list_keys` child
+  exists, not only when the tag repeats among siblings, so configs with
+  different list-entry counts diff surgically instead of deleting and
+  re-adding surviving entries (#232).
+
 - Structured config ingestion and rendering (#232): `HConfig.from_json()` /
   `HConfig.from_xml()` build config trees from JSON (e.g. OpenConfig) and XML
   (e.g. NETCONF payloads), with OpenConfig-style keyed lists identified via

--- a/hier_config/formats.py
+++ b/hier_config/formats.py
@@ -31,8 +31,13 @@ Both mappings are invertible via ``hconfig_to_json`` / ``hconfig_to_xml``.
 Known caveats: a JSON list of scalars with exactly one item renders back as a
 bare scalar; empty JSON lists are dropped (the tree has no way to represent
 them); duplicate list items or duplicate list-entry identities raise
-``DuplicateChildError``; NETCONF ``edit-config`` operation attributes are not
-yet given remediation semantics.
+``DuplicateChildError``.
+
+Remediation between ``hconfig_from_xml`` trees can be rendered as a NETCONF
+``edit-config`` payload via ``hconfig_to_netconf_xml`` (deletions become
+``nc:operation="delete"`` elements; additions use the default merge
+operation). Attribute-level changes cannot be expressed as NETCONF
+operations and raise ``InvalidConfigError``.
 """
 
 from __future__ import annotations
@@ -53,6 +58,8 @@ if TYPE_CHECKING:
     from .platforms.driver_base import HConfigDriverBase
 
 DEFAULT_LIST_KEYS = ("name", "id")
+
+NETCONF_BASE_NS = "urn:ietf:params:xml:ns:netconf:base:1.0"
 
 JsonValue: TypeAlias = (
     "str | int | float | bool | list[JsonValue] | dict[str, JsonValue] | None"
@@ -217,16 +224,20 @@ def _node_to_json_object(node: HConfigBase) -> dict[str, JsonValue]:
 def _xml_identity_suffix(
     element: ET.Element,
     list_keys: tuple[str, ...],
+    *,
+    required: bool,
 ) -> str:
     for key in list_keys:
         if (identity := element.find(key)) is not None and identity.text:
             return f" {dumps(identity.text.strip())}"
-    message = (
-        f"Repeated <{element.tag}> elements need a child element named one of"
-        f" {list_keys} to identify them; pass list_keys= to name the"
-        " identifying element"
-    )
-    raise InvalidConfigError(message)
+    if required:
+        message = (
+            f"Repeated <{element.tag}> elements need a child element named one"
+            f" of {list_keys} to identify them; pass list_keys= to name the"
+            " identifying element"
+        )
+        raise InvalidConfigError(message)
+    return ""
 
 
 def _xml_element_into(
@@ -250,10 +261,14 @@ def _xml_element_into(
                 f"{child.tag} {dumps(child_text)}" if child_text else child.tag
             )
         else:
-            suffix = (
-                _xml_identity_suffix(child, list_keys)
-                if tag_counts[child.tag] > 1
-                else ""
+            # Key the node whenever an identifying child exists so entries get
+            # the same text regardless of sibling count - configs with
+            # different entry counts must still diff surgically. An identity
+            # is only mandatory when the tag actually repeats.
+            suffix = _xml_identity_suffix(
+                child,
+                list_keys,
+                required=tag_counts[child.tag] > 1,
             )
             _xml_element_into(node, child, list_keys, node_suffix=suffix)
 
@@ -263,8 +278,7 @@ def _node_to_xml_element(node: HConfigChild) -> ET.Element:
     element = ET.Element(words[0])
     if not node.children:
         if len(words) > 1:
-            value = _leaf_value(words[1])
-            element.text = value if isinstance(value, str) else words[1]
+            element.text = _xml_text(words[1])
         return element
     for child in node.children:
         if child.children:
@@ -276,4 +290,112 @@ def _node_to_xml_element(node: HConfigChild) -> ET.Element:
             element.text = str(_leaf_value(child.text[len("#text ") :]))
         else:
             element.append(_node_to_xml_element(child))
+    return element
+
+
+def _xml_text(raw: str) -> str:
+    value = _leaf_value(raw)
+    return value if isinstance(value, str) else raw
+
+
+def hconfig_to_netconf_xml(
+    remediation: HConfig,
+    *,
+    running: HConfig | None = None,
+    list_keys: tuple[str, ...] | None = None,
+) -> str:
+    """Render a remediation between `hconfig_from_xml` trees as NETCONF XML.
+
+    Negated nodes become elements with ``nc:operation="delete"``; everything
+    else uses the NETCONF default merge operation. When `running` is given,
+    deletions of keyed list entries are expressed by their key leaf (found
+    via `list_keys`); without it, deletions fall back to value-bearing leaf
+    elements.
+    """
+    if len(remediation.children) != 1:
+        message = "XML rendering requires a single root node"
+        raise InvalidConfigError(message)
+    root_node = next(iter(remediation.children))
+    running_root = (
+        running.get_child(equals=root_node.text) if running is not None else None
+    )
+    element = _netconf_element(
+        root_node,
+        remediation.driver.negation_prefix,
+        running_root,
+        list_keys or DEFAULT_LIST_KEYS,
+    )
+    element.set("xmlns:nc", NETCONF_BASE_NS)
+    ET.indent(element)
+    return ET.tostring(element, encoding="unicode")
+
+
+def _netconf_element(
+    node: HConfigChild,
+    negation_prefix: str,
+    running_node: HConfigChild | None,
+    list_keys: tuple[str, ...],
+) -> ET.Element:
+    if node.text.startswith(negation_prefix):
+        return _netconf_delete_element(
+            node.text.removeprefix(negation_prefix),
+            running_node,
+            list_keys,
+        )
+    words = node.text.split(maxsplit=1)
+    element = ET.Element(words[0])
+    if not node.children:
+        if len(words) > 1:
+            element.text = _xml_text(words[1])
+        return element
+    for child in node.children:
+        if not child.children and child.text.startswith("@"):
+            name, _, raw = child.text.partition(" ")
+            element.set(name[1:], str(_leaf_value(raw)))
+        elif not child.children and child.text.startswith("#text "):
+            element.text = _xml_text(child.text[len("#text ") :])
+        else:
+            # A negated child is looked up in the running parent by
+            # _netconf_delete_element, so it receives the parent context.
+            child_running = (
+                running_node
+                if child.text.startswith(negation_prefix)
+                else running_node.get_child(equals=child.text)
+                if running_node
+                else None
+            )
+            element.append(
+                _netconf_element(child, negation_prefix, child_running, list_keys)
+            )
+    return element
+
+
+def _netconf_delete_element(
+    positive_text: str,
+    running_parent: HConfigChild | None,
+    list_keys: tuple[str, ...],
+) -> ET.Element:
+    words = positive_text.split(maxsplit=1)
+    if words[0].startswith("@"):
+        message = (
+            "Attribute changes cannot be expressed as NETCONF operations:"
+            f" {positive_text!r}"
+        )
+        raise InvalidConfigError(message)
+    element = ET.Element(words[0])
+    element.set("nc:operation", "delete")
+    if len(words) == 1:
+        return element
+    # A keyed list entry (branch in the running config) deletes by key leaf.
+    if (
+        running_parent is not None
+        and (running_entry := running_parent.get_child(equals=positive_text))
+        is not None
+        and running_entry.children
+    ):
+        for key in list_keys:
+            if running_entry.get_child(equals=f"{key} {words[1]}") is not None:
+                ET.SubElement(element, key).text = _xml_text(words[1])
+                return element
+    element.text = _xml_text(words[1])
     return element

--- a/hier_config/workflows.py
+++ b/hier_config/workflows.py
@@ -121,6 +121,27 @@ class WorkflowRemediation:
 
         return rollback_config
 
+    def remediation_netconf_xml(
+        self,
+        *,
+        list_keys: tuple[str, ...] | None = None,
+    ) -> str:
+        """Render the remediation as a NETCONF edit-config payload.
+
+        Requires running and generated configs built by `HConfig.from_xml()`.
+        Keyed list-entry deletions are expressed by their key leaf, resolved
+        against the running config via `list_keys`.
+        """
+        from .formats import (
+            hconfig_to_netconf_xml,
+        )
+
+        return hconfig_to_netconf_xml(
+            self.remediation_config,
+            running=self.running_config,
+            list_keys=list_keys,
+        )
+
     def apply_remediation_tag_rules(self, tag_rules: tuple[TagRule, ...]) -> None:
         """Applies tag rules to selectively label parts of the remediation configuration.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -150,9 +150,11 @@ parametrize-values-type = "tuple"
 [tool.ruff.lint.per-file-ignores]
 "**/tests/*" = ["PLC2701", "S101"]
 "tests/test_benchmarks.py" = ["T201", "PLR6301", "PERF401"]
-# HConfig's classmethod constructors defer their loader imports to call time
-# to avoid a circular import with constructors.py.
+# HConfig's classmethod constructors and WorkflowRemediation's format
+# renderers defer their loader imports to call time to avoid circular
+# imports and keep `import hier_config` light.
 "hier_config/root.py" = ["PLC0415"]
+"hier_config/workflows.py" = ["PLC0415"]
 
 [tool.pytest.ini_options]
 markers = [

--- a/tests/unit/test_formats.py
+++ b/tests/unit/test_formats.py
@@ -1,11 +1,13 @@
 """Tests for hier_config/formats.py — JSON/XML ingestion and rendering (#232)."""
 
 import json
+import xml.etree.ElementTree as ET  # ruff:ignore[suspicious-xml-etree-import]
 
 import pytest
 
-from hier_config import HConfig, Platform
+from hier_config import HConfig, Platform, WorkflowRemediation
 from hier_config.exceptions import DuplicateChildError, InvalidConfigError
+from hier_config.formats import hconfig_to_netconf_xml
 
 OPENCONFIG_STYLE = {
     "system": {
@@ -211,3 +213,113 @@ def test_duplicate_list_items_raise_hier_config_error() -> None:
         HConfig.from_json(
             Platform.GENERIC, {"interface": [{"name": "e0"}, {"name": "e0"}]}
         )
+
+
+NC_OPERATION = "{urn:ietf:params:xml:ns:netconf:base:1.0}operation"
+
+NETCONF_RUNNING_XML = (
+    "<config>"
+    "<system><hostname>old</hostname><location>hq</location></system>"
+    "<interfaces>"
+    "<interface><name>eth0</name><mtu>9000</mtu></interface>"
+    "<interface><name>eth1</name><mtu>1500</mtu></interface>"
+    "</interfaces>"
+    "</config>"
+)
+NETCONF_GENERATED_XML = (
+    "<config>"
+    "<system><hostname>new</hostname><location>hq</location></system>"
+    "<interfaces>"
+    "<interface><name>eth0</name><mtu>9000</mtu></interface>"
+    "</interfaces>"
+    "</config>"
+)
+
+
+def test_netconf_remediation_payload() -> None:
+    """Remediation between from_xml trees renders as a NETCONF edit-config payload."""
+    running = HConfig.from_xml(Platform.GENERIC, NETCONF_RUNNING_XML)
+    generated = HConfig.from_xml(Platform.GENERIC, NETCONF_GENERATED_XML)
+    workflow = WorkflowRemediation(running, generated)
+    payload = workflow.remediation_netconf_xml()
+
+    assert 'xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0"' in payload
+    root = ET.fromstring(payload)  # ruff:ignore[suspicious-xml-element-tree-usage]
+    assert root.tag == "config"
+
+    system = root.find("system")
+    assert system is not None
+    hostnames = system.findall("hostname")
+    deleted = [e for e in hostnames if e.get(NC_OPERATION) == "delete"]
+    added = [e for e in hostnames if e.get(NC_OPERATION) is None]
+    assert len(deleted) == 1
+    assert added[0].text == "new"
+
+    # The removed keyed list entry deletes by key leaf, not by value text.
+    interfaces = root.find("interfaces")
+    assert interfaces is not None
+    removed = interfaces.find("interface")
+    assert removed is not None
+    assert removed.get(NC_OPERATION) == "delete"
+    name = removed.find("name")
+    assert name is not None
+    assert name.text == "eth1"
+    assert removed.find("mtu") is None
+
+
+def test_netconf_addition_renders_plain_subtree() -> None:
+    """Added sections carry no operation attribute (NETCONF merge default)."""
+    running = HConfig.from_xml(Platform.GENERIC, "<config><system/></config>")
+    generated = HConfig.from_xml(
+        Platform.GENERIC,
+        "<config><system/><ntp><enabled>true</enabled></ntp></config>",
+    )
+    workflow = WorkflowRemediation(running, generated)
+    root = ET.fromstring(workflow.remediation_netconf_xml())  # ruff:ignore[suspicious-xml-element-tree-usage]
+    ntp = root.find("ntp")
+    assert ntp is not None
+    assert ntp.get(NC_OPERATION) is None
+    enabled = ntp.find("enabled")
+    assert enabled is not None
+    assert enabled.text == "true"
+
+
+def test_netconf_attribute_negation_raises() -> None:
+    """Attribute removals cannot be expressed as NETCONF operations."""
+    running = HConfig.from_xml(Platform.GENERIC, '<config><system foo="bar"/></config>')
+    generated = HConfig.from_xml(Platform.GENERIC, "<config><system/></config>")
+    workflow = WorkflowRemediation(running, generated)
+    with pytest.raises(InvalidConfigError, match="Attribute"):
+        workflow.remediation_netconf_xml()
+
+
+def test_netconf_leaf_delete_without_running_context() -> None:
+    """The standalone function falls back to value-bearing leaf deletes."""
+    running = HConfig.from_xml(
+        Platform.GENERIC, "<config><system><hostname>old</hostname></system></config>"
+    )
+    generated = HConfig.from_xml(Platform.GENERIC, "<config><system/></config>")
+    remediation = running.remediation(generated)
+    root = ET.fromstring(hconfig_to_netconf_xml(remediation))  # ruff:ignore[suspicious-xml-element-tree-usage]
+    system = root.find("system")
+    assert system is not None
+    hostname = system.find("hostname")
+    assert hostname is not None
+    assert hostname.get(NC_OPERATION) == "delete"
+    assert hostname.text == "old"
+
+
+def test_xml_diff_is_surgical_across_entry_counts() -> None:
+    """A keyed entry keeps the same node text regardless of sibling count.
+
+    Removing one of two entries must not delete-and-re-add the survivor
+    (#232): identity suffixes apply whenever an identifying child exists,
+    not only when the tag repeats.
+    """
+    running = HConfig.from_xml(Platform.GENERIC, NETCONF_RUNNING_XML)
+    generated = HConfig.from_xml(Platform.GENERIC, NETCONF_GENERATED_XML)
+    remediation = running.remediation(generated)
+    interfaces_lines = [
+        line.strip() for line in remediation.to_lines() if "interface" in line
+    ]
+    assert interfaces_lines == ["interfaces", 'no interface "eth1"']


### PR DESCRIPTION
## Summary

Completes the final scope of #232: remediation output that matches the XML input format.

- **`WorkflowRemediation.remediation_netconf_xml()`** (plus standalone `formats.hconfig_to_netconf_xml()`) renders the remediation between two `HConfig.from_xml()` trees as a NETCONF `edit-config`-style payload: negated nodes become `nc:operation="delete"` elements (namespaced via `xmlns:nc`), additions use NETCONF's default merge operation, and attribute-level changes raise a clear `InvalidConfigError` (they have no NETCONF operation encoding).
- **Keyed list-entry deletions delete by key leaf** (`<interface nc:operation="delete"><name>eth1</name></interface>`), resolved against the running config; without running-config context the standalone function falls back to value-bearing leaf deletes, which is correct for leaves and leaf-lists.
- **Ingestion fix found via this work**: the identity suffix was only applied when a tag repeated among siblings, so the same list entry got different node text in configs with different entry counts — producing spurious delete-and-re-add diffs (the exact scenario remediation exists for). Elements are now keyed whenever an identifying `list_keys` child exists; an identity is only *mandatory* when the tag actually repeats.

## Test plan

- [x] New tests: end-to-end payload structure (delete + merge + namespace declaration), keyed-entry deletion by key leaf, plain-subtree additions, attribute-negation error, no-running-context fallback, and the surgical-diff regression for differing entry counts.
- [x] `poetry run ./scripts/build.py lint-and-test` — all linters pass, 698 tests, ≥95% coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)