### PR TITLE
Canonicalize registry keys to uppercase platform names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,9 +35,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   their driver modules (e.g. `remove_ipv4_acl_remarks` in
   `hier_config.platforms.cisco_ios.driver`), so a built-in callback can be
   removed by identity with `rules.post_load_callbacks.remove(...)` (#286).
+- The driver registry is keyed internally on canonical uppercase platform
+  names; `Platform` members are converted via their names at the boundary, so
+  a member and its name are fully interchangeable in `register_driver`,
+  `unregister_driver`, and `get_hconfig_driver`. `get_registered_platforms()`
+  returns `Platform` members for enum-known names and uppercase strings for
+  custom names (#284).
 
 ### Fixed
 
+- Registering a driver under a `Platform` member's *value* string (e.g. `"3"`,
+  the value of `Platform.CISCO_IOS`) no longer silently overwrites that
+  platform's built-in registry entry, and value strings no longer resolve in
+  platform lookups — platforms are identified by name (#284).
 - `future()` negation edge cases (#269): a negation whose positive form exists
   in the running config now removes it without surviving as a literal `no ...`
   child (evaluated before the idempotency rules, which can match the negation

--- a/docs/admin/custom-drivers.md
+++ b/docs/admin/custom-drivers.md
@@ -94,6 +94,8 @@ config = HConfig.from_text("MY_NOS", config_text)
 config = HConfig.from_text("my_nos", config_text)  # same driver
 ```
 
+Names are canonicalized to uppercase, and a `Platform` member is interchangeable with its name — `register_driver("cisco_ios", ...)` and `register_driver(Platform.CISCO_IOS, ...)` address the same entry.
+
 The registry is not synchronized — register drivers at application startup, before configs are parsed concurrently.
 
 ### Overriding a built-in driver
@@ -130,6 +132,8 @@ from hier_config import get_registered_platforms
 print(get_registered_platforms())
 # (Platform.ARISTA_EOS, Platform.CISCO_IOS, ..., 'MY_NOS')
 ```
+
+Names known to the `Platform` enum are returned as members; custom names are returned as canonical uppercase strings.
 
 ## Using an unregistered driver instance
 

--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -113,11 +113,11 @@ See the [Driver Rule Reference](rule-reference.md) for every model's fields.
 
 ### Registry (`hier_config/registry.py`)
 
-Built-in drivers are registered at import time in a module-level registry mapping `Platform | str` → driver class:
+Built-in drivers are registered at import time in a module-level registry keyed on canonical uppercase platform names — `Platform` members are converted via their `.name`, string names are uppercased, so a member and its name address the same entry (#284):
 
 - `register_driver(platform, driver_class)` — add a custom platform (string names, case-insensitive) or override a built-in.
 - `unregister_driver(platform)` — remove a custom platform or restore an overridden built-in.
-- `get_registered_platforms()` — list everything registered.
+- `get_registered_platforms()` — list everything registered: `Platform` members for enum-known names, uppercase strings for custom names.
 - `get_hconfig_driver(platform)` — instantiate the registered driver.
 - `resolve_driver(platform_or_driver)` — accept a `Platform`, string, or driver instance (used by every constructor).
 

--- a/hier_config/registry.py
+++ b/hier_config/registry.py
@@ -4,6 +4,10 @@ Built-in drivers are registered at import time. Users can register drivers for
 custom platforms (by string name), override built-in drivers, and restore
 built-in defaults by unregistering the override.
 
+Entries are keyed on canonical uppercase platform names (#284): `Platform`
+members are converted via their names at the boundary, and string names are
+uppercased, so a member and its name address the same entry.
+
 The registry is not synchronized; register drivers at application startup,
 before configs are parsed concurrently.
 """
@@ -25,33 +29,31 @@ from hier_config.platforms.juniper_junos.driver import HConfigDriverJuniperJUNOS
 from hier_config.platforms.nokia_srl.driver import HConfigDriverNokiaSRL
 from hier_config.platforms.vyos.driver import HConfigDriverVYOS
 
-_BUILTIN_DRIVERS: dict[Platform | str, type[HConfigDriverBase]] = {
-    Platform.ARISTA_EOS: HConfigDriverAristaEOS,
-    Platform.ARUBA_AOSCX: HConfigDriverArubaAOSCX,
-    Platform.CISCO_IOS: HConfigDriverCiscoIOS,
-    Platform.CISCO_NXOS: HConfigDriverCiscoNXOS,
-    Platform.CISCO_XR: HConfigDriverCiscoIOSXR,
-    Platform.FORTINET_FORTIOS: HConfigDriverFortinetFortiOS,
-    Platform.GENERIC: HConfigDriverGeneric,
-    Platform.HP_PROCURVE: HConfigDriverHPProcurve,
-    Platform.HP_COMWARE5: HConfigDriverHPComware5,
-    Platform.HUAWEI_VRP: HConfigDriverHuaweiVrp,
-    Platform.JUNIPER_JUNOS: HConfigDriverJuniperJUNOS,
-    Platform.NOKIA_SRL: HConfigDriverNokiaSRL,
-    Platform.VYOS: HConfigDriverVYOS,
+_BUILTIN_DRIVERS: dict[str, type[HConfigDriverBase]] = {
+    Platform.ARISTA_EOS.name: HConfigDriverAristaEOS,
+    Platform.ARUBA_AOSCX.name: HConfigDriverArubaAOSCX,
+    Platform.CISCO_IOS.name: HConfigDriverCiscoIOS,
+    Platform.CISCO_NXOS.name: HConfigDriverCiscoNXOS,
+    Platform.CISCO_XR.name: HConfigDriverCiscoIOSXR,
+    Platform.FORTINET_FORTIOS.name: HConfigDriverFortinetFortiOS,
+    Platform.GENERIC.name: HConfigDriverGeneric,
+    Platform.HP_PROCURVE.name: HConfigDriverHPProcurve,
+    Platform.HP_COMWARE5.name: HConfigDriverHPComware5,
+    Platform.HUAWEI_VRP.name: HConfigDriverHuaweiVrp,
+    Platform.JUNIPER_JUNOS.name: HConfigDriverJuniperJUNOS,
+    Platform.NOKIA_SRL.name: HConfigDriverNokiaSRL,
+    Platform.VYOS.name: HConfigDriverVYOS,
 }
 
-_registry: dict[Platform | str, type[HConfigDriverBase]] = dict(_BUILTIN_DRIVERS)
+_registry: dict[str, type[HConfigDriverBase]] = dict(_BUILTIN_DRIVERS)
 
 
-def _normalize(platform: Platform | str) -> Platform | str:
+def _normalize(platform: Platform | str) -> str:
+    # Platform must be checked first: it subclasses str, and its str content
+    # is the enum value, not the platform name.
     if isinstance(platform, Platform):
-        return platform
-    name = platform.upper()
-    try:
-        return Platform[name]
-    except KeyError:
-        return name
+        return platform.name
+    return platform.upper()
 
 
 def register_driver(
@@ -61,30 +63,37 @@ def register_driver(
     """Register a driver for a platform.
 
     Passing a string registers a custom platform usable anywhere a `Platform`
-    is accepted (names are case-insensitive). Passing an existing `Platform`
-    member overrides the built-in driver for that platform.
+    is accepted; names are canonicalized to uppercase, so registration and
+    lookup are case-insensitive. Passing an existing `Platform` member (or its
+    name — the two are interchangeable) overrides the built-in driver for
+    that platform.
     """
     _registry[_normalize(platform)] = driver_class
 
 
 def unregister_driver(platform: Platform | str) -> None:
     """Remove a custom platform, or restore an overridden built-in driver."""
-    platform = _normalize(platform)
-    if platform not in _registry:
+    name = _normalize(platform)
+    if name not in _registry:
         message = f"Unsupported platform: {platform}"
         raise DriverNotFoundError(message)
-    if isinstance(platform, Platform):
-        if _registry[platform] is _BUILTIN_DRIVERS[platform]:
-            message = f"Built-in platform {platform} is not overridden"
-            raise DriverNotFoundError(message)
-        _registry[platform] = _BUILTIN_DRIVERS[platform]
+    builtin = _BUILTIN_DRIVERS.get(name)
+    if builtin is None:
+        del _registry[name]
+    elif _registry[name] is builtin:
+        message = f"Built-in platform {platform} is not overridden"
+        raise DriverNotFoundError(message)
     else:
-        del _registry[platform]
+        _registry[name] = builtin
 
 
 def get_registered_platforms() -> tuple[Platform | str, ...]:
-    """Return all registered platforms, built-in and custom."""
-    return tuple(_registry)
+    """Return all registered platforms, built-in and custom.
+
+    Names matching a `Platform` member are returned as members; custom names
+    are returned as canonical uppercase strings.
+    """
+    return tuple(Platform.__members__.get(name, name) for name in _registry)
 
 
 def resolve_driver(

--- a/hier_config/registry.py
+++ b/hier_config/registry.py
@@ -81,7 +81,9 @@ def unregister_driver(platform: Platform | str) -> None:
     if builtin is None:
         del _registry[name]
     elif _registry[name] is builtin:
-        message = f"Built-in platform {platform} is not overridden"
+        # Format the canonical name: pre-3.11 f-strings render a str-Enum
+        # member as its meaningless value string.
+        message = f"Built-in platform {name} is not overridden"
         raise DriverNotFoundError(message)
     else:
         _registry[name] = builtin

--- a/tests/unit/test_registry.py
+++ b/tests/unit/test_registry.py
@@ -116,3 +116,59 @@ def test_unregister_builtin_without_override_raises() -> None:
     """A built-in platform without an override cannot be unregistered."""
     with pytest.raises(DriverNotFoundError, match="not overridden"):
         unregister_driver(Platform.CISCO_XR)
+
+
+def test_register_platform_value_does_not_collide_with_builtin() -> None:
+    """A Platform member's value string is a distinct custom key (#284)."""
+    register_driver(str(Platform.CISCO_IOS.value), _CustomDriver)
+    try:
+        assert get_hconfig_driver(Platform.CISCO_IOS).__class__ is (
+            HConfigDriverCiscoIOS
+        )
+    finally:
+        unregister_driver(str(Platform.CISCO_IOS.value))
+
+
+def test_platform_value_lookup_raises() -> None:
+    """Platform member value strings are not platform names (#284)."""
+    with pytest.raises(DriverNotFoundError, match="Unsupported platform"):
+        get_hconfig_driver(str(Platform.CISCO_IOS.value))
+
+
+def test_get_registered_platforms_includes_custom_names() -> None:
+    """Custom platforms are listed by their canonical uppercase name (#284)."""
+    register_driver("my_nos", _CustomDriver)
+    try:
+        assert [
+            platform
+            for platform in get_registered_platforms()
+            if not isinstance(platform, Platform)
+        ] == ["MY_NOS"]
+    finally:
+        unregister_driver("my_nos")
+
+
+def test_get_registered_platforms_returns_enum_members_for_builtins() -> None:
+    """Enum-known names are listed as Platform members, not strings (#284)."""
+    members = {
+        platform
+        for platform in get_registered_platforms()
+        if isinstance(platform, Platform)
+    }
+    assert members == set(Platform)
+
+
+def test_platform_name_string_interchangeable_with_member() -> None:
+    """A Platform member and its name address the same registry entry (#284)."""
+
+    class CustomIOSDriver(HConfigDriverCiscoIOS):
+        """Override registered by name string."""
+
+    register_driver("cisco_ios", CustomIOSDriver)
+    try:
+        assert isinstance(get_hconfig_driver(Platform.CISCO_IOS), CustomIOSDriver)
+    finally:
+        unregister_driver(Platform.CISCO_IOS)
+
+    driver = get_hconfig_driver(Platform.CISCO_IOS)
+    assert driver.__class__ is HConfigDriverCiscoIOS

--- a/tests/unit/test_registry.py
+++ b/tests/unit/test_registry.py
@@ -26,6 +26,10 @@ class _CustomDriver(HConfigDriverBase):
         return HConfigDriverRules()
 
 
+# The member's value string ("3"): a str-Enum artifact, not a platform name.
+_CISCO_IOS_VALUE = str(Platform.CISCO_IOS.value)
+
+
 def _assert_custom_platform_works() -> None:
     driver = get_hconfig_driver("MY_NOS")
     assert isinstance(driver, _CustomDriver)
@@ -120,19 +124,18 @@ def test_unregister_builtin_without_override_raises() -> None:
 
 def test_register_platform_value_does_not_collide_with_builtin() -> None:
     """A Platform member's value string is a distinct custom key (#284)."""
-    register_driver(str(Platform.CISCO_IOS.value), _CustomDriver)
+    register_driver(_CISCO_IOS_VALUE, _CustomDriver)
     try:
-        assert get_hconfig_driver(Platform.CISCO_IOS).__class__ is (
-            HConfigDriverCiscoIOS
-        )
+        driver = get_hconfig_driver(Platform.CISCO_IOS)
     finally:
-        unregister_driver(str(Platform.CISCO_IOS.value))
+        unregister_driver(_CISCO_IOS_VALUE)
+    assert driver.__class__ is HConfigDriverCiscoIOS
 
 
 def test_platform_value_lookup_raises() -> None:
     """Platform member value strings are not platform names (#284)."""
     with pytest.raises(DriverNotFoundError, match="Unsupported platform"):
-        get_hconfig_driver(str(Platform.CISCO_IOS.value))
+        get_hconfig_driver(_CISCO_IOS_VALUE)
 
 
 def test_get_registered_platforms_includes_custom_names() -> None:
@@ -160,13 +163,9 @@ def test_get_registered_platforms_returns_enum_members_for_builtins() -> None:
 
 def test_platform_name_string_interchangeable_with_member() -> None:
     """A Platform member and its name address the same registry entry (#284)."""
-
-    class CustomIOSDriver(HConfigDriverCiscoIOS):
-        """Override registered by name string."""
-
-    register_driver("cisco_ios", CustomIOSDriver)
+    register_driver("cisco_ios", _CustomDriver)
     try:
-        assert isinstance(get_hconfig_driver(Platform.CISCO_IOS), CustomIOSDriver)
+        assert isinstance(get_hconfig_driver(Platform.CISCO_IOS), _CustomDriver)
     finally:
         unregister_driver(Platform.CISCO_IOS)
 


### PR DESCRIPTION
## Summary

Implements #284. Targets `next` for v4.0.0 — an API-shape decision that is free to make now and breaking to make later.

The driver registry keyed entries by `Platform | str`, which leaked into the public API two ways: `get_registered_platforms()` returned an accidentally-mixed tuple, and custom names were silently uppercased. Exploration also surfaced a verified latent bug: `Platform` is a `str`-Enum with `auto()` values, so members hash/compare as stringified counters (`Platform.CISCO_IOS == "3"`) — `register_driver("3", X)` silently overwrote the built-in CISCO_IOS entry and `get_hconfig_driver("3")` resolved to the IOS driver.

- `_BUILTIN_DRIVERS` / `_registry` are now `dict[str, type[HConfigDriverBase]]` keyed on canonical uppercase names; `_normalize()` converts `Platform` members via `.name` and uppercases strings — a member and its name are fully interchangeable in `register_driver` / `unregister_driver` / `get_hconfig_driver`.
- `get_registered_platforms()` keeps its `tuple[Platform | str, ...]` signature with now-deterministic, documented semantics: `Platform` members for enum-known names (via exact-name `Platform.__members__` lookup — never value lookup), canonical uppercase strings for custom names.
- Value strings like `"3"` no longer collide with or resolve as platforms — they raise `DriverNotFoundError`.
- `DriverNotFoundError` messages now echo the caller's spelling rather than the normalized form.

No public signatures changed. Out of scope per the issue: `register_driver` validation, thread-safety, exporting `resolve_driver`.

## Testing

TDD: five new tests in `tests/unit/test_registry.py`; the collision test and the value-lookup test were observed failing on the pre-change code (custom driver returned for `Platform.CISCO_IOS`; `"3"` resolving instead of raising). The other three pin the listing semantics (custom names appear as uppercase strings, builtins as enum members) and member/name interchangeability with builtin restore. All existing registry tests pass unmodified.

- `poetry run ./scripts/build.py lint-and-test` exits 0 (762 passed, coverage ≥95%)
- `poetry run mkdocs build --strict` passes

## Docs & changelog

- `docs/dev/architecture.md` — registry section describes canonical uppercase-name keying and the listing semantics
- `docs/admin/custom-drivers.md` — member/name interchangeability and listing-return notes
- `hier_config/registry.py` docstrings (rendered into `docs/dev/api-reference.md` via mkdocstrings) document the canonicalization
- `CHANGELOG.md` — Changed (key canonicalization) + Fixed (value-string collision) entries (#284)

Closes #284