### PR TITLE
Add Aruba AOS-CX platform support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,7 +41,7 @@ Three-layer design — full detail in [docs/dev/architecture.md](docs/dev/archit
 - **Driver** (`platforms/`): each platform subclasses `HConfigDriverBase` and overrides `_instantiate_rules()` returning `HConfigDriverRules` — typed, frozen Pydantic rule models matched against config lineage via `MatchRule` tuples.
 - **Workflow** (`workflows.py`, `reporting.py`): `WorkflowRemediation` exposes `remediation_config` / `rollback_config`; constructors live in `constructors.py` (`get_hconfig()`, `get_hconfig_fast_load()`, `get_hconfig_driver()`).
 
-Supported platforms (`Platform` enum in `models.py`): ARISTA_EOS, CISCO_IOS, CISCO_NXOS, CISCO_XR, FORTINET_FORTIOS, GENERIC, HP_COMWARE5, HP_PROCURVE, HUAWEI_VRP, JUNIPER_JUNOS, NOKIA_SRL, VYOS.
+Supported platforms (`Platform` enum in `models.py`): ARISTA_EOS, ARUBA_AOSCX, CISCO_IOS, CISCO_NXOS, CISCO_XR, FORTINET_FORTIOS, GENERIC, HP_COMWARE5, HP_PROCURVE, HUAWEI_VRP, JUNIPER_JUNOS, NOKIA_SRL, VYOS.
 
 ## Hard Rules
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Aruba AOS-CX platform support (`Platform.ARUBA_AOSCX`): a new driver and
+  config view covering AOS-CX's Cisco/EOS-like hierarchical CLI. Because
+  `vlan trunk allowed` is additive on AOS-CX rather than declarative, collapsed
+  unnamed VLAN headers (`vlan 1,10`) and comma/range trunk lists are split into
+  one VLAN per line via `post_load_callbacks`, so remediation adds a missing
+  VLAN with `vlan trunk allowed <id>` and removes an extra one with
+  `no vlan trunk allowed <id>`. All other sections, including `evpn` and
+  `interface vxlan`, are remediated with the standard rule framework. (#289)
 - `HConfig.future(..., prune_empty_branches=True)` removes sections that a
   change emptied out — matching devices that prune empty stanzas on commit —
   while keeping sections that were already empty (#269).

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Hierarchical Configuration has been used extensively on:
 - [x] Cisco IOSXR
 - [x] Cisco NXOS
 - [x] Arista EOS
+- [x] Aruba AOS-CX
 - [x] Fortinet FortiOS
 - [x] HP Procurve (Aruba AOSS)
 - [x] HP Comware5 / H3C

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,6 +28,7 @@
 | Fortinet FortiOS | `Platform.FORTINET_FORTIOS` | Fully supported |
 | HP ProCurve (Aruba AOSS) | `Platform.HP_PROCURVE` | Fully supported |
 | HP Comware5 / H3C | `Platform.HP_COMWARE5` | Fully supported |
+| Aruba AOS-CX | `Platform.ARUBA_AOSCX` | Experimental |
 | Juniper JunOS | `Platform.JUNIPER_JUNOS` | Experimental |
 | Nokia SRL | `Platform.NOKIA_SRL` | Experimental |
 | VyOS | `Platform.VYOS` | Experimental |

--- a/docs/user/drivers.md
+++ b/docs/user/drivers.md
@@ -40,6 +40,7 @@ The following drivers are included in Hier Config:
 | HP ProCurve (Aruba AOSS) | `Platform.HP_PROCURVE` | Fully supported |
 | HP Comware5 / H3C | `Platform.HP_COMWARE5` | Fully supported |
 | Huawei VRP | `Platform.HUAWEI_VRP` | Fully supported |
+| Aruba AOS-CX | `Platform.ARUBA_AOSCX` | Experimental |
 | Juniper JunOS | `Platform.JUNIPER_JUNOS` | Experimental |
 | Nokia SRL | `Platform.NOKIA_SRL` | Experimental |
 | VyOS | `Platform.VYOS` | Experimental |
@@ -88,6 +89,29 @@ Platform enum: `Platform.ARISTA_EOS`
 from hier_config import Platform, get_hconfig_driver
 
 driver = get_hconfig_driver(Platform.ARISTA_EOS)
+```
+
+---
+
+### Aruba AOS-CX Driver
+
+Aruba AOS-CX uses a Cisco IOS/EOS-like hierarchical CLI with `no ` as the [negation prefix](glossary.md#negation-prefix), so the `ARUBA_AOSCX` driver reuses the standard IOS/EOS tree model and remediation. The one platform-specific behavior is how trunk VLAN membership is modeled:
+
+- `vlan trunk allowed` is *additive* on AOS-CX rather than declarative. The driver splits comma/range VLAN lists into one command per VLAN (on load and in the intended config), so remediation adds a missing VLAN with `vlan trunk allowed <id>` and removes an extra one with `no vlan trunk allowed <id>`, rather than rewriting the whole list.
+- Unnamed collapsed VLAN headers such as `vlan 1,10` or `vlan 100-102` are likewise split into individual `vlan <id>` sections.
+- Structured sections such as `evpn` and `interface vxlan` are remediated like any other section: individual members (for example an EVPN `vlan`) are added or negated, while unchanged siblings such as `arp-suppression` are left untouched. As with Arista/Cisco, the intended config should list the members that must remain.
+- Common one-value commands such as interface `description`, `ip address`, `vlan access`, `vlan trunk native`, and `vrf attach` are treated as idempotent replacements.
+- BGP address-family blocks close with `exit-address-family`.
+- Per-line substitutions strip comment lines and rendered `exit`/`end` markers during parsing.
+
+**Known limitation**: because trunk VLAN lists are modeled one VLAN per line, a very wide range (for example `vlan trunk allowed 1-4094`) expands to one command per VLAN internally, so remediation that creates such a trunk from scratch renders many lines instead of the single range the operator wrote. Only the *delta* is emitted for an existing trunk, so day-to-day changes stay minimal; the expansion only shows up when adding a wide range wholesale.
+
+Platform enum: `Platform.ARUBA_AOSCX`
+
+```python
+from hier_config import Platform, get_hconfig_driver
+
+driver = get_hconfig_driver(Platform.ARUBA_AOSCX)
 ```
 
 ---

--- a/hier_config/constructors.py
+++ b/hier_config/constructors.py
@@ -10,6 +10,8 @@ from .child import HConfigChild
 from .models import Dump, Platform
 from .platforms.arista_eos.driver import HConfigDriverAristaEOS
 from .platforms.arista_eos.view import HConfigViewAristaEOS
+from .platforms.aruba_aoscx.driver import HConfigDriverArubaAOSCX
+from .platforms.aruba_aoscx.view import HConfigViewArubaAOSCX
 from .platforms.cisco_ios.driver import HConfigDriverCiscoIOS
 from .platforms.cisco_ios.view import HConfigViewCiscoIOS
 from .platforms.cisco_nxos.driver import HConfigDriverCiscoNXOS
@@ -35,6 +37,7 @@ def get_hconfig_driver(platform: Platform) -> HConfigDriverBase:
     """Create base options on an OS level."""
     platform_drivers: dict[Platform, type[HConfigDriverBase]] = {
         Platform.ARISTA_EOS: HConfigDriverAristaEOS,
+        Platform.ARUBA_AOSCX: HConfigDriverArubaAOSCX,
         Platform.CISCO_IOS: HConfigDriverCiscoIOS,
         Platform.CISCO_NXOS: HConfigDriverCiscoNXOS,
         Platform.CISCO_XR: HConfigDriverCiscoIOSXR,
@@ -64,6 +67,8 @@ def get_hconfig_view(config: HConfig) -> HConfigViewBase:
     driver = config.driver
     if isinstance(driver, HConfigDriverAristaEOS):
         return HConfigViewAristaEOS(config)
+    if isinstance(driver, HConfigDriverArubaAOSCX):
+        return HConfigViewArubaAOSCX(config)
     if isinstance(driver, HConfigDriverCiscoIOS):
         return HConfigViewCiscoIOS(config)
     if isinstance(driver, HConfigDriverCiscoNXOS):

--- a/hier_config/models.py
+++ b/hier_config/models.py
@@ -188,6 +188,7 @@ class Platform(str, Enum):
     """Enumeration of supported network operating system platforms."""
 
     ARISTA_EOS = auto()
+    ARUBA_AOSCX = auto()
     CISCO_IOS = auto()
     CISCO_NXOS = auto()
     CISCO_XR = auto()

--- a/hier_config/platforms/aruba_aoscx/driver.py
+++ b/hier_config/platforms/aruba_aoscx/driver.py
@@ -1,0 +1,184 @@
+from hier_config.models import (
+    IdempotentCommandsRule,
+    MatchRule,
+    OrderingRule,
+    PerLineSubRule,
+    SectionalExitingRule,
+)
+from hier_config.platforms.driver_base import HConfigDriverBase, HConfigDriverRules
+from hier_config.platforms.functions import expand_range
+from hier_config.platforms.utils import split_vlan_id_lists
+from hier_config.root import HConfig
+
+
+def _split_interface_vlan_trunk_allowed(config: HConfig) -> None:
+    """Split AOS-CX additive trunk VLAN lists into one VLAN per line.
+
+    ``vlan trunk allowed`` is additive on AOS-CX rather than declarative, so
+    modelling one VLAN per line lets standard remediation add missing VLANs with
+    ``vlan trunk allowed <id>`` and remove extra ones with
+    ``no vlan trunk allowed <id>`` -- matching how the device actually behaves.
+    A spec that does not parse to at least one VLAN id is left untouched so the
+    line is never deleted without a replacement.
+    """
+    for interface in config.get_children(startswith="interface "):
+        for allowed in tuple(interface.get_children(startswith="vlan trunk allowed ")):
+            words = allowed.text.split(maxsplit=3)
+            if len(words) != 4:
+                continue
+            spec = words[3]
+            if spec in {"all", "none"} or not any(
+                separator in spec for separator in (",", "-")
+            ):
+                continue
+            try:
+                vlan_ids = expand_range(spec)
+            except ValueError:
+                continue
+            if not vlan_ids:
+                continue
+            for vlan_id in vlan_ids:
+                interface.add_child(
+                    f"vlan trunk allowed {vlan_id}",
+                    return_if_present=True,
+                )
+            allowed.delete()
+
+
+class HConfigDriverArubaAOSCX(HConfigDriverBase):
+    """Driver for Aruba AOS-CX switches.
+
+    AOS-CX uses a Cisco IOS/EOS-like hierarchical CLI with ``no`` negation, so it
+    reuses the standard tree model and remediation. The one platform-specific
+    behaviour is that ``vlan trunk allowed`` is additive rather than declarative:
+    the driver splits comma/range VLAN lists into one VLAN per line (both on load
+    and in the intended config, via ``post_load_callbacks``) so remediation adds
+    only the missing VLANs and negates only the removed ones. Unnamed collapsed
+    VLAN headers like ``vlan 1,10`` are split into separate VLAN sections the same
+    way. Platform enum: ``Platform.ARUBA_AOSCX``.
+    """
+
+    @staticmethod
+    def _instantiate_rules() -> HConfigDriverRules:
+        return HConfigDriverRules(
+            sectional_exiting=[
+                SectionalExitingRule(
+                    match_rules=(
+                        MatchRule(startswith="router bgp"),
+                        MatchRule(startswith="address-family"),
+                    ),
+                    exit_text="exit-address-family",
+                ),
+            ],
+            ordering=[
+                # Create/modify top-level VLANs before the interfaces that
+                # reference them: AOS-CX rejects `vlan trunk allowed <id>` for a
+                # VLAN that does not yet exist.
+                OrderingRule(
+                    match_rules=(MatchRule(startswith="vlan "),),
+                    weight=-10,
+                ),
+            ],
+            per_line_sub=[
+                PerLineSubRule(search=r"^\S+(?:\([^)]+\))?#.*", replace=""),
+                PerLineSubRule(search=r"^Current configuration.*", replace=""),
+                PerLineSubRule(search=r"^!.*", replace=""),
+                PerLineSubRule(search=r"^#.*", replace=""),
+                PerLineSubRule(search=r"^end$", replace=""),
+                PerLineSubRule(search=r"^\s*exit$", replace=""),
+                PerLineSubRule(search=r"^\s*exit-address-family$", replace=""),
+            ],
+            idempotent_commands=[
+                IdempotentCommandsRule(
+                    match_rules=(MatchRule(startswith="hostname "),),
+                ),
+                IdempotentCommandsRule(
+                    match_rules=(
+                        MatchRule(startswith="vlan "),
+                        MatchRule(startswith="name "),
+                    ),
+                ),
+                IdempotentCommandsRule(
+                    match_rules=(
+                        MatchRule(startswith="interface "),
+                        MatchRule(startswith="description "),
+                    ),
+                ),
+                IdempotentCommandsRule(
+                    match_rules=(
+                        MatchRule(startswith="interface "),
+                        MatchRule(startswith="ip address "),
+                    ),
+                ),
+                IdempotentCommandsRule(
+                    match_rules=(
+                        MatchRule(startswith="interface "),
+                        MatchRule(startswith="vlan access "),
+                    ),
+                ),
+                IdempotentCommandsRule(
+                    match_rules=(
+                        MatchRule(startswith="interface "),
+                        MatchRule(startswith="vlan trunk native "),
+                    ),
+                ),
+                IdempotentCommandsRule(
+                    match_rules=(
+                        MatchRule(startswith="interface "),
+                        MatchRule(startswith="vrf attach "),
+                    ),
+                ),
+                IdempotentCommandsRule(
+                    match_rules=(
+                        MatchRule(startswith="interface "),
+                        MatchRule(startswith="mtu "),
+                    ),
+                ),
+                IdempotentCommandsRule(
+                    match_rules=(
+                        MatchRule(startswith="interface "),
+                        MatchRule(startswith="speed "),
+                    ),
+                ),
+                IdempotentCommandsRule(
+                    match_rules=(
+                        MatchRule(startswith="interface "),
+                        MatchRule(startswith="flow-control "),
+                    ),
+                ),
+                IdempotentCommandsRule(
+                    match_rules=(
+                        MatchRule(startswith="router bgp "),
+                        MatchRule(startswith="bgp router-id "),
+                    ),
+                ),
+                IdempotentCommandsRule(
+                    match_rules=(
+                        MatchRule(startswith="router bgp "),
+                        MatchRule(re_search=r"neighbor \S+ description "),
+                    ),
+                ),
+                IdempotentCommandsRule(
+                    match_rules=(
+                        MatchRule(startswith="router ospf "),
+                        MatchRule(startswith="router-id "),
+                    ),
+                ),
+                IdempotentCommandsRule(
+                    match_rules=(MatchRule(startswith="snmp-server location "),),
+                ),
+                IdempotentCommandsRule(
+                    match_rules=(MatchRule(startswith="snmp-server contact "),),
+                ),
+                IdempotentCommandsRule(
+                    match_rules=(MatchRule(startswith="logging "),),
+                ),
+                IdempotentCommandsRule(
+                    match_rules=(MatchRule(startswith="ntp vrf "),),
+                ),
+            ],
+            post_load_callbacks=[
+                split_vlan_id_lists,
+                _split_interface_vlan_trunk_allowed,
+            ],
+        )

--- a/hier_config/platforms/aruba_aoscx/view.py
+++ b/hier_config/platforms/aruba_aoscx/view.py
@@ -1,0 +1,275 @@
+from collections.abc import Iterable
+from ipaddress import AddressValueError, IPv4Address, IPv4Interface
+from re import sub
+
+from hier_config.child import HConfigChild
+from hier_config.platforms.functions import expand_range
+from hier_config.platforms.models import (
+    InterfaceDot1qMode,
+    InterfaceDuplex,
+    NACHostMode,
+    StackMember,
+    Vlan,
+)
+from hier_config.platforms.view_base import (
+    ConfigViewInterfaceBase,
+    HConfigViewBase,
+)
+
+
+def _safe_expand_range(spec: str) -> tuple[int, ...]:
+    """Expand a VLAN range spec, skipping a malformed one instead of raising.
+
+    The driver's post-load callbacks deliberately leave an unparseable spec
+    (e.g. ``10-12-13``) collapsed, so the view must tolerate the same input
+    rather than surface a bare ``ValueError`` from deep inside ``expand_range``.
+    """
+    try:
+        return expand_range(spec)
+    except ValueError:
+        return ()
+
+
+class ConfigViewInterfaceArubaAOSCX(ConfigViewInterfaceBase):  # ruff:ignore[too-many-public-methods]
+    """Interface config view for Aruba AOS-CX."""
+
+    @property
+    def bundle_id(self) -> str | None:
+        if self.is_bundle:
+            # Names look like "lag 1" or "lag 1 multi-chassis"; the id is the
+            # token after the "lag " prefix, not the last word.
+            return self.name.split()[1]
+        if lag := self.config.get_child(startswith="lag "):
+            return lag.text.split()[1]
+        return None
+
+    @property
+    def bundle_member_interfaces(self) -> Iterable[str]:
+        if not self.is_bundle or not self.bundle_id:
+            return
+        lag_text = f"lag {self.bundle_id}"
+        for interface in self.config.root.get_children(startswith="interface "):
+            if interface.get_child(equals=lag_text):
+                yield interface.text.split(maxsplit=1)[1]
+
+    @property
+    def bundle_name(self) -> str | None:
+        if self.bundle_id:
+            return f"{self._bundle_prefix}{self.bundle_id}"
+        return None
+
+    @property
+    def description(self) -> str:
+        if child := self.config.get_child(startswith="description "):
+            return child.text.split(maxsplit=1)[1]
+        return ""
+
+    @property
+    def duplex(self) -> InterfaceDuplex:
+        if duplex := self.config.get_child(startswith="duplex "):
+            return InterfaceDuplex(duplex.text.split()[1])
+        return InterfaceDuplex.AUTO
+
+    @property
+    def enabled(self) -> bool:
+        # AOS-CX ports are admin-down by default and express the up state as an
+        # explicit `no shutdown`, so absence of `shutdown` does not mean enabled.
+        return bool(self.config.get_child(equals="no shutdown"))
+
+    @property
+    def has_nac(self) -> bool:
+        return bool(self.config.get_child(startswith="aaa authentication port-access"))
+
+    @property
+    def ipv4_interfaces(self) -> Iterable[IPv4Interface]:
+        for ipv4_address_obj in self.config.get_children(startswith="ip address "):
+            words = ipv4_address_obj.text.split()
+            if len(words) < 3 or words[2] == "dhcp":
+                continue
+            try:
+                yield IPv4Interface(words[2])
+            except AddressValueError:
+                continue
+
+    @property
+    def is_bundle(self) -> bool:
+        return self.name.lower().startswith(self._bundle_prefix)
+
+    @property
+    def is_loopback(self) -> bool:
+        return self.name.lower().startswith("loopback")
+
+    @property
+    def is_svi(self) -> bool:
+        return self.name.lower().startswith("vlan")
+
+    @property
+    def module_number(self) -> int | None:
+        words = self.number.split("/", 1)
+        if len(words) == 1:
+            return None
+        return int(words[0])
+
+    @property
+    def nac_control_direction_in(self) -> bool:
+        return False
+
+    @property
+    def nac_host_mode(self) -> NACHostMode | None:
+        return None
+
+    @property
+    def nac_mab_first(self) -> bool:
+        return False
+
+    @property
+    def nac_max_dot1x_clients(self) -> int:
+        raise NotImplementedError
+
+    @property
+    def nac_max_mab_clients(self) -> int:
+        raise NotImplementedError
+
+    @property
+    def name(self) -> str:
+        return self.config.text.split(maxsplit=1)[1]
+
+    @property
+    def native_vlan(self) -> int | None:
+        if self.is_loopback or self.is_svi:
+            return None
+        if vlan := self.config.get_child(startswith="vlan trunk native "):
+            return int(vlan.text.split()[3])
+        if vlan := self.config.get_child(startswith="vlan access "):
+            return int(vlan.text.split()[2])
+        return None
+
+    @property
+    def number(self) -> str:
+        return sub(r"^[a-zA-Z-]+\s?", "", self.name)
+
+    @property
+    def parent_name(self) -> str | None:
+        if self.is_subinterface:
+            return self.name.split(".")[0]
+        return self.bundle_name if self.bundle_id and not self.is_bundle else None
+
+    @property
+    def poe(self) -> bool:
+        return not self.config.get_child(equals="no power-over-ethernet")
+
+    @property
+    def port_number(self) -> int:
+        return int(self.name.split("/")[-1].split(".")[0])
+
+    @property
+    def speed(self) -> tuple[int, ...] | None:
+        if speed := self.config.get_child(startswith="speed "):
+            if speed.text == "speed auto":
+                return None
+            return (int(speed.text.split()[1]),)
+        return None
+
+    @property
+    def subinterface_number(self) -> int | None:
+        return int(self.name.split(".")[-1]) if self.is_subinterface else None
+
+    @property
+    def tagged_all(self) -> bool:
+        return bool(self.config.get_child(equals="vlan trunk allowed all"))
+
+    @property
+    def tagged_vlans(self) -> tuple[int, ...]:
+        vlans: set[int] = set()
+        for child in self.config.get_children(
+            re_search=r"^vlan trunk allowed [0-9,-]+$"
+        ):
+            vlans.update(_safe_expand_range(child.text.split()[3]))
+        return tuple(sorted(vlans))
+
+    @property
+    def vrf(self) -> str:
+        if vrf := self.config.get_child(startswith="vrf attach "):
+            return vrf.text.split()[2]
+        return ""
+
+    @property
+    def _bundle_prefix(self) -> str:
+        return "lag "
+
+
+class HConfigViewArubaAOSCX(HConfigViewBase):
+    """Full-tree config view for Aruba AOS-CX."""
+
+    def dot1q_mode_from_vlans(  # ruff:ignore[no-self-use]
+        self,
+        untagged_vlan: int | None = None,
+        tagged_vlans: tuple[int, ...] = (),
+        *,
+        tagged_all: bool = False,
+    ) -> InterfaceDot1qMode | None:
+        if tagged_all:
+            return InterfaceDot1qMode.TAGGED_ALL
+        if tagged_vlans:
+            return InterfaceDot1qMode.TAGGED
+        if untagged_vlan:
+            return InterfaceDot1qMode.ACCESS
+        return None
+
+    @property
+    def hostname(self) -> str | None:
+        if child := self.config.get_child(startswith="hostname "):
+            return child.text.split()[1].lower()
+        return None
+
+    @property
+    def interface_names_mentioned(self) -> frozenset[str]:
+        return frozenset(model.name for model in self.interface_views)
+
+    @property
+    def interface_views(self) -> Iterable[ConfigViewInterfaceArubaAOSCX]:
+        for interface in self.interfaces:
+            yield ConfigViewInterfaceArubaAOSCX(interface)
+
+    @property
+    def interfaces(self) -> Iterable[HConfigChild]:
+        return self.config.get_children(startswith="interface ")
+
+    @property
+    def ipv4_default_gw(self) -> IPv4Address | None:
+        if gateway := self.config.get_child(startswith="ip route 0.0.0.0/0 "):
+            return IPv4Address(gateway.text.split()[3])
+        return None
+
+    @property
+    def location(self) -> str:
+        if location := self.config.get_child(startswith="snmp-server location "):
+            return location.text.split(maxsplit=2)[2].replace('"', "")
+        return ""
+
+    @property
+    def stack_members(self) -> Iterable[StackMember]:
+        return ()
+
+    @property
+    def vlans(self) -> Iterable[Vlan]:
+        yielded_vlans: set[int] = set()
+        for child in self.config.get_children(re_search=r"^vlan [0-9,-]+$"):
+            vlan_name = None
+            if name := child.get_child(startswith="name "):
+                _, vlan_name = name.text.split(maxsplit=1)
+                vlan_name = vlan_name.replace('"', "")
+            for vlan_id in _safe_expand_range(child.text.split()[1]):
+                yielded_vlans.add(vlan_id)
+                yield Vlan(id=vlan_id, name=vlan_name or None)
+
+        for interface_view in self.interface_views:
+            for vlan_id in interface_view.tagged_vlans:
+                if vlan_id not in yielded_vlans:
+                    yielded_vlans.add(vlan_id)
+                    yield Vlan(id=vlan_id, name=None)
+            if (
+                native_vlan := interface_view.native_vlan
+            ) and native_vlan not in yielded_vlans:
+                yielded_vlans.add(native_vlan)
+                yield Vlan(id=native_vlan, name=None)

--- a/hier_config/platforms/cisco_ios/driver.py
+++ b/hier_config/platforms/cisco_ios/driver.py
@@ -10,6 +10,7 @@ from hier_config.models import (
     SectionalExitingRule,
 )
 from hier_config.platforms.driver_base import HConfigDriverBase, HConfigDriverRules
+from hier_config.platforms.utils import split_vlan_id_lists
 from hier_config.root import HConfig
 
 logger = getLogger(__name__)
@@ -41,36 +42,6 @@ def _add_acl_sequence_numbers(config: HConfig) -> None:
                 if sub_child.text.startswith(acl_line_sw):
                     sub_child.text = f"{sequence_number} {sub_child.text}"
                     sequence_number += 10
-
-
-def _expand_vlan_id_list(spec: str) -> list[int]:
-    """Expand a VLAN id spec like ``69,381`` or ``10-12,20`` into a list of ints."""
-    ids: list[int] = []
-    for part in spec.split(","):
-        if "-" in part:
-            low, high = part.split("-")
-            ids.extend(range(int(low), int(high) + 1))
-        else:
-            ids.append(int(part))
-    return ids
-
-
-def _split_vlan_id_lists(config: HConfig) -> None:
-    """Split ``vlan 69,381`` / ``vlan 10-12`` into a separate ``vlan <id>`` block per VLAN.
-
-    IOS can render unnamed VLANs collapsed onto a single comma/range line
-    (depending on how they were created; named VLANs always get their own block).
-    Splitting such a line at load time lets the diff engine match VLANs
-    block-to-block against an intended config that lists them separately,
-    avoiding a destructive ``no vlan 69,381``.
-    """
-    for vlan in tuple(config.get_children(re_search=r"^vlan \d[\d,\-]*$")):
-        spec = vlan.text.split(maxsplit=1)[1]
-        if not any(separator in spec for separator in (",", "-")):
-            continue
-        for vlan_id in _expand_vlan_id_list(spec):
-            config.add_child(f"vlan {vlan_id}")
-        vlan.delete()
 
 
 class HConfigDriverCiscoIOS(HConfigDriverBase):
@@ -227,6 +198,6 @@ class HConfigDriverCiscoIOS(HConfigDriverBase):
                 _rm_ipv6_acl_sequence_numbers,
                 _remove_ipv4_acl_remarks,
                 _add_acl_sequence_numbers,
-                _split_vlan_id_lists,
+                split_vlan_id_lists,
             ],
         )

--- a/hier_config/platforms/functions.py
+++ b/hier_config/platforms/functions.py
@@ -1,18 +1,30 @@
 def expand_range(number_range_str: str) -> tuple[int, ...]:
-    """Expand ranges like 2-5,8,22-45."""
+    """Expand ranges like ``2-5,8,22-45`` into a de-duplicated, ordered tuple.
+
+    Overlapping/duplicated ids (e.g. ``10,10-12``) collapse to a single entry
+    rather than raising, so callers that split a collapsed line get the set of
+    ids the operator meant. A malformed segment -- non-numeric, or more than one
+    ``-`` such as ``1-2-3`` -- raises ``ValueError`` instead of silently
+    truncating, so callers can leave the original line untouched.
+    """
     numbers: list[int] = []
     for number_range in number_range_str.split(","):
         start_stop = number_range.split("-")
-        if len(start_stop) == 2:
+        if len(start_stop) == 1:
+            numbers.append(int(start_stop[0]))
+        elif len(start_stop) == 2:
             start = int(start_stop[0])
             stop = int(start_stop[1])
-            numbers.extend(n for n in range(start, stop + 1))
+            if stop < start:
+                message = (
+                    f"reversed range segment {number_range!r} in {number_range_str!r}"
+                )
+                raise ValueError(message)
+            numbers.extend(range(start, stop + 1))
         else:
-            numbers.append(int(start_stop[0]))
-    if len(set(numbers)) != len(numbers):
-        message = "len(set(numbers)) must be equal to len(numbers)."
-        raise ValueError(message)
-    return tuple(numbers)
+            message = f"invalid range segment {number_range!r} in {number_range_str!r}"
+            raise ValueError(message)
+    return tuple(dict.fromkeys(numbers))
 
 
 def convert_to_set_commands(config_raw: str) -> str:

--- a/hier_config/platforms/utils.py
+++ b/hier_config/platforms/utils.py
@@ -1,0 +1,35 @@
+"""Shared helpers for platform drivers that transform a parsed config tree."""
+
+from hier_config.platforms.functions import expand_range
+from hier_config.root import HConfig
+
+
+def split_vlan_id_lists(config: HConfig) -> None:
+    """Split a collapsed ``vlan 1,10`` / ``vlan 10-12`` header into one per VLAN.
+
+    Several platforms (Cisco IOS, Aruba AOS-CX, ...) can render unnamed VLANs
+    collapsed onto a single comma/range line. Splitting them at load time lets
+    the diff engine match VLANs block-to-block against an intended config that
+    lists them separately, avoiding a destructive ``no vlan 1,10``.
+
+    Only a bare (childless) collapsed header is split: a real collapsed range is
+    unnamed, because devices reject per-VLAN settings such as ``name`` on a
+    range, so a header that carries configuration is left untouched rather than
+    fanning its children (and a non-unique ``name``) onto every expanded VLAN. A
+    spec that does not parse as pure integers/ranges is likewise left untouched.
+    """
+    for vlan in tuple(config.get_children(re_search=r"^vlan \d[\d,\-]*$")):
+        spec = vlan.text.split(maxsplit=1)[1]
+        if not any(separator in spec for separator in (",", "-")):
+            continue
+        if vlan.children:
+            continue
+        try:
+            vlan_ids = expand_range(spec)
+        except ValueError:
+            continue
+        if not vlan_ids:
+            continue
+        for vlan_id in vlan_ids:
+            config.add_child(f"vlan {vlan_id}", return_if_present=True)
+        vlan.delete()

--- a/hier_config/utils.py
+++ b/hier_config/utils.py
@@ -28,6 +28,11 @@ from hier_config.models import (
 from hier_config.platforms.driver_base import HConfigDriverBase
 
 HCONFIG_PLATFORM_V2_TO_V3_MAPPING = {
+    # netutils sets this platform's network_driver_mappings["hier_config"] to
+    # "aruba_aoscx", and nautobot-golden-config resolves the driver by feeding
+    # that string through this mapper, so the entry is required for AOS-CX to
+    # resolve instead of falling back to GENERIC.
+    "aruba_aoscx": Platform.ARUBA_AOSCX,
     "ios": Platform.CISCO_IOS,
     "iosxe": Platform.CISCO_IOS,
     "iosxr": Platform.CISCO_XR,
@@ -96,6 +101,12 @@ def load_hier_config_tags(tags_file: str) -> tuple[TagRule, ...]:
 def hconfig_v2_os_v3_platform_mapper(os_name: str) -> Platform:
     """Map a Hier Config v2 operating system name to a v3 Platform enumeration.
 
+    Surrounding whitespace is stripped before lookup: consumers such as
+    nautobot-golden-config pass ``platform.network_driver_mappings["hier_config"]``
+    straight in, and a stray trailing space there would otherwise miss the table
+    and silently fall back to ``Platform.GENERIC`` -- producing a wrong (often
+    destructive) remediation with no error. Case is left untouched.
+
     Args:
         os_name (str): The name of the OS as defined in Hier Config v2.
 
@@ -107,7 +118,7 @@ def hconfig_v2_os_v3_platform_mapper(os_name: str) -> Platform:
         <Platform.CISCO_IOS: 'ios'>
 
     """
-    return HCONFIG_PLATFORM_V2_TO_V3_MAPPING.get(os_name, Platform.GENERIC)
+    return HCONFIG_PLATFORM_V2_TO_V3_MAPPING.get(os_name.strip(), Platform.GENERIC)
 
 
 def hconfig_v3_platform_v2_os_mapper(platform: Platform) -> str:

--- a/tests/circular/conftest.py
+++ b/tests/circular/conftest.py
@@ -16,6 +16,31 @@ def _fixture_file_read(filename: str) -> str:
     )
 
 
+# Aruba AOS-CX fixtures
+@pytest.fixture(scope="module")
+def aruba_aoscx_running_config() -> str:
+    """Load Aruba AOS-CX running config fixture."""
+    return _fixture_file_read("aruba_aoscx_running.conf")
+
+
+@pytest.fixture(scope="module")
+def aruba_aoscx_generated_config() -> str:
+    """Load Aruba AOS-CX generated config fixture."""
+    return _fixture_file_read("aruba_aoscx_generated.conf")
+
+
+@pytest.fixture(scope="module")
+def aruba_aoscx_remediation_config() -> str:
+    """Load Aruba AOS-CX remediation config fixture."""
+    return _fixture_file_read("aruba_aoscx_remediation.conf")
+
+
+@pytest.fixture(scope="module")
+def aruba_aoscx_rollback_config() -> str:
+    """Load Aruba AOS-CX rollback config fixture."""
+    return _fixture_file_read("aruba_aoscx_rollback.conf")
+
+
 # Cisco IOS fixtures
 @pytest.fixture(scope="module")
 def ios_running_config() -> str:

--- a/tests/circular/fixtures/aruba_aoscx_generated.conf
+++ b/tests/circular/fixtures/aruba_aoscx_generated.conf
@@ -1,0 +1,77 @@
+hostname switch-aruba_aoscx-01
+vlan 10
+  name Vlan10_Updated
+vlan 20
+  name Vlan20
+vlan 40
+  name New_Vlan
+evpn
+  arp-suppression
+  vlan 10
+    rd auto
+    route-target export 65100:10
+    route-target import 65100:10
+    redistribute host-route
+  vlan 20
+    rd auto
+    route-target export 65100:20
+    route-target import 65100:20
+    redistribute host-route
+  vlan 40
+    rd auto
+    route-target export 65100:40
+    route-target import 65100:40
+    redistribute host-route
+interface 1/1/1
+  description Uplink-Spine_01
+  no shutdown
+  ip address 192.168.10.1/24
+interface 1/1/2
+  description Access-Port Updated
+  no shutdown
+  no routing
+  vlan access 10
+  spanning-tree loop-guard
+interface 1/1/3
+  description Trunk Port
+  no shutdown
+  no routing
+  vlan trunk native 1
+  vlan trunk allowed 10
+  vlan trunk allowed 20
+  vlan trunk allowed 40
+interface 1/1/4
+  description New Interface
+  no shutdown
+  no routing
+  vlan access 40
+interface vlan 10
+  description VLAN 10 SVI Updated
+  ip address 10.10.10.1/24
+interface vlan 40
+  description VLAN 40 SVI
+  ip address 10.10.40.1/24
+interface vxlan 1
+  source ip 192.168.10.1
+  vxlan-counters aggregate
+  no shutdown
+  vni 100010
+    vlan 10
+  vni 100020
+    vlan 20
+  vni 100040
+    vlan 40
+router bgp 65100
+  bgp router-id 192.168.10.1
+  neighbor 192.168.10.2 remote-as 65200
+  neighbor 192.168.10.2 description Core Switch Primary
+  neighbor 192.168.10.3 remote-as 65300
+  neighbor 192.168.10.3 description Second Peer
+  address-family ipv4
+    neighbor 192.168.10.2 activate
+    neighbor 192.168.10.3 activate
+ip route 0.0.0.0/0 192.168.10.254
+ip route 10.20.0.0/16 192.168.10.253
+ntp server 10.0.0.20
+ntp server 10.0.0.21
+snmp-server community UpdatedTest123

--- a/tests/circular/fixtures/aruba_aoscx_remediation.conf
+++ b/tests/circular/fixtures/aruba_aoscx_remediation.conf
@@ -1,0 +1,43 @@
+vlan 10
+  name Vlan10_Updated
+vlan 40
+  name New_Vlan
+no vlan 30
+no snmp-server community test123
+evpn
+  no vlan 30
+  vlan 40
+    rd auto
+    route-target export 65100:40
+    route-target import 65100:40
+    redistribute host-route
+interface 1/1/1
+  description Uplink-Spine_01
+interface 1/1/2
+  description Access-Port Updated
+  spanning-tree loop-guard
+interface 1/1/3
+  vlan trunk allowed 40
+interface 1/1/4
+  description New Interface
+  no shutdown
+  no routing
+  vlan access 40
+interface vlan 10
+  description VLAN 10 SVI Updated
+interface vlan 40
+  description VLAN 40 SVI
+  ip address 10.10.40.1/24
+interface vxlan 1
+  no vni 100030
+  vni 100040
+    vlan 40
+router bgp 65100
+  neighbor 192.168.10.2 description Core Switch Primary
+  neighbor 192.168.10.3 remote-as 65300
+  neighbor 192.168.10.3 description Second Peer
+  address-family ipv4
+    neighbor 192.168.10.3 activate
+ip route 10.20.0.0/16 192.168.10.253
+ntp server 10.0.0.21
+snmp-server community UpdatedTest123

--- a/tests/circular/fixtures/aruba_aoscx_rollback.conf
+++ b/tests/circular/fixtures/aruba_aoscx_rollback.conf
@@ -1,0 +1,37 @@
+vlan 10
+  name Vlan10
+vlan 30
+  name Old_Vlan
+no vlan 40
+no interface 1/1/4
+no interface vlan 40
+no ip route 10.20.0.0/16 192.168.10.253
+no ntp server 10.0.0.21
+no snmp-server community UpdatedTest123
+evpn
+  no vlan 40
+  vlan 30
+    rd auto
+    route-target export 65100:30
+    route-target import 65100:30
+    redistribute host-route
+interface 1/1/1
+  description Uplink-Spine
+interface 1/1/2
+  no spanning-tree loop-guard
+  description Access-Port
+interface 1/1/3
+  no vlan trunk allowed 40
+interface vlan 10
+  description VLAN 10 SVI
+interface vxlan 1
+  no vni 100040
+  vni 100030
+    vlan 30
+router bgp 65100
+  no neighbor 192.168.10.3 remote-as 65300
+  no neighbor 192.168.10.3 description Second Peer
+  neighbor 192.168.10.2 description Core Switch
+  address-family ipv4
+    no neighbor 192.168.10.3 activate
+snmp-server community test123

--- a/tests/circular/fixtures/aruba_aoscx_running.conf
+++ b/tests/circular/fixtures/aruba_aoscx_running.conf
@@ -1,0 +1,62 @@
+hostname switch-aruba_aoscx-01
+vlan 10
+  name Vlan10
+vlan 20
+  name Vlan20
+vlan 30
+  name Old_Vlan
+evpn
+  arp-suppression
+  vlan 10
+    rd auto
+    route-target export 65100:10
+    route-target import 65100:10
+    redistribute host-route
+  vlan 20
+    rd auto
+    route-target export 65100:20
+    route-target import 65100:20
+    redistribute host-route
+  vlan 30
+    rd auto
+    route-target export 65100:30
+    route-target import 65100:30
+    redistribute host-route
+interface 1/1/1
+  description Uplink-Spine
+  no shutdown
+  ip address 192.168.10.1/24
+interface 1/1/2
+  description Access-Port
+  no shutdown
+  no routing
+  vlan access 10
+interface 1/1/3
+  description Trunk Port
+  no shutdown
+  no routing
+  vlan trunk native 1
+  vlan trunk allowed 10
+  vlan trunk allowed 20
+interface vlan 10
+  description VLAN 10 SVI
+  ip address 10.10.10.1/24
+interface vxlan 1
+  source ip 192.168.10.1
+  vxlan-counters aggregate
+  no shutdown
+  vni 100010
+    vlan 10
+  vni 100020
+    vlan 20
+  vni 100030
+    vlan 30
+router bgp 65100
+  bgp router-id 192.168.10.1
+  neighbor 192.168.10.2 remote-as 65200
+  neighbor 192.168.10.2 description Core Switch
+  address-family ipv4
+    neighbor 192.168.10.2 activate
+ip route 0.0.0.0/0 192.168.10.254
+ntp server 10.0.0.20
+snmp-server community test123

--- a/tests/circular/test_config_workflows.py
+++ b/tests/circular/test_config_workflows.py
@@ -24,6 +24,7 @@ class TestConfigWorkflows:  # pylint: disable=too-few-public-methods
     @pytest.mark.parametrize(
         ("platform", "fixture_prefix"),
         (
+            (Platform.ARUBA_AOSCX, "aruba_aoscx"),
             (Platform.CISCO_IOS, "ios"),
             (Platform.ARISTA_EOS, "eos"),
             (Platform.CISCO_NXOS, "nxos"),

--- a/tests/config_view/test_view_aruba_aoscx.py
+++ b/tests/config_view/test_view_aruba_aoscx.py
@@ -1,0 +1,193 @@
+"""Tests for Aruba AOS-CX config views."""
+
+from ipaddress import IPv4Address, IPv4Interface
+
+import pytest
+
+from hier_config import Platform, get_hconfig, get_hconfig_view
+from hier_config.platforms.models import InterfaceDot1qMode, InterfaceDuplex, Vlan
+from hier_config.platforms.view_base import HConfigViewBase
+
+
+def _view_from_config(config_text: str = "") -> HConfigViewBase:
+    return get_hconfig_view(get_hconfig(Platform.ARUBA_AOSCX, config_text))
+
+
+def test_hostname() -> None:
+    view = _view_from_config("hostname CX-LEAF-01\n")
+
+    assert view.hostname == "cx-leaf-01"
+
+
+def test_interface_properties() -> None:
+    view = _view_from_config(
+        """
+interface 1/1/1
+    description Uplink to Core
+    no shutdown
+    vlan trunk native 10
+    vlan trunk allowed 20,21,26
+    vrf attach CUSTOMER
+"""
+    )
+
+    interface_view = view.interface_view_by_name("1/1/1")
+    assert interface_view is not None
+    assert interface_view.description == "Uplink to Core"
+    assert interface_view.enabled is True
+    assert interface_view.native_vlan == 10
+    assert interface_view.tagged_vlans == (20, 21, 26)
+    assert interface_view.vrf == "CUSTOMER"
+    assert interface_view.dot1q_mode == InterfaceDot1qMode.TAGGED
+
+
+def test_access_interface_properties() -> None:
+    view = _view_from_config(
+        """
+interface 1/1/2
+    shutdown
+    vlan access 25
+"""
+    )
+
+    interface_view = view.interface_view_by_name("1/1/2")
+    assert interface_view is not None
+    assert interface_view.enabled is False
+    assert interface_view.native_vlan == 25
+    assert interface_view.dot1q_mode == InterfaceDot1qMode.ACCESS
+
+
+def test_interface_enabled_defaults_to_down() -> None:
+    # AOS-CX ports are admin-down by default: with neither `shutdown` nor
+    # `no shutdown` present, `enabled` must be False, not True.
+    view = _view_from_config(
+        """
+interface 1/1/3
+    description unconfigured
+"""
+    )
+
+    interface_view = view.interface_view_by_name("1/1/3")
+    assert interface_view is not None
+    assert interface_view.enabled is False
+
+
+def test_view_tolerates_malformed_trunk_vlan_spec() -> None:
+    # A malformed spec the driver leaves collapsed (e.g. 10-12-13) must not
+    # surface a bare ValueError from the view; the parseable VLANs still come
+    # through and the bad one is skipped.
+    view = _view_from_config(
+        """
+interface 1/1/1
+    vlan trunk allowed 10
+    vlan trunk allowed 10-12-13
+"""
+    )
+
+    interface_view = view.interface_view_by_name("1/1/1")
+    assert interface_view is not None
+    assert interface_view.tagged_vlans == (10,)
+    assert view.vlan_ids == frozenset({10})
+
+
+def test_ip_properties() -> None:
+    view = _view_from_config(
+        """
+interface vlan 25
+    ip address 10.25.0.1/24
+ip route 0.0.0.0/0 10.25.0.254
+"""
+    )
+
+    interface_view = view.interface_view_by_name("vlan 25")
+    assert interface_view is not None
+    assert interface_view.is_svi is True
+    assert list(interface_view.ipv4_interfaces) == [IPv4Interface("10.25.0.1/24")]
+    assert view.ipv4_default_gw == IPv4Address("10.25.0.254")
+
+
+def test_vlan_properties() -> None:
+    view = _view_from_config(
+        """
+vlan 20
+    name SERVERS
+interface 1/1/1
+    vlan trunk allowed 25
+interface 1/1/2
+    vlan access 30
+"""
+    )
+
+    assert list(view.vlans) == [
+        Vlan(id=20, name="SERVERS"),
+        Vlan(id=25, name=None),
+        Vlan(id=30, name=None),
+    ]
+
+
+def test_bundle_properties() -> None:
+    view = _view_from_config(
+        """
+interface lag 48
+    description UPLINK LAG
+interface 1/1/47
+    lag 48
+interface 1/1/48
+    lag 48
+"""
+    )
+
+    bundle_view = view.interface_view_by_name("lag 48")
+    member_view = view.interface_view_by_name("1/1/47")
+    assert bundle_view is not None
+    assert member_view is not None
+    assert bundle_view.is_bundle is True
+    assert bundle_view.bundle_id == "48"
+    assert tuple(bundle_view.bundle_member_interfaces) == ("1/1/47", "1/1/48")
+    assert member_view.bundle_name == "lag 48"
+    assert member_view.parent_name == "lag 48"
+
+
+def test_bundle_properties_multi_chassis() -> None:
+    # Multi-word LAG names ("lag 1 multi-chassis") must still resolve the numeric
+    # bundle id, not the trailing "multi-chassis" word.
+    view = _view_from_config(
+        """
+interface lag 1 multi-chassis
+    description Test-Server
+interface 1/1/1
+    lag 1
+"""
+    )
+
+    bundle_view = view.interface_view_by_name("lag 1 multi-chassis")
+    member_view = view.interface_view_by_name("1/1/1")
+    assert bundle_view is not None
+    assert member_view is not None
+    assert bundle_view.is_bundle is True
+    assert bundle_view.bundle_id == "1"
+    assert bundle_view.bundle_name == "lag 1"
+    assert tuple(bundle_view.bundle_member_interfaces) == ("1/1/1",)
+    assert member_view.bundle_id == "1"
+    assert member_view.parent_name == "lag 1"
+
+
+def test_duplex_speed_and_poe_defaults() -> None:
+    view = _view_from_config("interface 1/1/1\n")
+
+    interface_view = view.interface_view_by_name("1/1/1")
+    assert interface_view is not None
+    assert interface_view.duplex == InterfaceDuplex.AUTO
+    assert interface_view.speed is None
+    assert interface_view.poe is True
+
+
+def test_unsupported_nac_client_limits() -> None:
+    view = _view_from_config("interface 1/1/1\n")
+
+    interface_view = view.interface_view_by_name("1/1/1")
+    assert interface_view is not None
+    with pytest.raises(NotImplementedError):
+        _ = interface_view.nac_max_dot1x_clients
+    with pytest.raises(NotImplementedError):
+        _ = interface_view.nac_max_mab_clients

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -3,6 +3,7 @@ from hier_config.child import HConfigChild
 from hier_config.constructors import get_hconfig
 from hier_config.models import Platform
 from hier_config.platforms.arista_eos.driver import HConfigDriverAristaEOS
+from hier_config.platforms.aruba_aoscx.driver import HConfigDriverArubaAOSCX
 from hier_config.platforms.cisco_ios.driver import HConfigDriverCiscoIOS
 from hier_config.platforms.cisco_nxos.driver import HConfigDriverCiscoNXOS
 from hier_config.platforms.cisco_xr.driver import HConfigDriverCiscoIOSXR
@@ -13,6 +14,7 @@ from hier_config.platforms.vyos.driver import HConfigDriverVYOS
 
 
 def test_get_hconfig_driver() -> None:
+    assert isinstance(get_hconfig_driver(Platform.ARUBA_AOSCX), HConfigDriverArubaAOSCX)
     assert isinstance(get_hconfig_driver(Platform.ARISTA_EOS), HConfigDriverAristaEOS)
     assert isinstance(get_hconfig_driver(Platform.CISCO_IOS), HConfigDriverCiscoIOS)
     assert isinstance(get_hconfig_driver(Platform.CISCO_NXOS), HConfigDriverCiscoNXOS)

--- a/tests/test_driver_aruba_aoscx.py
+++ b/tests/test_driver_aruba_aoscx.py
@@ -1,0 +1,282 @@
+from hier_config import WorkflowRemediation, get_hconfig
+from hier_config.models import Platform
+
+
+def _remediation_text(running: str, intended: str) -> str:
+    workflow = WorkflowRemediation(
+        get_hconfig(Platform.ARUBA_AOSCX, running),
+        get_hconfig(Platform.ARUBA_AOSCX, intended),
+    )
+    return "\n".join(
+        line.cisco_style_text()
+        for line in workflow.remediation_config.all_children_sorted()
+    )
+
+
+def test_interface_vlan_trunk_allowed_is_additive() -> None:
+    # AOS-CX trunk allowed lists are additive: the driver splits them into one
+    # VLAN per line, so remediation adds the missing VLAN and negates the extras
+    # individually while leaving VLANs already present (26) untouched.
+    running = """
+interface 1/1/1
+    vlan trunk allowed 20,21,26
+"""
+    intended = """
+interface 1/1/1
+    vlan trunk allowed 25,26
+"""
+
+    assert _remediation_text(running, intended).strip() == (
+        "interface 1/1/1\n"
+        "  no vlan trunk allowed 20\n"
+        "  no vlan trunk allowed 21\n"
+        "  vlan trunk allowed 25"
+    )
+
+
+def test_interface_vlan_trunk_allowed_expands_ranges() -> None:
+    running = """
+interface 1/1/1
+    vlan trunk allowed 20-21,26
+"""
+    intended = """
+interface 1/1/1
+    vlan trunk allowed 25-26
+"""
+
+    assert _remediation_text(running, intended).strip() == (
+        "interface 1/1/1\n"
+        "  no vlan trunk allowed 20\n"
+        "  no vlan trunk allowed 21\n"
+        "  vlan trunk allowed 25"
+    )
+
+
+def test_interface_vlan_trunk_allowed_emits_minimal_delta() -> None:
+    # A small change to a large trunk list (add 166, remove 1522) must produce
+    # only that delta, not a full negate-and-re-add of the whole list. Also
+    # covers multi-word interface names like a multi-chassis LAG.
+    running = """
+interface lag 1 multi-chassis
+    vlan trunk allowed 554,1520-1522,2236,2240,3232
+"""
+    intended = """
+interface lag 1 multi-chassis
+    vlan trunk allowed 554,166,1520-1521,2236,2240,3232
+"""
+
+    assert _remediation_text(running, intended).strip() == (
+        "interface lag 1 multi-chassis\n"
+        "  no vlan trunk allowed 1522\n"
+        "  vlan trunk allowed 166"
+    )
+
+
+def test_aruba_aoscx_splits_top_level_vlan_lists() -> None:
+    config = get_hconfig(
+        Platform.ARUBA_AOSCX,
+        """
+vlan 1,10
+vlan 100-102
+""",
+    )
+
+    assert tuple(line.cisco_style_text() for line in config.all_children_sorted()) == (
+        "vlan 1",
+        "vlan 10",
+        "vlan 100",
+        "vlan 101",
+        "vlan 102",
+    )
+
+
+def test_aruba_aoscx_top_level_vlan_lists_match_individual_vlans() -> None:
+    running = """
+vlan 1,10
+"""
+    intended = """
+vlan 1
+vlan 10
+"""
+
+    assert not _remediation_text(running, intended).strip()
+
+
+def test_aruba_aoscx_collapsed_vlan_header_with_children_is_left_untouched() -> None:
+    # A collapsed range that carries configuration is left as-is rather than
+    # fanning a non-unique `name` onto every expanded VLAN (which the device
+    # rejects). Real collapsed ranges are unnamed/childless.
+    config = get_hconfig(
+        Platform.ARUBA_AOSCX,
+        """
+vlan 10-12
+    name USERS
+""",
+    )
+
+    assert tuple(line.cisco_style_text() for line in config.all_children_sorted()) == (
+        "vlan 10-12",
+        "  name USERS",
+    )
+
+
+def test_aruba_aoscx_trunk_overlapping_spec_is_not_destructive() -> None:
+    # An overlapping/duplicated trunk spec de-duplicates and splits, rather than
+    # staying collapsed and forcing a remove-and-re-add on an additive trunk.
+    running = """
+interface 1/1/1
+    vlan trunk allowed 20-22,21
+"""
+    intended = """
+interface 1/1/1
+    vlan trunk allowed 20
+    vlan trunk allowed 21
+    vlan trunk allowed 22
+"""
+
+    assert not _remediation_text(running, intended).strip()
+
+
+def test_aruba_aoscx_leaves_unparseable_vlan_range_untouched() -> None:
+    config = get_hconfig(Platform.ARUBA_AOSCX, "vlan 10-\n")
+
+    assert tuple(line.cisco_style_text() for line in config.all_children_sorted()) == (
+        "vlan 10-",
+    )
+
+
+def test_aruba_aoscx_leaves_empty_trunk_spec_untouched() -> None:
+    # A trunk line whose spec expands to nothing must not be deleted, otherwise
+    # the interface looks like it has no allowed VLANs at all.
+    config = get_hconfig(
+        Platform.ARUBA_AOSCX,
+        """
+interface 1/1/1
+    vlan trunk allowed ,
+""",
+    )
+    interface = config.get_child(equals="interface 1/1/1")
+    assert interface is not None
+    assert [child.text for child in interface.children] == ["vlan trunk allowed ,"]
+
+
+def test_aruba_aoscx_orders_new_vlans_before_interfaces() -> None:
+    # A newly created VLAN must sort ahead of the interface that references it.
+    running = """
+interface 1/1/1
+    vlan access 10
+"""
+    intended = """
+vlan 40
+    name NEW
+interface 1/1/1
+    vlan access 40
+"""
+    text = _remediation_text(running, intended)
+    assert text.index("vlan 40") < text.index("interface 1/1/1")
+
+
+def test_aruba_aoscx_top_level_vlan_lists_remove_only_extra_vlans() -> None:
+    running = """
+vlan 1,10,20
+"""
+    intended = """
+vlan 1
+vlan 10
+"""
+
+    assert _remediation_text(running, intended).strip() == "no vlan 20"
+
+
+def test_aruba_aoscx_strips_terminal_prompt_lines() -> None:
+    config = get_hconfig(
+        Platform.ARUBA_AOSCX,
+        """
+cx-switch# show run
+hostname cx-switch
+cx-switch(config)# interface 1/1/1
+interface 1/1/1
+    description #P3# Test
+cx-switch(config-if)# vlan trunk allowed 500
+""",
+    )
+
+    assert tuple(line.cisco_style_text() for line in config.all_children_sorted()) == (
+        "hostname cx-switch",
+        "interface 1/1/1",
+        "  description #P3# Test",
+    )
+
+
+def test_aruba_aoscx_replaces_single_value_interface_commands() -> None:
+    running = """
+interface 1/1/1
+    description OLD
+    vlan access 10
+interface vlan 10
+    ip address 10.0.0.2/24
+"""
+    intended = """
+interface 1/1/1
+    description USER-PORT
+    vlan access 20
+interface vlan 10
+    ip address 10.0.0.3/24
+"""
+
+    assert _remediation_text(running, intended).strip() == (
+        "interface 1/1/1\n"
+        "  description USER-PORT\n"
+        "  vlan access 20\n"
+        "interface vlan 10\n"
+        "  ip address 10.0.0.3/24"
+    )
+
+
+def test_aruba_aoscx_evpn_section_adds_and_removes_vlans() -> None:
+    # EVPN is remediated like any other section (Arista/NXOS style): individual
+    # VLANs are added or negated, while unchanged children such as
+    # arp-suppression and vlan 10 are left untouched.
+    running = """
+evpn
+    arp-suppression
+    vlan 10
+        rd auto
+    vlan 20
+        rd auto
+"""
+    intended = """
+evpn
+    arp-suppression
+    vlan 10
+        rd auto
+    vlan 30
+        rd auto
+"""
+
+    assert _remediation_text(running, intended).strip() == (
+        "evpn\n  no vlan 20\n  vlan 30\n    rd auto"
+    )
+
+
+def test_aruba_aoscx_vxlan_section_adds_and_removes_vnis() -> None:
+    running = """
+interface vxlan 1
+    no shutdown
+    vni 100010
+        vlan 10
+    vni 100020
+        vlan 20
+"""
+    intended = """
+interface vxlan 1
+    no shutdown
+    vni 100010
+        vlan 10
+    vni 100030
+        vlan 30
+"""
+
+    assert _remediation_text(running, intended).strip() == (
+        "interface vxlan 1\n  no vni 100020\n  vni 100030\n    vlan 30"
+    )

--- a/tests/test_driver_cisco_ios.py
+++ b/tests/test_driver_cisco_ios.py
@@ -174,6 +174,48 @@ def test_non_vlan_id_line_not_split_on_load() -> None:
     )
 
 
+def test_vlan_id_list_with_overlap_splits_without_negation() -> None:
+    """An overlapping collapsed list (vlan 10,10-12) de-duplicates and splits cleanly."""
+    running_config = get_hconfig(Platform.CISCO_IOS, "vlan 10,10-12\n")
+    assert [c.text for c in running_config.children] == [
+        "vlan 10",
+        "vlan 11",
+        "vlan 12",
+    ]
+    generated_config = get_hconfig(Platform.CISCO_IOS, "vlan 10\nvlan 11\nvlan 12\n")
+    remediation = running_config.config_to_get_to(generated_config).dump_simple()
+    assert not any(line.lstrip().startswith("no vlan") for line in remediation)
+
+
+def test_malformed_vlan_range_left_untouched() -> None:
+    """A malformed range (vlan 1-2-3) is left collapsed rather than silently truncated."""
+    config = get_hconfig(Platform.CISCO_IOS, "vlan 1-2-3\n")
+    assert config.get_child(equals="vlan 1-2-3") is not None
+    assert config.get_child(equals="vlan 1") is None
+
+
+def test_reversed_vlan_range_left_untouched() -> None:
+    """A reversed range (vlan 5-3,7) must not silently drop the reversed segment."""
+    config = get_hconfig(Platform.CISCO_IOS, "vlan 5-3,7\n")
+    assert config.get_child(equals="vlan 5-3,7") is not None
+    assert config.get_child(equals="vlan 7") is None
+
+
+def test_cisco_ios_trunk_allowed_vlan_not_split() -> None:
+    """Cisco trunk membership is declarative, not additive: the trunk line stays a
+    single command. Only AOS-CX splits `vlan trunk allowed` one VLAN per line.
+    """
+    config = get_hconfig(
+        Platform.CISCO_IOS,
+        "interface GigabitEthernet0/1\n switchport trunk allowed vlan 150-166\n",
+    )
+    interface = config.get_child(equals="interface GigabitEthernet0/1")
+    assert interface is not None
+    assert [c.text for c in interface.children] == [
+        "switchport trunk allowed vlan 150-166"
+    ]
+
+
 def test_vlan_id_list_rename_is_not_destructive() -> None:
     """Renaming one VLAN in a collapsed list must not negate the whole list."""
     running_config = get_hconfig(Platform.CISCO_IOS, "vlan 69,381\n")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -94,6 +94,10 @@ def test_load_hier_config_tags_empty_file(tmp_path: Path) -> None:
 def test_hconfig_v2_os_v3_platform_mapper() -> None:
     # Valid mappings
     assert hconfig_v2_os_v3_platform_mapper("ios") == Platform.CISCO_IOS
+    assert hconfig_v2_os_v3_platform_mapper("aruba_aoscx") == Platform.ARUBA_AOSCX
+    # Surrounding whitespace must not defeat the lookup (real network_driver
+    # mappings have been seen with a trailing space).
+    assert hconfig_v2_os_v3_platform_mapper("aruba_aoscx ") == Platform.ARUBA_AOSCX
     assert hconfig_v2_os_v3_platform_mapper("nxos") == Platform.CISCO_NXOS
     assert hconfig_v2_os_v3_platform_mapper("junos") == Platform.JUNIPER_JUNOS
     assert hconfig_v2_os_v3_platform_mapper("nokia_srl") == Platform.NOKIA_SRL
@@ -102,6 +106,7 @@ def test_hconfig_v2_os_v3_platform_mapper() -> None:
 
 def test_hconfig_v3_platform_v2_os_mapper() -> None:
     # Valid mappings
+    assert hconfig_v3_platform_v2_os_mapper(Platform.ARUBA_AOSCX) == "aruba_aoscx"
     assert hconfig_v3_platform_v2_os_mapper(Platform.CISCO_IOS) == "ios"
     assert hconfig_v3_platform_v2_os_mapper(Platform.CISCO_NXOS) == "nxos"
     assert hconfig_v3_platform_v2_os_mapper(Platform.JUNIPER_JUNOS) == "junos"


### PR DESCRIPTION
Adds support for the **Aruba AOS-CX** platform (`Platform.ARUBA_AOSCX`): a new driver and config view, unit tests, and circular remediation/rollback fixtures.

AOS-CX uses a Cisco IOS/EOS-like hierarchical CLI with `no` negation, so the driver reuses the standard tree model and remediation. The one platform-specific behavior is that **`vlan trunk allowed` is additive** on AOS-CX rather than declarative:

- Comma/range VLAN lists (`vlan trunk allowed 10,20-22`) are split into one VLAN per line via `post_load_callbacks`, on both the running and intended configs. Remediation then adds a missing VLAN with `vlan trunk allowed <id>` and removes an extra one with `no vlan trunk allowed <id>` — the minimal delta, matching how the device behaves. No re-collapse on output.
- Unnamed collapsed VLAN headers (`vlan 1,10`, `vlan 100-102`) are split into individual `vlan <id>` sections the same way.
- All other sections, including `evpn` and `interface vxlan`, are remediated with the standard rule framework (individual members added or negated, siblings untouched) — like Arista/NX-OS.

The v2→v3 os-name mapper gains a single `aruba_aoscx` entry (the netutils `network_driver_mappings["hier_config"]` value that nautobot-golden-config passes to `hconfig_v2_os_v3_platform_mapper()`), and strips surrounding whitespace from its input so a stray space resolves correctly instead of silently falling back to `Platform.GENERIC`.

### Testing
`python scripts/build.py lint-and-test` passes (ruff, mypy, pyright, pylint, pytest ≥95% coverage, yamllint, flynt).