### PR TITLE
Fix future() negation edge cases; add prune_empty_branches (#269)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `future()` negation edge cases (#269): a negation whose positive form exists
+  in the running config now removes it without surviving as a literal `no ...`
+  child (evaluated before the idempotency rules, which can match the negation
+  line itself); shorthand negations (`no description`) remove the valued lines
+  they match, as devices do. Negations matching nothing are still kept as a
+  did-not-apply-cleanly signal, and idempotency-tracked negated forms (e.g.
+  IOS `no logging console`) still replace their counterpart and persist.
+
+### Added
+
+- `HConfig.future(..., prune_empty_branches=True)` removes sections that a
+  change emptied out — matching devices that prune empty stanzas on commit —
+  while keeping sections that were already empty (#269).
+
 ### Added
 
 - NETCONF `edit-config` remediation rendering (#232):

--- a/hier_config/root.py
+++ b/hier_config/root.py
@@ -11,6 +11,7 @@ from .tree_algorithms import (
     compute_future,
     compute_remediation,
     compute_with_tags,
+    prune_emptied_branches,
 )
 
 if TYPE_CHECKING:
@@ -280,15 +281,26 @@ class HConfig(HConfigBase):  # ruff:ignore[too-many-public-methods]
                     child.order_weight = rule.weight
         return self
 
-    def future(self, config: HConfig) -> HConfig:
+    def future(
+        self,
+        config: HConfig,
+        *,
+        prune_empty_branches: bool = False,
+    ) -> HConfig:
         """EXPERIMENTAL - predict the future config after config is applied to self.
 
         The quality of this method's output will in part depend on how well
         the OS options are tuned. Ensuring that idempotency rules are accurate is
         especially important.
+
+        With `prune_empty_branches`, sections that the change emptied out are
+        removed, matching devices that prune empty stanzas on commit; sections
+        that were already empty are kept.
         """
         future_config = HConfig(self.driver)
         compute_future(self, config, future_config)
+        if prune_empty_branches:
+            prune_emptied_branches(self, future_config)
         return future_config
 
     def with_tags(self, tags: Iterable[str]) -> HConfig:

--- a/hier_config/tree_algorithms.py
+++ b/hier_config/tree_algorithms.py
@@ -190,6 +190,7 @@ def compute_future(  # ruff:ignore[complex-structure]
     for config_child in config.children:
         if config_child.text in config_children_ignore:
             continue
+        is_negation = config_child.text.startswith(source.driver.negation_prefix)
         # sectional_overwrite
         # sectional_overwrite_no_negate
         if (
@@ -197,26 +198,44 @@ def compute_future(  # ruff:ignore[complex-structure]
             or config_child.use_sectional_overwrite_without_negation()
         ):
             future_config.add_deep_copy_of(config_child)
-        # Idempotent commands
+        # A negation whose positive form exists removes it; neither line
+        # survives. Evaluated before the idempotency rules, which can match
+        # the negation line itself and keep it as a literal child (#269).
+        elif is_negation and (
+            exact := source.get_child(equals=config_child.text_without_negation)
+        ):
+            negated_or_recursed.add(exact.text)
+        # Idempotent commands: interchangeable forms of one setting replace
+        # each other. This deliberately covers negated forms tracked by a
+        # rule (e.g. IOS `no logging console`), which persist in the render.
         elif self_child := source.root.driver.idempotent_for(
             config_child,
             source.children,
         ):
             future_config.add_deep_copy_of(config_child)
             negated_or_recursed.add(self_child.text)
+        # Shorthand negation: `no description` removes `description foo`, as
+        # devices do (#269).
+        elif is_negation and (
+            prefix_matches := [
+                child
+                for child in source.children
+                if child.text.startswith(
+                    f"{config_child.text_without_negation} ",
+                )
+            ]
+        ):
+            negated_or_recursed.update(child.text for child in prefix_matches)
         # config_child is already in source
         elif self_child := source.get_child(equals=config_child.text):
             future_child = future_config.add_shallow_copy_of(self_child)
             compute_future(self_child, config_child, future_child)
             negated_or_recursed.add(config_child.text)
-        # config_child is being negated
-        elif config_child.text.startswith(source.driver.negation_prefix):
-            unnegated_command = config_child.text_without_negation
-            if source.get_child(equals=unnegated_command):
-                negated_or_recursed.add(unnegated_command)
-            # Account for "no ..." commands in the running config
-            else:
-                future_config.add_shallow_copy_of(config_child)
+        # A negation matching nothing is kept: it accounts for "no ..." lines
+        # native to the running config and doubles as a did-not-apply-cleanly
+        # signal for callers (#269).
+        elif is_negation:
+            future_config.add_shallow_copy_of(config_child)
         # The negated form of config_child is in source.children
         elif self_child := source.get_child(
             equals=f"{source.driver.negation_prefix}{config_child.text}",
@@ -246,3 +265,21 @@ def compute_with_tags(
             compute_with_tags(child, tags, new_child)
 
     return new_instance
+
+
+def prune_emptied_branches(
+    source: HConfigBase,
+    future_node: HConfigBase,
+) -> None:
+    """Remove branches that a change emptied out, as devices do (#269).
+
+    Only prunes nodes whose counterpart in the running config had children;
+    sections that were already empty (or are newly added empty) are kept.
+    Cascades upward via post-order traversal.
+    """
+    for child in tuple(future_node.children):
+        source_child = source.get_child(equals=child.text) if source else None
+        if source_child is not None:
+            prune_emptied_branches(source_child, child)
+            if not child.children and source_child.children:
+                child.delete()

--- a/tests/integration/test_remediation.py
+++ b/tests/integration/test_remediation.py
@@ -594,9 +594,7 @@ def test_future_bare_shorthand_negation_removes_valued_line() -> None:
     """`no description` removes `description foo` as devices do (#269)."""
     running_config = HConfig.from_text(
         Platform.ARISTA_EOS,
-        "interface Ethernet1\n"
-        "   description foo\n"
-        "   switchport access vlan 10\n",
+        "interface Ethernet1\n   description foo\n   switchport access vlan 10\n",
     )
     change = HConfig.from_text(
         Platform.ARISTA_EOS, "interface Ethernet1\n no description\n"
@@ -637,7 +635,7 @@ def test_future_prune_emptied_parents() -> None:
         "router static\n address-family ipv4 unicast\n  no 192.0.2.0/24 Null0\n",
     )
 
-    assert running_config.future(change, prune_empty_branches=True).to_lines() == ()
+    assert not running_config.future(change, prune_empty_branches=True).to_lines()
     # Default keeps the emptied parents (spurious-diff behavior is opt-out only).
     assert running_config.future(change).to_lines() == (
         "router static",

--- a/tests/integration/test_remediation.py
+++ b/tests/integration/test_remediation.py
@@ -546,3 +546,114 @@ def test_remediation_does_not_mutate_inputs() -> None:
 
     assert running_config.to_lines() == running_before
     assert generated_config.to_lines() == generated_before
+
+
+def test_future_value_carrying_negation_on_idempotent_line() -> None:
+    """A negation matching an existing line removes it and does not survive (#269)."""
+    running_config = HConfig.from_text(
+        Platform.ARISTA_EOS,
+        "router bgp 65000\n"
+        "   neighbor 10.0.0.1 peer group PEERS\n"
+        "   neighbor 10.0.0.1 description spine1\n",
+    )
+    change = HConfig.from_text(
+        Platform.ARISTA_EOS,
+        "router bgp 65000\n"
+        " no neighbor 10.0.0.1 peer group PEERS\n"
+        " no neighbor 10.0.0.1 description spine1\n",
+    )
+    future_config = running_config.future(change)
+
+    assert future_config.to_lines() == ("router bgp 65000",)
+
+
+def test_future_value_differing_negation_replaces_via_idempotency() -> None:
+    """A stale-valued negation displaces the tracked line but stays visible.
+
+    Idempotency rules declare interchangeable forms of one setting, so the
+    negation replaces the matched line; keeping it in the render preserves
+    the did-not-apply-cleanly signal (#269).
+    """
+    running_config = HConfig.from_text(
+        Platform.ARISTA_EOS,
+        "router bgp 65000\n   neighbor 10.0.0.1 description spine1\n",
+    )
+    change = HConfig.from_text(
+        Platform.ARISTA_EOS,
+        "router bgp 65000\n no neighbor 10.0.0.1 description stale-value\n",
+    )
+    future_config = running_config.future(change)
+
+    assert future_config.to_lines() == (
+        "router bgp 65000",
+        "  no neighbor 10.0.0.1 description stale-value",
+    )
+
+
+def test_future_bare_shorthand_negation_removes_valued_line() -> None:
+    """`no description` removes `description foo` as devices do (#269)."""
+    running_config = HConfig.from_text(
+        Platform.ARISTA_EOS,
+        "interface Ethernet1\n"
+        "   description foo\n"
+        "   switchport access vlan 10\n",
+    )
+    change = HConfig.from_text(
+        Platform.ARISTA_EOS, "interface Ethernet1\n no description\n"
+    )
+    future_config = running_config.future(change)
+
+    assert future_config.to_lines() == (
+        "interface Ethernet1",
+        "  switchport access vlan 10",
+    )
+
+
+def test_future_unmatched_negation_is_kept_as_signal() -> None:
+    """A negation matching nothing still surfaces in the render (#269)."""
+    running_config = HConfig.from_text(
+        Platform.ARISTA_EOS, "interface Ethernet1\n   switchport access vlan 10\n"
+    )
+    change = HConfig.from_text(
+        Platform.ARISTA_EOS, "interface Ethernet1\n no description\n"
+    )
+    future_config = running_config.future(change)
+
+    assert future_config.to_lines() == (
+        "interface Ethernet1",
+        "  no description",
+        "  switchport access vlan 10",
+    )
+
+
+def test_future_prune_emptied_parents() -> None:
+    """Removing the last child can prune the emptied ancestors (#269)."""
+    running_config = HConfig.from_text(
+        Platform.CISCO_XR,
+        "router static\n address-family ipv4 unicast\n  192.0.2.0/24 Null0\n",
+    )
+    change = HConfig.from_text(
+        Platform.CISCO_XR,
+        "router static\n address-family ipv4 unicast\n  no 192.0.2.0/24 Null0\n",
+    )
+
+    assert running_config.future(change, prune_empty_branches=True).to_lines() == ()
+    # Default keeps the emptied parents (spurious-diff behavior is opt-out only).
+    assert running_config.future(change).to_lines() == (
+        "router static",
+        "  address-family ipv4 unicast",
+    )
+
+
+def test_future_prune_keeps_originally_empty_parents() -> None:
+    """Pruning only removes parents that had children in the running config (#269)."""
+    running_config = HConfig.from_text(
+        Platform.CISCO_XR, "interface GigabitEthernet0/0/0/0\n"
+    )
+    change = HConfig.from_text(Platform.CISCO_XR, "hostname r1\n")
+    future_config = running_config.future(change, prune_empty_branches=True)
+
+    assert future_config.to_lines() == (
+        "hostname r1",
+        "interface GigabitEthernet0/0/0/0",
+    )


### PR DESCRIPTION
## Summary

Closes #269 (next side; a master port follows as a separate PR).

`compute_future` now resolves negations in an explicit, documented order:

1. **Exact positive match** → the negation removes the line and neither survives (case 1). The root cause was ordering: the idempotency check ran first and EOS's unanchored `neighbor \S+ description` rule matched the *negation line itself*, keeping it as a literal child while displacing the original.
2. **Idempotency rules** → unchanged replace semantics, deliberately including rule-tracked negated forms: IOS `no logging console` still replaces `logging console X` and persists in the render — real device behavior for display-default commands, and the existing remediation roundtrip depends on it. A stale-valued EOS negation likewise displaces the tracked line but stays visible, preserving the did-not-apply-cleanly signal the issue explicitly asked to retain.
3. **Shorthand prefix match** → `no description` removes `description foo` (and `no X` removes all `X ...` lines), as devices do (case 2).
4. **Unmatched negations are kept** — both for `no ...` lines native to running configs and as the apply-signal.

**Case 3** ships as an opt-in: `HConfig.future(change, prune_empty_branches=True)` prunes sections the change emptied out (cascading upward, e.g. XR `router static / address-family`), while sections that were already empty — or newly added empty — are kept, so legitimately-empty interfaces don't vanish.

## Test plan

- [x] Six new integration tests: all three issue repros verbatim (adapted to v4 constructors), the stale-value idempotency-replace pin, the unmatched-negation signal pin, and prune on/off/originally-empty behavior.
- [x] Full suite passes (702 tests) — including the IOS `logging console` roundtrip that constrains the idempotency-replace semantics.
- [x] `poetry run ./scripts/build.py lint-and-test` — all linters green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)