### PR TITLE
increment prerelease

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -909,14 +909,14 @@ files = [
 
 [[package]]
 name = "packaging"
-version = "26.2"
+version = "26.3"
 description = "Core utilities for Python packages"
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.9"
 groups = ["dev"]
 files = [
-    {file = "packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e"},
-    {file = "packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661"},
+    {file = "packaging-26.3-py3-none-any.whl", hash = "sha256:d7193f7c8e4e93f444fde0262bf90af30e16fa0ad0ad44cb553c87339b23cd1c"},
+    {file = "packaging-26.3.tar.gz", hash = "sha256:94edc256424af38762eb31306eed28beb9f0efc50a8837492c9d6fd6004aed79"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hier-config"
-version = "4.0.0b1"
+version = "4.0.0b2"
 description = "A network configuration query and comparison library, used to build remediation configurations."
 packages = [
     { include="hier_config", from="."},


### PR DESCRIPTION
# Summary

<!-- What does this PR change, and why? Link the related issue, e.g. "Closes #123". -->

## Self-Review Checklist

<!-- The full standards live in AGENTS.md and https://hier-config.readthedocs.io/en/latest/dev/contributing/ -->

- [ ] `poetry run ./scripts/build.py lint-and-test` passes locally (lint + 95% test coverage).
- [ ] Tests were written first (TDD) and cover the change, following the [testing conventions](https://hier-config.readthedocs.io/en/latest/dev/testing/).
- [ ] `CHANGELOG.md` has an entry under `## [Unreleased]` referencing this issue/PR (`(#NNN)`).
- [ ] Documentation is updated if public API or driver behavior changed (and `mkdocs build --strict` passes if docs were touched).
- [ ] Commit messages follow the [contributing guide](https://github.com/netdevops/hier_config/blob/master/CONTRIBUTING.md): imperative mood, subject ≤72 characters, body explains *why*.

## AI-Assisted Contributions

If this PR was written with an AI coding tool, review it against the repo standards before requesting review: Claude Code users can run the `hier-config-review` skill; other tools should be pointed at `AGENTS.md` and the [developer docs](https://hier-config.readthedocs.io/en/latest/dev/contributing/).
