### PR TITLE
Add future_with_report() for explicit negation-resolution audit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `HConfig.future_with_report()` returns the predicted future config together
+  with a frozen `FutureReport` listing unresolved negations (negations that
+  matched nothing in the running config) and idempotency-tracked negation
+  replacements, so change-validation pipelines can assert
+  `not report.unresolved_negations` instead of grepping the render for
+  `no ` lines (#285).
 - Migration guide for v3 → v4 upgrades (`docs/user/migrating-from-v3.md`):
   rename tables for constructors, methods, and utilities, the unified
   negation rule mapping, exception and config-view changes, and behavior

--- a/docs/dev/api-reference.md
+++ b/docs/dev/api-reference.md
@@ -58,6 +58,8 @@ Auto-generated reference documentation for the `hier_config` public API. Signatu
 
 ::: hier_config.ChangeDetail
 
+::: hier_config.FutureReport
+
 ---
 
 ## Driver System

--- a/docs/user/future-config.md
+++ b/docs/user/future-config.md
@@ -32,7 +32,25 @@ If you receive a `DuplicateChildError` while calling `merge()`, consider whether
 - **Exact negation** — a `no <command>` whose positive form exists in the running config removes that command; neither line survives in the prediction. This is evaluated before the idempotency rules, so an idempotency rule that happens to match the negation text cannot accidentally keep it as a literal child.
 - **Shorthand negation** — a valueless negation such as `no description` removes the valued lines it matches (`description foo`), just as the device CLI does.
 - **Idempotency-tracked negated forms** — when a negated form is itself tracked by an idempotency rule (e.g. IOS `no logging console`), it replaces its counterpart and *persists* in the rendered future config, because the device stores it as explicit configuration.
-- **Unmatched negations** — a negation that matches nothing in the running config is kept in the output as a signal that the change would not apply cleanly.
+- **Unmatched negations** — a negation that matches nothing in the running config is kept in the output as a signal that the change would not apply cleanly. Use [`future_with_report()`](#auditing-negation-resolution) to detect these explicitly instead of scanning the render.
+
+## Auditing negation resolution
+
+`HConfig.future_with_report()` behaves exactly like `future()` but also returns a `FutureReport` describing how the change's negations resolved:
+
+```python
+future_config, report = running_config.future_with_report(change_config)
+
+report.unresolved_negations      # negations that matched nothing in the running config
+report.idempotency_replacements  # negations that displaced an idempotency-tracked line but persist
+```
+
+Change-validation pipelines can assert `not report.unresolved_negations` instead of grepping the rendered output for `no ` lines. Both fields hold `HConfigChild` nodes that live in the returned future config tree, so `path()` and `lineage()` give the surrounding context:
+
+```python
+for negation in report.unresolved_negations:
+    print(" > ".join(negation.path()))
+```
 
 ## Pruning emptied sections
 

--- a/docs/user/migrating-from-v3.md
+++ b/docs/user/migrating-from-v3.md
@@ -177,6 +177,8 @@ Not required for migration, but these are the headline additions:
   [custom drivers](../dev/creating-drivers.md).
 - Built-in post-load callbacks are public functions removable by identity —
   see [Customizing Driver Rules](../admin/customizing-rules.md#customizing-post-load-callbacks).
+- `HConfig.future_with_report()` — predict a future config and get a
+  `FutureReport` of [how the change's negations resolved](future-config.md#auditing-negation-resolution).
 
 ## Next steps
 

--- a/hier_config/__init__.py
+++ b/hier_config/__init__.py
@@ -26,6 +26,7 @@ from .registry import (
 )
 from .reporting import RemediationReporter
 from .root import HConfig
+from .tree_algorithms import FutureReport
 from .workflows import WorkflowRemediation
 
 __all__ = (
@@ -33,6 +34,7 @@ __all__ = (
     "ConfigViewInterfaceBase",
     "DriverNotFoundError",
     "DuplicateChildError",
+    "FutureReport",
     "HConfig",
     "HConfigChild",
     "HConfigDriverBase",

--- a/hier_config/root.py
+++ b/hier_config/root.py
@@ -9,7 +9,6 @@ from .models import Dump, DumpLine, Platform, ReferenceLocation
 from .tree_algorithms import (
     FutureReport,
     compute_difference,
-    compute_future,
     compute_future_with_report,
     compute_remediation,
     compute_with_tags,
@@ -299,10 +298,10 @@ class HConfig(HConfigBase):  # ruff:ignore[too-many-public-methods]
         removed, matching devices that prune empty stanzas on commit; sections
         that were already empty are kept.
         """
-        future_config = HConfig(self.driver)
-        compute_future(self, config, future_config)
-        if prune_empty_branches:
-            prune_emptied_branches(self, future_config)
+        future_config, _ = self.future_with_report(
+            config,
+            prune_empty_branches=prune_empty_branches,
+        )
         return future_config
 
     def future_with_report(

--- a/hier_config/root.py
+++ b/hier_config/root.py
@@ -7,8 +7,10 @@ from .base import HConfigBase
 from .child import HConfigChild
 from .models import Dump, DumpLine, Platform, ReferenceLocation
 from .tree_algorithms import (
+    FutureReport,
     compute_difference,
     compute_future,
+    compute_future_with_report,
     compute_remediation,
     compute_with_tags,
     prune_emptied_branches,
@@ -302,6 +304,28 @@ class HConfig(HConfigBase):  # ruff:ignore[too-many-public-methods]
         if prune_empty_branches:
             prune_emptied_branches(self, future_config)
         return future_config
+
+    def future_with_report(
+        self,
+        config: HConfig,
+        *,
+        prune_empty_branches: bool = False,
+    ) -> tuple[HConfig, FutureReport]:
+        """EXPERIMENTAL - like `future()`, but also report how negations resolved.
+
+        Returns the predicted future config together with a `FutureReport`
+        whose `unresolved_negations` are negations that matched nothing in
+        self and `idempotency_replacements` are negations that displaced an
+        idempotency-tracked line but persist in the render. Both hold nodes
+        of the returned future config tree. Change-validation pipelines can
+        assert `not report.unresolved_negations` instead of grepping the
+        render for negation lines.
+        """
+        future_config = HConfig(self.driver)
+        report = compute_future_with_report(self, config, future_config)
+        if prune_empty_branches:
+            prune_emptied_branches(self, future_config)
+        return future_config, report
 
     def with_tags(self, tags: Iterable[str]) -> HConfig:
         """Returns a new instance recursively containing children that only have a subset of tags."""

--- a/hier_config/tree_algorithms.py
+++ b/hier_config/tree_algorithms.py
@@ -9,6 +9,7 @@ so they can be tested and extended independently of the tree structure.
 
 from __future__ import annotations
 
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, TypeVar
 
 if TYPE_CHECKING:
@@ -17,6 +18,58 @@ if TYPE_CHECKING:
     from .root import HConfig
 
     _HConfigRootOrChildT = TypeVar("_HConfigRootOrChildT", bound=HConfig | HConfigChild)
+
+
+@dataclass(frozen=True, slots=True)
+class FutureReport:
+    """How `HConfig.future_with_report()` resolved a change's negations (#285).
+
+    The nodes reference the returned future config tree, so `path()` and
+    `lineage()` give the surrounding context.
+    """
+
+    unresolved_negations: tuple[HConfigChild, ...]
+    idempotency_replacements: tuple[HConfigChild, ...]
+
+
+def _new_child_list() -> list[HConfigChild]:
+    return []
+
+
+@dataclass(slots=True)
+class _FutureReportBuilder:
+    """Mutable collector threaded through the `compute_future` recursion."""
+
+    unresolved_negations: list[HConfigChild] = field(default_factory=_new_child_list)
+    idempotency_replacements: list[HConfigChild] = field(
+        default_factory=_new_child_list,
+    )
+
+    def record_unresolved(self, node: HConfigChild) -> None:
+        """Record a kept negation that matched nothing in the source config."""
+        self.unresolved_negations.append(node)
+
+    def record_idempotency(self, node: HConfigChild, *, is_negation: bool) -> None:
+        """Record a persisting idempotency replacement when it is a negation."""
+        if is_negation:
+            self.idempotency_replacements.append(node)
+
+    def build(self) -> FutureReport:
+        return FutureReport(
+            unresolved_negations=tuple(self.unresolved_negations),
+            idempotency_replacements=tuple(self.idempotency_replacements),
+        )
+
+
+def compute_future_with_report(
+    source: HConfigBase,
+    config: HConfig | HConfigChild,
+    future_config: HConfig | HConfigChild,
+) -> FutureReport:
+    """Compute the future config subtree and report how negations resolved."""
+    report = _FutureReportBuilder()
+    compute_future(source, config, future_config, report=report)
+    return report.build()
 
 
 def compute_remediation(
@@ -171,6 +224,8 @@ def compute_future(  # ruff:ignore[complex-structure]
     source: HConfigBase,
     config: HConfig | HConfigChild,
     future_config: HConfig | HConfigChild,
+    *,
+    report: _FutureReportBuilder | None = None,
 ) -> None:
     """Recursively compute the future configuration subtree.
 
@@ -185,6 +240,7 @@ def compute_future(  # ruff:ignore[complex-structure]
     - Idempotent command avoid list
     - And likely other edge cases
     """
+    report = report or _FutureReportBuilder()
     negated_or_recursed, config_children_ignore = _future_pre(source, config)
 
     for config_child in config.children:
@@ -212,7 +268,10 @@ def compute_future(  # ruff:ignore[complex-structure]
             config_child,
             source.children,
         ):
-            future_config.add_deep_copy_of(config_child)
+            report.record_idempotency(
+                future_config.add_deep_copy_of(config_child),
+                is_negation=is_negation,
+            )
             negated_or_recursed.add(self_child.text)
         # Shorthand negation: `no description` removes `description foo`, as
         # devices do (#269).
@@ -229,13 +288,13 @@ def compute_future(  # ruff:ignore[complex-structure]
         # config_child is already in source
         elif self_child := source.get_child(equals=config_child.text):
             future_child = future_config.add_shallow_copy_of(self_child)
-            compute_future(self_child, config_child, future_child)
+            compute_future(self_child, config_child, future_child, report=report)
             negated_or_recursed.add(config_child.text)
         # A negation matching nothing is kept: it accounts for "no ..." lines
         # native to the running config and doubles as a did-not-apply-cleanly
         # signal for callers (#269).
         elif is_negation:
-            future_config.add_shallow_copy_of(config_child)
+            report.record_unresolved(future_config.add_shallow_copy_of(config_child))
         # The negated form of config_child is in source.children
         elif self_child := source.get_child(
             equals=f"{source.driver.negation_prefix}{config_child.text}",

--- a/tests/integration/test_remediation.py
+++ b/tests/integration/test_remediation.py
@@ -1,6 +1,11 @@
 """Integration tests for remediation, future, difference, and sectional overwrite."""
 
+from dataclasses import FrozenInstanceError
+
+import pytest
+
 from hier_config import (
+    FutureReport,
     HConfig,
     HConfigChild,
     WorkflowRemediation,
@@ -655,3 +660,169 @@ def test_future_prune_keeps_originally_empty_parents() -> None:
         "hostname r1",
         "interface GigabitEthernet0/0/0/0",
     )
+
+
+def test_future_with_report_flags_unresolved_negation() -> None:
+    """A negation matching nothing is reported as unresolved (#285)."""
+    running_config = HConfig.from_text(
+        Platform.ARISTA_EOS, "interface Ethernet1\n   switchport access vlan 10\n"
+    )
+    change = HConfig.from_text(
+        Platform.ARISTA_EOS, "interface Ethernet1\n no description\n"
+    )
+    future_config, report = running_config.future_with_report(change)
+
+    assert future_config.to_lines() == (
+        "interface Ethernet1",
+        "  no description",
+        "  switchport access vlan 10",
+    )
+    assert len(report.unresolved_negations) == 1
+    assert tuple(report.unresolved_negations[0].path()) == (
+        "interface Ethernet1",
+        "no description",
+    )
+    assert not report.idempotency_replacements
+
+
+def test_future_with_report_clean_change_is_empty() -> None:
+    """Exact-match and shorthand negations resolve without report entries (#285)."""
+    running_config = HConfig.from_text(
+        Platform.ARISTA_EOS,
+        "router bgp 65000\n"
+        "   neighbor 10.0.0.1 peer group PEERS\n"
+        "interface Ethernet1\n"
+        "   description foo\n"
+        "   switchport access vlan 10\n",
+    )
+    change = HConfig.from_text(
+        Platform.ARISTA_EOS,
+        "router bgp 65000\n"
+        " no neighbor 10.0.0.1 peer group PEERS\n"
+        "interface Ethernet1\n"
+        " no description\n",
+    )
+    _, report = running_config.future_with_report(change)
+
+    assert not report.unresolved_negations
+    assert not report.idempotency_replacements
+
+
+def test_future_with_report_records_idempotency_replacement() -> None:
+    """A stale-valued negation that persists via idempotency is reported (#285)."""
+    running_config = HConfig.from_text(
+        Platform.ARISTA_EOS,
+        "router bgp 65000\n   neighbor 10.0.0.1 description spine1\n",
+    )
+    change = HConfig.from_text(
+        Platform.ARISTA_EOS,
+        "router bgp 65000\n no neighbor 10.0.0.1 description stale-value\n",
+    )
+    future_config, report = running_config.future_with_report(change)
+
+    bgp = future_config.get_child(equals="router bgp 65000")
+    assert bgp is not None
+    rendered = bgp.get_child(equals="no neighbor 10.0.0.1 description stale-value")
+    assert rendered is not None
+    assert len(report.idempotency_replacements) == 1
+    assert report.idempotency_replacements[0] is rendered
+    assert not report.unresolved_negations
+
+
+def test_future_with_report_ignores_positive_idempotent_replacement() -> None:
+    """A positive-form idempotent value update is not a signal (#285)."""
+    running_config = HConfig.from_text(
+        Platform.ARISTA_EOS,
+        "router bgp 65000\n   neighbor 10.0.0.1 description spine1\n",
+    )
+    change = HConfig.from_text(
+        Platform.ARISTA_EOS,
+        "router bgp 65000\n neighbor 10.0.0.1 description new-value\n",
+    )
+    future_config, report = running_config.future_with_report(change)
+
+    assert future_config.to_lines() == (
+        "router bgp 65000",
+        "  neighbor 10.0.0.1 description new-value",
+    )
+    assert not report.unresolved_negations
+    assert not report.idempotency_replacements
+
+
+def test_future_with_report_accumulates_across_sections() -> None:
+    """Unresolved negations are collected across recursed sections (#285)."""
+    running_config = HConfig.from_text(
+        Platform.ARISTA_EOS,
+        "interface Ethernet1\n"
+        "   switchport access vlan 10\n"
+        "interface Ethernet2\n"
+        "   switchport access vlan 20\n",
+    )
+    change = HConfig.from_text(
+        Platform.ARISTA_EOS,
+        "interface Ethernet1\n no description\ninterface Ethernet2\n no shutdown\n",
+    )
+    _, report = running_config.future_with_report(change)
+
+    assert tuple(
+        tuple(negation.path()) for negation in report.unresolved_negations
+    ) == (
+        ("interface Ethernet1", "no description"),
+        ("interface Ethernet2", "no shutdown"),
+    )
+
+
+def test_future_with_report_survives_pruning() -> None:
+    """Reported nodes remain live in the pruned future tree (#285)."""
+    running_config = HConfig.from_text(
+        Platform.ARISTA_EOS, "interface Ethernet1\n   switchport access vlan 10\n"
+    )
+    change = HConfig.from_text(
+        Platform.ARISTA_EOS, "interface Ethernet1\n no description\n"
+    )
+    future_config, report = running_config.future_with_report(
+        change, prune_empty_branches=True
+    )
+
+    assert len(report.unresolved_negations) == 1
+    interface = future_config.get_child(equals="interface Ethernet1")
+    assert interface is not None
+    assert report.unresolved_negations[0] is interface.get_child(
+        equals="no description"
+    )
+
+
+def test_future_with_report_output_matches_future() -> None:
+    """future_with_report() renders identically to future() (#285)."""
+    running_text = (
+        "router bgp 65000\n"
+        "   neighbor 10.0.0.1 peer group PEERS\n"
+        "   neighbor 10.0.0.1 description spine1\n"
+        "interface Ethernet1\n"
+        "   description foo\n"
+    )
+    change_text = (
+        "router bgp 65000\n"
+        " no neighbor 10.0.0.1 peer group PEERS\n"
+        " no neighbor 10.0.0.1 description stale-value\n"
+        "interface Ethernet1\n"
+        " no description\n"
+        " no shutdown\n"
+    )
+    for prune in (False, True):
+        running_config = HConfig.from_text(Platform.ARISTA_EOS, running_text)
+        change = HConfig.from_text(Platform.ARISTA_EOS, change_text)
+        expected = running_config.future(change, prune_empty_branches=prune).to_lines()
+        future_config, _ = running_config.future_with_report(
+            change, prune_empty_branches=prune
+        )
+
+        assert future_config.to_lines() == expected
+
+
+def test_future_report_is_frozen() -> None:
+    """FutureReport is immutable once built (#285)."""
+    report = FutureReport(unresolved_negations=(), idempotency_replacements=())
+
+    with pytest.raises(FrozenInstanceError):
+        report.unresolved_negations = ()  # type: ignore[misc]


### PR DESCRIPTION
## Summary

Implements #285 (follow-on to #269). Targets `next` for v4.0.0.

`future()` resolves negations in explicit tiers (exact match → idempotency replace → shorthand prefix → keep-as-signal), but a leftover literal `no ...` line was the only way a caller could detect a negation that did not apply cleanly — change-validation pipelines had to grep the render for `no ` lines.

- **`HConfig.future_with_report(config, *, prune_empty_branches=False)`** returns `tuple[HConfig, FutureReport]`; `future()` is byte-identical (no overloads or union returns under strict typing).
- **`FutureReport`** (exported from `hier_config`) is a frozen slotted dataclass:
  - `unresolved_negations` — negations that matched nothing in the running config (the keep-as-signal tier)
  - `idempotency_replacements` — negation-form lines that displaced an idempotency-tracked line but persist in the render (e.g. IOS `no logging console`); positive-form idempotent value updates are normal changes and are excluded
  - Both hold `HConfigChild` nodes living in the returned future tree, so `path()`/`lineage()` give context. A dataclass rather than a Pydantic model because `HConfigChild` is a plain slotted class and the repo convention forbids `arbitrary_types_allowed`.
- Collection threads a private `_FutureReportBuilder` through the `compute_future` recursion via a keyword-only parameter; `compute_future_with_report()` keeps the builder private to `tree_algorithms`.
- Report nodes are never removed by `prune_empty_branches=True`: pruning only deletes childless nodes whose running-config counterpart had children, which cannot match a kept negation or a persisting replacement (covered by test).

## Testing

TDD: 8 new integration tests written first (failed on missing import), covering unresolved detection with lineage, clean-change empty report, idempotency-replacement identity with the rendered node, positive-form exclusion, accumulation across recursed sections, pruning interaction, render identity with `future()`, and report immutability.

- `poetry run ./scripts/build.py lint-and-test` exits 0 (757 passed, coverage 97.08%)
- `poetry run mkdocs build --strict` passes

## Docs & changelog

- `docs/user/future-config.md` — new "Auditing negation resolution" section, cross-linked from the unmatched-negations bullet
- `docs/dev/api-reference.md` — `FutureReport` in the Reporting group
- `docs/user/migrating-from-v3.md` — "New in v4" bullet
- `CHANGELOG.md` — Unreleased → Added (#285)

Closes #285