### PR TITLE
Fix documentation, agent-instruction, and changelog gaps

### DIFF
--- a/.claude/skills/hier-config-new-driver/SKILL.md
+++ b/.claude/skills/hier-config-new-driver/SKILL.md
@@ -77,16 +77,18 @@ class HConfigDriverAcmeOS(HConfigDriverBase):
         )
 ```
 
-Replace `#` in the `per_line_sub` regex with the platform's actual comment token, and keep the `^\s*` anchor so indented comments are stripped too. Rules take `match_rules: tuple[MatchRule, ...]` (immutable — never lists). A minimal driver returning bare `HConfigDriverRules()` is valid; only add rules the platform needs. Public classes require docstrings.
+Replace `#` in the `per_line_sub` regex with the platform's actual comment token, and keep the `^\s*` anchor so indented comments are stripped too. Rules take `match_rules: tuple[MatchRule, ...]` (immutable — never lists), while the `HConfigDriverRules` *collection fields themselves* are intentionally `list[...]` as shown above (so built-in rules/callbacks can be removed by identity). A minimal driver returning bare `HConfigDriverRules()` is valid; only add rules the platform needs. Public classes require docstrings.
 
 ## Step 4: Register the Platform
 
 1. Add the member to the `Platform` enum in `hier_config/models.py` (alphabetical position). Note the enum uses `auto()`, so inserting a member renumbers everything after it — fine for in-repo use, but never rely on `Platform.value` for serialization.
-2. Add the mapping to the `_BUILTIN_DRIVERS` dict in `hier_config/registry.py` and import the driver class there. If the platform has a config view, set the `view_class` attribute on the driver.
+2. Add the mapping to the `_BUILTIN_DRIVERS` dict in `hier_config/registry.py` and import the driver class there. The key must be the canonical uppercase name string — `Platform.ACME_OS.name` — not the enum member (`_normalize()` canonicalizes lookups to `.name`, so a `Platform`-member key would be silently unreachable). If the platform has a config view, set the `view_class` attribute on the driver.
 
 ## Step 5: Document and Log
 
+- Add driver-level unit tests in `tests/unit/platforms/test_<platform>.py` (every recent driver has one; see `tests/unit/platforms/test_aruba_aoscx.py`). If the driver ships a config view, add `tests/unit/platforms/views/test_<platform>.py` too.
 - Add a driver section (behavior summary) and a platform-table row to `docs/admin/platforms.md`. Mark the status `Experimental` for a new driver.
+- If you introduced a new *rule type* (not just rule instances), document it in `docs/dev/rule-reference.md`.
 - Add a `CHANGELOG.md` entry under `## [Unreleased]` → `### Added`.
 
 ## Step 6: Run the Gates

--- a/.claude/skills/hier-config-review/SKILL.md
+++ b/.claude/skills/hier-config-review/SKILL.md
@@ -9,8 +9,11 @@ Review the current change set against this repository's standards and report fin
 
 ## Step 1: Establish the Diff
 
+Pick the base branch first: v4 work branches from `next`; only v3.x maintenance work branches from `master`. Diffing a `next`-based branch against `master` would include all of v4 and make the review meaningless.
+
 ```bash
-git diff master...HEAD --stat   # on a branch
+git diff "$(git merge-base origin/next HEAD)"...HEAD --stat   # v4 branch (the usual case)
+git diff "$(git merge-base origin/master HEAD)"...HEAD --stat # v3.x maintenance branch
 git diff HEAD --stat            # fall back: uncommitted work
 git diff --staged --stat        # fall back: staged only
 ```
@@ -26,11 +29,13 @@ poetry run ./scripts/build.py lint
 poetry run ./scripts/build.py pytest --coverage
 ```
 
-If docs/ or mkdocs.yml changed, also run:
+Also run the docs build — CI runs it unconditionally on every push/PR, not just when docs change:
 
 ```bash
 poetry run mkdocs build --strict
 ```
+
+Remember CI's test matrix covers Python 3.10–3.14: flag syntax or stdlib usage newer than 3.10 even if local checks pass.
 
 ## Step 3: Review by Category
 
@@ -39,7 +44,7 @@ Read the referenced doc before judging that category — the docs are the standa
 ### Models & Typing — read `docs/dev/code-style.md`
 
 - New Pydantic models subclass the local `BaseModel` (`hier_config/models.py`), never `pydantic.BaseModel` directly.
-- Model fields use `tuple`/`frozenset`, never `list`/`set`. Rule models use `match_rules: tuple[MatchRule, ...]`.
+- Model fields use `tuple`/`frozenset`, never `list`/`set`. Rule models use `match_rules: tuple[MatchRule, ...]`. Exception: the rule-collection fields on `HConfigDriverRules` are intentionally `list[...]` (removal-by-identity, #286) — do not flag them.
 - No `Any`, no missing annotations, no unjustified `# type: ignore` / `# noqa`.
 - Lint/coverage/type-checking configuration was not loosened.
 
@@ -53,8 +58,8 @@ Read the referenced doc before judging that category — the docs are the standa
 
 ### Driver & Rule Changes — read `docs/dev/creating-drivers.md` and `docs/dev/rule-reference.md`
 
-- New rule types: frozen model in `models.py` → named default factory + field on `HConfigDriverRules` → consumed in `child.py`/`root.py` → populated in drivers.
-- New platforms: `Platform` enum member, `_BUILTIN_DRIVERS` wiring in `hier_config/registry.py`, `view_class` on the driver if it has a config view, per-platform test file, and a driver section + table row in `docs/admin/platforms.md`.
+- New rule types: frozen model in `models.py` → named default factory + field on `HConfigDriverRules` → consumed in `child.py`/`root.py` → populated in drivers → documented in `docs/dev/rule-reference.md`.
+- New platforms: `Platform` enum member, `_BUILTIN_DRIVERS` wiring in `hier_config/registry.py` **keyed on `Platform.X.name`** (a `Platform`-member key is silently unreachable — `_normalize()` canonicalizes to uppercase name strings), `view_class` on the driver if it has a config view, per-platform test file, and a driver section + table row in `docs/admin/platforms.md`.
 
 ### Changelog
 

--- a/.claude/skills/hier-config-troubleshoot/SKILL.md
+++ b/.claude/skills/hier-config-troubleshoot/SKILL.md
@@ -40,6 +40,9 @@ Bisect: delete config lines until removing one more makes the symptom disappear.
 | Commands in an order the device rejects | Ordering weights | `ordering` rules (lower weight applies first) |
 | Junk lines in the tree (banners, comments, timestamps) | Load-time substitutions | `per_line_sub` / `full_text_sub` |
 | `future()` or rollback doesn't match real device behavior | Known algorithm limitations | `docs/user/future-config.md#known-limitations` — duplicate children and order-dependent sections (ACLs need sequence numbers) are documented limits |
+| Suspected unresolved negations or silent idempotent replacements in `future()` | Negation resolution ambiguity | Use `HConfig.future_with_report()` — the returned `FutureReport.unresolved_negations` / `.idempotency_replacements` name the exact nodes instead of you scanning the render |
+| JSON/XML config raises on `from_text()` / parses as gibberish | Structured input fed to the text parser (rejected by design) | Use `HConfig.from_json()` / `HConfig.from_xml()`; text constructors deliberately reject structured formats |
+| `InvalidConfigError: Attribute changes cannot be expressed as gNMI delete paths` (or the NETCONF equivalent) | Structured-rendering limitation on attribute-style (`@`-prefixed) changes | `hier_config/formats.py` (`hconfig_to_gnmi_json` / `hconfig_to_netconf_xml`); restructure the change as element updates |
 | Wrong platform behavior entirely | Wrong driver selected | Confirm the `Platform` enum member; `GENERIC` has almost no rules |
 
 Rule semantics reference: `docs/dev/rule-reference.md`. Layer responsibilities: `docs/dev/architecture.md`.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -4,21 +4,28 @@
 
 hier_config is a Python library that compares network device configurations (running vs intended) and generates minimal remediation commands by parsing config text into hierarchical trees. Runtime dependencies are deliberately minimal (`pydantic` only).
 
+## Branching
+
+`master` is the stable v3.x branch; `next` is the v4 development branch. All v4 features and breaking changes must target `next`, not `master`.
+
 ## Build & Test
 
 All commands use poetry (not pip):
 
 ```bash
-poetry run ./scripts/build.py lint-and-test   # what CI runs
-poetry run ./scripts/build.py pytest --coverage   # 95% coverage floor
+poetry run ./scripts/build.py lint          # CI lint step
+poetry run ./scripts/build.py pytest --coverage   # CI test step, 95% coverage floor
+poetry run ./scripts/build.py lint-and-test # both in one command
 ```
+
+CI also runs the test step across Python 3.10–3.14 (code must stay 3.10-compatible) and builds docs with `mkdocs build --strict` on every push/PR.
 
 ## Rules to Enforce in Review
 
 - **Pydantic models must subclass the project-local `BaseModel`** from `hier_config/models.py` (it sets `frozen=True, extra="forbid"`). Direct use of `pydantic.BaseModel` is a defect.
-- **Model fields use immutable collections only**: `tuple` and `frozenset`, never `list` or `set`. Rule models match config lineage with `match_rules: tuple[MatchRule, ...]`.
+- **Model fields use immutable collections only**: `tuple` and `frozenset`, never `list` or `set`. Rule models match config lineage with `match_rules: tuple[MatchRule, ...]`. Deliberate exception: the rule-collection fields on `HConfigDriverRules` are intentionally `list[...]` so built-in rules/callbacks can be removed by identity (#286) — do not flag them.
 - **Strict typing**: flag `Any`, missing annotations (including in tests), and `# type: ignore` / `# noqa` comments without a justifying reason. mypy and pyright both run in strict mode.
-- **Tests must accompany every code change** (the project follows TDD). Tests are flat functions — no test classes (benchmarks excepted). Driver behavior changes belong in `tests/integration/test_<platform>.py`; config view changes in `tests/unit/platforms/views/`.
+- **Tests must accompany every code change** (the project follows TDD). Tests are flat functions — no test classes (benchmarks excepted). Driver behavior changes belong in `tests/integration/test_<platform>.py`; driver unit tests in `tests/unit/platforms/`; config view changes in `tests/unit/platforms/views/`.
 - **Driver/rule changes need round-trip assertions**: build running + intended configs, assert the exact remediation output (`to_lines()`), and verify the rollback restores the original (no `unified_diff`).
 - **Fields on `HConfigDriverRules`** (`hier_config/platforms/driver_base.py`) use named module-level default factory functions, not lambdas.
 - **`CHANGELOG.md` must have an entry** under `## [Unreleased]` (Keep a Changelog categories: Added/Changed/Fixed/Removed, with an issue/PR reference like `(#209)`).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,12 +6,18 @@ This file is the canonical quick reference for AI coding agents (and humans) wor
 
 hier_config is a Python library that compares network device configurations (running vs intended) and generates minimal remediation commands. It parses config text into hierarchical trees and computes diffs respecting vendor-specific syntax rules. Runtime dependencies are deliberately minimal (`pydantic` only).
 
+## Branching Strategy
+
+- `master` — stable branch for v3.x releases and maintenance.
+- `next` — long-lived development branch for v4 work. All v4 features and breaking changes target this branch; base v4 branches on `next` and open PRs against `next`.
+- `2.3-lts` — legacy LTS maintenance branch; only targeted fixes for 2.3.x land there.
+
 ## Build & Test Commands
 
 All commands use **poetry** (not pip):
 
 ```bash
-# Full lint + test suite (what CI runs)
+# Full lint + test suite (equivalent to CI's lint + pytest --coverage steps)
 poetry run ./scripts/build.py lint-and-test
 
 # Lint only (ruff, mypy, pyright, pylint, yamllint, flynt — run in parallel)
@@ -33,17 +39,25 @@ poetry run pytest tests/integration/ -v
 # Auto-fix formatting
 poetry run ruff format hier_config tests scripts
 
-# Validate docs (required if docs/ or mkdocs.yml changed)
+# Validate docs (CI runs this unconditionally on every push/PR)
 poetry run mkdocs build --strict
+
+# Benchmarks (deselected by default via the `benchmark` marker)
+poetry run pytest -m benchmark -v -s
 ```
+
+CI facts that matter for changes:
+
+- **Python matrix**: CI tests on Python 3.10–3.14 and ruff targets `py310` — write 3.10-compatible syntax even though your local interpreter may be newer.
+- **Docs job**: CI builds docs with `mkdocs build --strict` on every push/PR using `docs/requirements.txt` (pip, not poetry). Adding an mkdocs plugin requires updating **both** `pyproject.toml` and `docs/requirements.txt`.
 
 ## Architecture in Brief
 
 Three-layer design — full detail in [docs/dev/architecture.md](docs/dev/architecture.md):
 
-- **Tree** (`base.py`, `root.py`, `child.py`, `children.py`, `tree_algorithms.py`): `HConfig` root and `HConfigChild` nodes; key operations `remediation()`, `future()`, `unified_diff()`, `to_lines()`. Constructors are classmethods: `HConfig.from_text()`, `HConfig.from_lines()`, `HConfig.from_dump()`.
-- **Driver** (`platforms/`): each platform subclasses `HConfigDriverBase` and overrides `_instantiate_rules()` returning `HConfigDriverRules` — typed, frozen Pydantic rule models matched against config lineage via `MatchRule` tuples. Drivers register in `registry.py` (`get_hconfig_driver()`, `register_driver()`) and expose their config view via the `view_class` attribute.
-- **Workflow** (`workflows.py`, `reporting.py`): `WorkflowRemediation` exposes `remediation_config` / `rollback_config`; `RemediationReporter` aggregates changes across devices.
+- **Tree** (`base.py`, `root.py`, `child.py`, `children.py`, `tree_algorithms.py`, `constructors.py`): `HConfig` root and `HConfigChild` nodes; key operations `remediation()`, `future()`, `future_with_report()`, `unified_diff()`, `to_lines()`. Constructors are classmethods: `HConfig.from_text()`, `HConfig.from_lines()`, `HConfig.from_dump()`, `HConfig.from_json()`, `HConfig.from_xml()`. Supporting modules: `formats.py` (JSON/XML ingestion and rendering, NETCONF `edit-config` XML, gNMI-style JSON via `GnmiRemediation`), `plugins.py` (`RemediationPlugin` extension point), `exceptions.py` (exception hierarchy under `HierConfigError`), `utils.py` (file/YAML rule loaders).
+- **Driver** (`platforms/`): each platform subclasses `HConfigDriverBase` and overrides `_instantiate_rules()` returning `HConfigDriverRules` — typed, frozen Pydantic rule models matched against config lineage via `MatchRule` tuples. Drivers register in `registry.py` (`get_hconfig_driver()`, `register_driver()`, `unregister_driver()`, `get_registered_platforms()`) and expose their config view via the `view_class` attribute. Registry keys are canonicalized to uppercase platform names (`Platform.X.name`); string lookups are case-insensitive (#284/#295).
+- **Workflow** (`workflows.py`, `reporting.py`): `WorkflowRemediation` exposes `remediation_config` / `rollback_config` plus structured renderings `remediation_netconf_xml()` / `remediation_json()`; `RemediationReporter` aggregates changes across devices.
 
 Supported platforms (`Platform` enum in `models.py`): ARISTA_EOS, ARUBA_AOSCX, CISCO_IOS, CISCO_NXOS, CISCO_XR, FORTINET_FORTIOS, GENERIC, HP_COMWARE5, HP_PROCURVE, HUAWEI_VRP, JUNIPER_JUNOS, NOKIA_SRL, VYOS.
 
@@ -51,7 +65,7 @@ Supported platforms (`Platform` enum in `models.py`): ARISTA_EOS, ARUBA_AOSCX, C
 
 These are enforced by CI and by reviewers; violations block merges:
 
-1. **Models**: always subclass the project-local `BaseModel` in `hier_config/models.py` (it sets `frozen=True, extra="forbid"`) — never `pydantic.BaseModel` directly. Model fields use immutable collections only (`tuple`, `frozenset`). Rule models match lineage with `match_rules: tuple[MatchRule, ...]`.
+1. **Models**: always subclass the project-local `BaseModel` in `hier_config/models.py` (it sets `frozen=True, extra="forbid"`) — never `pydantic.BaseModel` directly. Model fields use immutable collections only (`tuple`, `frozenset`). Rule models match lineage with `match_rules: tuple[MatchRule, ...]`. **Deliberate exception**: the rule-collection fields on `HConfigDriverRules` (`platforms/driver_base.py`) are intentionally `list[...]` so built-in rules and callbacks can be removed by identity (e.g. `rules.post_load_callbacks.remove(...)`, #286) — do not convert them to tuples.
 2. **Typing**: mypy strict + pyright strict. Full annotations everywhere, including tests. No `Any`, no unjustified `# type: ignore` or `# noqa`.
 3. **Lint**: ruff `select = ["ALL"]` with preview, line length 88. Never loosen lint or coverage configuration to make a change pass.
 4. **TDD**: write a failing test first, confirm it fails for the right reason, implement minimally, run the full suite. 95% coverage floor.
@@ -72,6 +86,9 @@ These are enforced by CI and by reviewers; violations block merges:
 | Understand the internals | [docs/dev/architecture.md](docs/dev/architecture.md) |
 | Dev environment setup, commit style, PR expectations | [CONTRIBUTING.md](CONTRIBUTING.md) |
 | Driver behavior reference | [docs/admin/platforms.md](docs/admin/platforms.md), [docs/admin/custom-drivers.md](docs/admin/custom-drivers.md), [docs/admin/customizing-rules.md](docs/admin/customizing-rules.md) |
+| Load rules/tags from YAML or JSON files | [docs/admin/rules-from-files.md](docs/admin/rules-from-files.md) |
+| Release process, prerelease versioning | [docs/admin/releases.md](docs/admin/releases.md) |
+| CI, Read the Docs, Renovate, redirect policy | [docs/admin/infrastructure.md](docs/admin/infrastructure.md) |
 
 ## Before Opening a PR
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+v4 design decisions, for the record:
+
+- `HConfig.remediation()` stays public (#223): it was deliberately renamed
+  from `config_to_get_to()` in #216 as the tree-level primitive;
+  `WorkflowRemediation` remains the recommended workflow API and already
+  validates driver compatibility (`IncompatibleDriverError`).
+- Drivers remain declaratively-configured with sanctioned imperative
+  extension points (#222): #220 removed the negation-related override needs;
+  `idempotent_for()`, `negate_with()`, and `config_preprocessor()` stay
+  overridable for logic that rules cannot express.
+- Config trees stay mutable (#224): full immutability would break the
+  callback/plugin mutation model for marginal benefit. The remediation
+  algorithms are guaranteed (and now tested) not to mutate their input
+  configs.
+
 ### Added
 
 - `HConfig.future_with_report()` returns the predicted future config together
@@ -21,43 +36,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   rename tables for constructors, methods, and utilities, the unified
   negation rule mapping, exception and config-view changes, and behavior
   changes to review.
-
-### Changed
-
-- Restructured the documentation into User, Administrator, and Developer
-  guides (`docs/user/`, `docs/admin/`, `docs/dev/`) with a rewritten landing
-  page, new pages for loading configurations and remediation workflows, and
-  content refreshed for the v4 API.
-- Old readthedocs.io URLs (both the original flat layout and the 3.7 `user/`
-  layout) keep working via the mkdocs-redirects plugin; CLAUDE.md was slimmed
-  to an overlay that imports `AGENTS.md` (#290).
-- Built-in driver post-load callbacks are now public functions exported from
-  their driver modules (e.g. `remove_ipv4_acl_remarks` in
-  `hier_config.platforms.cisco_ios.driver`), so a built-in callback can be
-  removed by identity with `rules.post_load_callbacks.remove(...)` (#286).
-- The driver registry is keyed internally on canonical uppercase platform
-  names; `Platform` members are converted via their names at the boundary, so
-  a member and its name are fully interchangeable in `register_driver`,
-  `unregister_driver`, and `get_hconfig_driver`. `get_registered_platforms()`
-  returns `Platform` members for enum-known names and uppercase strings for
-  custom names (#284).
-
-### Fixed
-
-- Registering a driver under a `Platform` member's *value* string (e.g. `"3"`,
-  the value of `Platform.CISCO_IOS`) no longer silently overwrites that
-  platform's built-in registry entry, and value strings no longer resolve in
-  platform lookups — platforms are identified by name (#284).
-- `future()` negation edge cases (#269): a negation whose positive form exists
-  in the running config now removes it without surviving as a literal `no ...`
-  child (evaluated before the idempotency rules, which can match the negation
-  line itself); shorthand negations (`no description`) remove the valued lines
-  they match, as devices do. Negations matching nothing are still kept as a
-  did-not-apply-cleanly signal, and idempotency-tracked negated forms (e.g.
-  IOS `no logging console`) still replace their counterpart and persist.
-
-### Added
-
 - `HConfig.future(..., prune_empty_branches=True)` removes sections that a
   change emptied out — matching devices that prune empty stanzas on commit —
   while keeping sections that were already empty (#269).
@@ -98,13 +76,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   entries keep their identity leaf), negations become xpath-ish `delete`
   paths with `[key=value]` selectors resolved against the running config,
   and attribute-level changes raise `InvalidConfigError`.
-
-### Fixed
-
-- XML ingestion keys an element whenever an identifying `list_keys` child
-  exists, not only when the tag repeats among siblings, so configs with
-  different list-entry counts diff surgically instead of deleting and
-  re-adding surviving entries (#232).
 
 - Structured config ingestion and rendering (#232): `HConfig.from_json()` /
   `HConfig.from_xml()` build config trees from JSON (e.g. OpenConfig) and XML
@@ -163,13 +134,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Structured config format detection (#232): `HConfig.from_text()` rejects XML
   and JSON input with a clear `InvalidConfigError`; set-style configs remain
   natively supported via the JunOS, VyOS, and Nokia SRL driver preprocessors.
-  Full XML/JSON ingestion is additive, post-4.0 roadmap work.
 - Custom exception hierarchy: `HierConfigError` base, `DriverNotFoundError`,
   `InvalidConfigError`, `IncompatibleDriverError` (#219). `DuplicateChildError`
   reparented under `HierConfigError`.
 
 ### Changed
 
+- Restructured the documentation into User, Administrator, and Developer
+  guides (`docs/user/`, `docs/admin/`, `docs/dev/`) with a rewritten landing
+  page, new pages for loading configurations and remediation workflows, and
+  content refreshed for the v4 API.
+- Old readthedocs.io URLs (both the original flat layout and the 3.7 `user/`
+  layout) keep working via the mkdocs-redirects plugin; CLAUDE.md was slimmed
+  to an overlay that imports `AGENTS.md` (#290).
+- Built-in driver post-load callbacks are now public functions exported from
+  their driver modules (e.g. `remove_ipv4_acl_remarks` in
+  `hier_config.platforms.cisco_ios.driver`), so a built-in callback can be
+  removed by identity with `rules.post_load_callbacks.remove(...)` (#286).
+- The driver registry is keyed internally on canonical uppercase platform
+  names; `Platform` members are converted via their names at the boundary, so
+  a member and its name are fully interchangeable in `register_driver`,
+  `unregister_driver`, and `get_hconfig_driver`. `get_registered_platforms()`
+  returns `Platform` members for enum-known names and uppercase strings for
+  custom names (#284).
 - Shared interface-view logic hoisted out of the five platform view files into
   concrete defaults on `ConfigViewInterfaceBase`, the capability mixins
   (parameterized by `_bundle_membership_prefix` / `_encapsulation_prefix`
@@ -229,6 +216,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Registering a driver under a `Platform` member's *value* string (e.g. `"3"`,
+  the value of `Platform.CISCO_IOS`) no longer silently overwrites that
+  platform's built-in registry entry, and value strings no longer resolve in
+  platform lookups — platforms are identified by name (#284).
+- `future()` negation edge cases (#269): a negation whose positive form exists
+  in the running config now removes it without surviving as a literal `no ...`
+  child (evaluated before the idempotency rules, which can match the negation
+  line itself); shorthand negations (`no description`) remove the valued lines
+  they match, as devices do. Negations matching nothing are still kept as a
+  did-not-apply-cleanly signal, and idempotency-tracked negated forms (e.g.
+  IOS `no logging console`) still replace their counterpart and persist.
+- XML ingestion keys an element whenever an identifying `list_keys` child
+  exists, not only when the tag repeats among siblings, so configs with
+  different list-entry counts diff surgically instead of deleting and
+  re-adding surviving entries (#232).
 - `port_number` no longer raises `ValueError` on slash-less interface names
   such as `Port-channel10`, `port-channel10`, `Bundle-Ether10`, and `Trk1`;
   it now derives from the letter-stripped `number` property on all platform
@@ -237,21 +239,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `IndexError` on degenerate single-word commands, and documented that dropping
   parameters when negating (`set description "Port 1"` → `unset description`) is
   intentional FortiOS semantics (#225).
-
-### v4 design decisions
-
-- `HConfig.remediation()` stays public (#223): it was deliberately renamed
-  from `config_to_get_to()` in #216 as the tree-level primitive;
-  `WorkflowRemediation` remains the recommended workflow API and already
-  validates driver compatibility (`IncompatibleDriverError`).
-- Drivers remain declaratively-configured with sanctioned imperative
-  extension points (#222): #220 removed the negation-related override needs;
-  `idempotent_for()`, `negate_with()`, and `config_preprocessor()` stay
-  overridable for logic that rules cannot express.
-- Config trees stay mutable (#224): full immutability would break the
-  callback/plugin mutation model for marginal benefit. The remediation
-  algorithms are guaranteed (and now tested) not to mutate their input
-  configs.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -216,6 +216,17 @@ v4 design decisions, for the record:
 
 ### Fixed
 
+- Documentation gap sweep: repaired doc examples that no longer ran or showed
+  wrong output (getting-started fixture path, tags filtering, the custom ACL
+  remediation `delete()` idiom, config-view and hierarchical-JunOS outputs);
+  removed the stale prerelease pin from the install page and added `--pre` to
+  the README install; propagated Aruba AOS-CX into the architecture and
+  config-view docs; documented the built-in post-load callbacks, the formats
+  module, `future_with_report()`, and the view data models in the API
+  reference and glossary; corrected agent instruction files (branching
+  strategy in `AGENTS.md`, the `HConfigDriverRules` mutable-list carve-out,
+  review-skill diff base, registry key format, CI Python matrix) and the
+  benchmarks per-file lint-ignore path (#297).
 - Registering a driver under a `Platform` member's *value* string (e.g. `"3"`,
   the value of `Platform.CISCO_IOS`) no longer silently overwrites that
   platform's built-in registry entry, and value strings no longer resolve in

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,18 +4,13 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 @AGENTS.md
 
-## Branching Strategy
-
-- `master` — stable branch for v3.x releases and maintenance.
-- `next` — long-lived development branch for v4 work. All v4 features and breaking changes target this branch. PRs for v4 work should be opened against `next`.
-
 ## Self-Review
 
 Before opening or finalizing a PR, run the `hier-config-review` skill (`/hier-config-review`). It checks the diff against the repo's standards — models/typing, tests/TDD/coverage, changelog, docs, and driver patterns — and reports findings by severity.
 
 ## Benchmarks
 
-Performance benchmarks are in `tests/benchmarks/test_benchmarks.py` and are **skipped by default** via the `benchmark` pytest marker. They generate ~10,000-line configs and measure parsing, remediation, and iteration performance.
+Performance benchmarks are in `tests/benchmarks/test_benchmarks.py` and are **deselected by default** (`addopts = "-m 'not benchmark'"` in `pyproject.toml`). They generate ~10,000-line configs and measure parsing, remediation, and iteration performance.
 
 ```bash
 # Run all benchmarks with timing output
@@ -25,6 +20,6 @@ poetry run pytest -m benchmark -v -s
 poetry run pytest -m benchmark -k test_parse_large_ios_config -v -s
 ```
 
-Use `-s` to see printed timing results. Each benchmark reports the best time over 3 iterations and asserts an upper bound (e.g., `< 5s` for parsing, `< 10s` for remediation). If a benchmark fails its time threshold, investigate the relevant code path for performance regressions.
+Use `-s` to see printed timing results. Each benchmark reports the best time over 3 iterations and asserts an upper bound (parsing `< 5s`; remediation `< 5s` small diff / `< 10s` large; iteration `< 2s`–`< 5s`). If a benchmark fails its time threshold, investigate the relevant code path for performance regressions.
 
 After running benchmarks, always display the results to the user in a table format summarizing each benchmark's config size and elapsed time.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,14 +18,17 @@ Set up your environment:
 ```
 cd hier_config
 poetry install
-poetry shell
+poetry shell   # Poetry 2.x: requires the shell plugin, or use `poetry run <cmd>` / `poetry env activate`
 ```
 
-Create a branch
+Create a branch from the right base: v4 features and breaking changes branch from **`next`**; v3.x maintenance fixes branch from **`master`**.
 
 ```
+git checkout next
 git checkout -b YOUR-BRANCH
 ```
+
+Open your pull request against the same branch you based on (`next` for v4 work).
 
 Make sure linters, type-checkers, and tests pass:
 
@@ -63,7 +66,7 @@ pytest
 Run a single test file:
 
 ```bash
-pytest tests/test_hconfig.py
+pytest tests/integration/test_cisco_ios.py
 ```
 
 Stop on the first failure:
@@ -88,12 +91,16 @@ pytest --cov=hier_config
 
 ## Running Linters Individually
 
+The build script runs all of these over `hier_config`, `tests`, and `scripts`:
+
 ```bash
 ruff check .                  # style + lint
 ruff format --check .         # formatting (no changes)
-mypy hier_config/             # type checking
-pyright hier_config/          # additional type checking
-pylint hier_config/           # extended lint rules
+mypy hier_config/ tests/ scripts/     # type checking
+pyright hier_config/ tests/ scripts/  # additional type checking
+pylint hier_config/ tests/ scripts/   # extended lint rules
+yamllint .                    # YAML files
+flynt -d -tc -f hier_config tests scripts  # f-string conversion check
 ```
 
 To auto-fix ruff issues:
@@ -126,8 +133,11 @@ NegationDefaultWithRule model so that the behaviour is preserved.
 
 ## PR Expectations
 
-- **Tests required** — all new behaviour must be covered by unit tests.
+- **Tests required** — all new behaviour must be covered by tests: unit tests in
+  `tests/unit/`, end-to-end driver scenarios in `tests/integration/test_<platform>.py`.
 - **Linting must pass** — `python scripts/build.py lint-and-test` must exit 0.
+- **Changelog entry required** — every PR adds an entry to `CHANGELOG.md` under
+  `## [Unreleased]` (Keep a Changelog categories, with a `(#NNN)` reference).
 - **Docstrings for new public API** — any new public class, method, or function
   must have a docstring.
 - **No breaking changes without discussion** — open an issue first if you plan to
@@ -144,7 +154,7 @@ Where do changes belong?
 | New platform support | `hier_config/platforms/<name>/driver.py` (subclass `HConfigDriverBase`) |
 | New rule type | `hier_config/models.py` (new `BaseModel` subclass) + `hier_config/platforms/driver_base.py` (`HConfigDriverRules` field) |
 | New utility function | `hier_config/utils.py` |
-| New view property | `hier_config/platforms/view_base.py` (abstract) + each platform's `view.py` |
+| New view property | `hier_config/platforms/view_base.py` (abstract) + the `view.py` of each platform that ships a view (currently 6 of 13 platforms) |
 | Core tree algorithm | `hier_config/base.py` (shared) or `hier_config/root.py` (`HConfig`-only) |
 
 Read the [Architecture Overview](docs/dev/architecture.md) before making structural changes.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ Hierarchical Configuration has been used extensively on:
 - [x] Cisco NXOS
 - [x] Arista EOS
 - [x] Fortinet FortiOS
-- [x] Aruba AOS-CX
 - [x] HP Procurve (Aruba AOSS)
 - [x] HP Comware5 / H3C
 - [x] Huawei VRP
@@ -19,6 +18,8 @@ In addition to the Cisco-style syntax, hier_config offers experimental support f
 - [x] Juniper JunOS
 - [x] Nokia SRL (Service Router Linux)
 - [x] VyOS
+
+Newer drivers start life as **experimental** until they have seen wider production use — currently Aruba AOS-CX joins the list above in that status. See [Supported Platforms](https://hier-config.readthedocs.io/en/latest/admin/platforms/) for the authoritative per-platform status.
 
 Hier Config is compatible with any NOS that utilizes a structured CLI syntax similar to Cisco IOS or Junos OS.
 
@@ -30,9 +31,11 @@ Network devices continuously drift from their intended state — VLANs appear, A
 
 ## Highlights
 
-- Predict the device state before deploying with [`future()`](https://hier-config.readthedocs.io/en/latest/user/future-config/) and generate accurate rollbacks that preserve distinct structural commands — BGP neighbor descriptions, for example, no longer collapse when multiple peers share a common prefix.
+- Predict the device state before deploying with [`future()`](https://hier-config.readthedocs.io/en/latest/user/future-config/) — and audit ambiguous negation resolution explicitly with `future_with_report()`.
 - Build remediation workflows with deterministic diffs across [Cisco-style](https://hier-config.readthedocs.io/en/latest/admin/platforms/) and [Junos-style](https://hier-config.readthedocs.io/en/latest/user/set-style-platforms/) configuration syntaxes.
+- Ingest and render structured configs: [JSON and XML loading](https://hier-config.readthedocs.io/en/latest/user/loading-configs/), NETCONF `edit-config` payloads, and gNMI-style JSON remediation.
 - Tag remediation lines and filter output with [tag-based rules](https://hier-config.readthedocs.io/en/latest/user/tags/) for phased or conditional deployment.
+- Extend the pipeline with [`RemediationPlugin` transforms](https://hier-config.readthedocs.io/en/latest/user/remediation-workflows/) and register [custom platform drivers](https://hier-config.readthedocs.io/en/latest/admin/custom-drivers/) at runtime.
 - Aggregate and analyse changes across a fleet with [RemediationReporter](https://hier-config.readthedocs.io/en/latest/user/remediation-reporting/).
 - Render structured, typed interface data with the [Config View](https://hier-config.readthedocs.io/en/latest/user/config-views/) abstraction.
 
@@ -42,11 +45,13 @@ See the [Architecture Overview](https://hier-config.readthedocs.io/en/latest/dev
 
 ### PIP
 
-Install from PyPi:
+Version 4 is currently published as a prerelease; pip skips prereleases by default, so pass `--pre`:
 
 ```shell
-pip install hier-config
+pip install --pre hier-config
 ```
+
+(The Quick Start below uses the v4 API. `pip install hier-config` without `--pre` installs the latest stable v3 release — see the [v3 documentation](https://hier-config.readthedocs.io/) for that API.)
 
 ## Quick Start
 

--- a/docs/admin/custom-drivers.md
+++ b/docs/admin/custom-drivers.md
@@ -130,7 +130,7 @@ Unregistering a platform that is not registered (or a built-in that is not overr
 from hier_config import get_registered_platforms
 
 print(get_registered_platforms())
-# (Platform.ARISTA_EOS, Platform.CISCO_IOS, ..., 'MY_NOS')
+# (<Platform.ARISTA_EOS: '1'>, <Platform.ARUBA_AOSCX: '2'>, ..., 'MY_NOS')
 ```
 
 Names known to the `Platform` enum are returned as members; custom names are returned as canonical uppercase strings.

--- a/docs/admin/customizing-rules.md
+++ b/docs/admin/customizing-rules.md
@@ -281,7 +281,7 @@ class HConfigDriverCiscoIOSKeepRemarks(HConfigDriverCiscoIOS):
 register_driver(Platform.CISCO_IOS, HConfigDriverCiscoIOSKeepRemarks)
 ```
 
-The same pattern works for adding callbacks (`rules.post_load_callbacks.append(my_callback)`) and for the remediation-stage equivalents in `rules.remediation_transform_callbacks` (see [Remediation Workflows](../user/remediation-workflows.md#the-remediation-transform-pipeline)).
+The same pattern works for adding callbacks (`rules.post_load_callbacks.append(my_callback)`) and for the remediation-stage equivalents in `rules.remediation_transform_callbacks` (see [Remediation Workflows](../user/remediation-workflows.md#the-remediation-transform-pipeline)). The full table of built-in post-load callbacks — which drivers ship them and what each one does — is in the [Driver Rule Reference](../dev/rule-reference.md#callbacks).
 
 ## Next steps
 

--- a/docs/admin/rules-from-files.md
+++ b/docs/admin/rules-from-files.md
@@ -58,7 +58,12 @@ Use the returned driver instance directly: `HConfig.from_text(driver, config_tex
 
 ### Supported option keys
 
-Each entry uses a `lineage` list of match criteria (`startswith`, `endswith`, `contains`, `equals`, `re_search`) that maps onto [`MatchRule`](../glossary.md#match-rule) tuples:
+Each entry uses a `lineage` list of match criteria (`startswith`, `endswith`, `contains`, `equals`, `re_search`) that maps onto [`MatchRule`](../glossary.md#match-rule) tuples.
+
+Two constraints to be aware of:
+
+- **One criterion per `lineage` entry.** The loader picks the first criterion it finds (checked in the order `startswith`, `endswith`, `contains`, `equals`, `re_search`) and silently ignores the rest — unlike a `MatchRule` built in Python, where multiple set fields AND together. Use `re_search` if a single entry needs compound matching.
+- **Built-in platforms only.** `load_driver_rules()` takes a `Platform` enum member; it does not accept the name string of a custom driver registered via `register_driver()`. Extend a custom driver in Python instead ([Custom Drivers](custom-drivers.md)).
 
 | YAML key | Resulting rule |
 |----------|----------------|

--- a/docs/dev/api-reference.md
+++ b/docs/dev/api-reference.md
@@ -30,6 +30,8 @@ Auto-generated reference documentation for the `hier_config` public API. Signatu
 
 ::: hier_config.get_registered_platforms
 
+::: hier_config.registry.resolve_driver
+
 ---
 
 ## Core Classes
@@ -39,6 +41,24 @@ Auto-generated reference documentation for the `hier_config` public API. Signatu
 ::: hier_config.HConfigChild
 
 ::: hier_config.children.HConfigChildren
+
+---
+
+## Future Config
+
+::: hier_config.HConfig.future
+
+::: hier_config.HConfig.future_with_report
+
+::: hier_config.FutureReport
+
+---
+
+## Structured Formats
+
+JSON/XML ingestion and rendering, NETCONF `edit-config` payloads, and gNMI-style JSON remediation. The module docstring below documents the tree↔structure mapping and its caveats.
+
+::: hier_config.formats
 
 ---
 
@@ -58,8 +78,6 @@ Auto-generated reference documentation for the `hier_config` public API. Signatu
 
 ::: hier_config.ChangeDetail
 
-::: hier_config.FutureReport
-
 ---
 
 ## Driver System
@@ -67,6 +85,28 @@ Auto-generated reference documentation for the `hier_config` public API. Signatu
 ::: hier_config.platforms.driver_base.HConfigDriverBase
 
 ::: hier_config.platforms.driver_base.HConfigDriverRules
+
+### Built-in post-load callbacks
+
+Public functions shipped by the built-in drivers (removable by identity — see [Customizing Driver Rules](../admin/customizing-rules.md#customizing-post-load-callbacks)):
+
+::: hier_config.platforms.cisco_ios.driver.remove_ipv6_acl_sequence_numbers
+
+::: hier_config.platforms.cisco_ios.driver.remove_ipv4_acl_remarks
+
+::: hier_config.platforms.cisco_ios.driver.add_acl_sequence_numbers
+
+::: hier_config.platforms.utils.split_vlan_id_lists
+
+::: hier_config.platforms.cisco_xr.driver.fixup_xr_comments
+
+::: hier_config.platforms.hp_procurve.driver.fixup_hp_procurve_aaa_port_access
+
+::: hier_config.platforms.hp_procurve.driver.fixup_hp_procurve_device_profile
+
+::: hier_config.platforms.hp_procurve.driver.fixup_hp_procurve_vlan
+
+::: hier_config.platforms.aruba_aoscx.driver.split_interface_vlan_trunk_allowed
 
 ---
 
@@ -83,6 +123,20 @@ Auto-generated reference documentation for the `hier_config` public API. Signatu
 ::: hier_config.InterfaceNACViewMixin
 
 ::: hier_config.InterfacePhysicalViewMixin
+
+### Typed view data models
+
+The value types returned by view properties:
+
+::: hier_config.platforms.models.Vlan
+
+::: hier_config.platforms.models.StackMember
+
+::: hier_config.platforms.models.InterfaceDot1qMode
+
+::: hier_config.platforms.models.InterfaceDuplex
+
+::: hier_config.platforms.models.NACHostMode
 
 ---
 

--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -126,6 +126,7 @@ Built-in drivers are registered at import time in a module-level registry keyed 
 | Platform enum | Driver class | Module |
 |--------------|-------------|--------|
 | `ARISTA_EOS` | `HConfigDriverAristaEOS` | `platforms/arista_eos/driver.py` |
+| `ARUBA_AOSCX` | `HConfigDriverArubaAOSCX` | `platforms/aruba_aoscx/driver.py` |
 | `CISCO_IOS` | `HConfigDriverCiscoIOS` | `platforms/cisco_ios/driver.py` |
 | `CISCO_NXOS` | `HConfigDriverCiscoNXOS` | `platforms/cisco_nxos/driver.py` |
 | `CISCO_XR` | `HConfigDriverCiscoIOSXR` | `platforms/cisco_xr/driver.py` |
@@ -179,7 +180,7 @@ Internally it calls `running_config.remediation(generated_config)` (which delega
 
 The view layer (`hier_config/platforms/view_base.py` and platform-specific `view.py` files) provides structured, typed access to configuration elements without modifying the underlying tree.
 
-- `HConfigViewBase` — abstract device-level base; subclasses implement `interface_views` and `dot1q_mode_from_vlans`.
+- `HConfigViewBase` — abstract device-level base; subclasses implement `hostname`, `interface_views`, `interfaces`, and `ipv4_default_gw` (`dot1q_mode_from_vlans` is a concrete static helper).
 - `ConfigViewInterfaceBase` — abstract per-interface base; exposes core properties like `name`, `description`, `enabled`, `ipv4_interfaces`, and `vrf`.
 - Optional capability mixins — `InterfaceBundleViewMixin` (`bundle_id`, `bundle_member_interfaces`, ...), `InterfaceVlanViewMixin` (`native_vlan`, `tagged_vlans`, `dot1q_mode`, ...), `InterfaceNACViewMixin` (`has_nac`, `nac_host_mode`, ...), and `InterfacePhysicalViewMixin` (`duplex`, `speed`, `poe`, `module_number`). Platform views inherit only the mixins they support; users check capability with `isinstance(view, InterfaceVlanViewMixin)`.
 

--- a/docs/dev/code-style.md
+++ b/docs/dev/code-style.md
@@ -18,7 +18,7 @@ The authoritative rule configuration lives in `pyproject.toml`. Do not add suppr
 ## Pydantic Model Conventions
 
 - **Always subclass the project-local `BaseModel`** defined in `hier_config/models.py` — never `pydantic.BaseModel` directly. The local base sets `ConfigDict(frozen=True, extra="forbid")`, making every model immutable and strict.
-- **Immutable collections only** in model fields: `tuple[...]` for ordered data, `frozenset[...]` for sets. Never `list` or `set`.
+- **Immutable collections only** in model fields: `tuple[...]` for ordered data, `frozenset[...]` for sets. Never `list` or `set`. Deliberate exception: the rule-collection fields on `HConfigDriverRules` are `list[...]` on purpose, so built-in rules and callbacks can be removed by identity (e.g. `rules.post_load_callbacks.remove(...)`) — do not convert them to tuples.
 - **Rule models** match configuration lineage with `match_rules: tuple[MatchRule, ...]`.
 - Fields on `HConfigDriverRules` use **named module-level default factory functions** (e.g., `_ordering_rules_default`) rather than lambdas, for strict-mode type checking.
 

--- a/docs/dev/contributing.md
+++ b/docs/dev/contributing.md
@@ -1,6 +1,6 @@
 # Contributing
 
-This page summarizes how to set up a development environment, run the checks that CI runs, and meet the project's expectations for pull requests. The authoritative reference is [CONTRIBUTING.md](https://github.com/netdevops/hier_config/blob/master/CONTRIBUTING.md) in the repository root.
+This page summarizes how to set up a development environment, run the checks that CI runs, and meet the project's expectations for pull requests. The authoritative reference is [CONTRIBUTING.md](https://github.com/netdevops/hier_config/blob/next/CONTRIBUTING.md) in the repository root.
 
 ## Development setup
 

--- a/docs/dev/creating-drivers.md
+++ b/docs/dev/creating-drivers.md
@@ -198,11 +198,10 @@ Idempotency matching is structural: `idempotent_for` builds an *idempotency key*
 
 To give the platform a typed [config view](../user/config-views.md), implement the two view classes and point the driver at them.
 
-**1. Interface view** — subclass `ConfigViewInterfaceBase` plus the capability mixins the platform genuinely supports:
+**1. Interface view** — subclass the capability mixins the platform genuinely supports (each mixin already subclasses `ConfigViewInterfaceBase`, so listing the base explicitly is redundant — the in-tree views don't):
 
 ```python
 from hier_config.platforms.view_base import (
-    ConfigViewInterfaceBase,
     InterfaceBundleViewMixin,
     InterfaceVlanViewMixin,
 )
@@ -211,7 +210,6 @@ from hier_config.platforms.view_base import (
 class ConfigViewInterfaceCustomNOS(
     InterfaceBundleViewMixin,
     InterfaceVlanViewMixin,
-    ConfigViewInterfaceBase,
 ):
     """Typed view over one `interface ...` block."""
 
@@ -230,7 +228,7 @@ class ConfigViewInterfaceCustomNOS(
 
 Inheriting a mixin is a contract: `isinstance(view, InterfaceVlanViewMixin)` tells users the capability exists, so only inherit mixins whose properties the platform can actually populate.
 
-**2. Device view** — subclass `HConfigViewBase` and implement its abstract members (`hostname`, `interface_views`, `interfaces`, `ipv4_default_gw`, `dot1q_mode_from_vlans`, ...):
+**2. Device view** — subclass `HConfigViewBase` and implement its abstract members (`hostname`, `interface_views`, `interfaces`, `ipv4_default_gw`; `dot1q_mode_from_vlans` is a concrete static helper you can call, not implement):
 
 ```python
 from hier_config.platforms.view_base import HConfigViewBase

--- a/docs/dev/rule-reference.md
+++ b/docs/dev/rule-reference.md
@@ -170,6 +170,22 @@ NegationRule(
 
 Built-in driver callbacks are public functions exported from their driver modules (e.g. `hier_config.platforms.cisco_ios.driver.remove_ipv4_acl_remarks`), so they can be removed from the list by identity — see [Customizing Driver Rules](../admin/customizing-rules.md#customizing-post-load-callbacks).
 
+The complete set of built-in post-load callbacks:
+
+| Driver | Callback | What it does |
+|--------|----------|--------------|
+| Cisco IOS | `hier_config.platforms.cisco_ios.driver.remove_ipv6_acl_sequence_numbers` | Strips sequence numbers from IPv6 ACL entries so they diff by content |
+| Cisco IOS | `hier_config.platforms.cisco_ios.driver.remove_ipv4_acl_remarks` | Removes `remark` lines from IPv4 ACLs |
+| Cisco IOS | `hier_config.platforms.cisco_ios.driver.add_acl_sequence_numbers` | Adds sequence numbers to IPv4 ACL entries for valid negation |
+| Cisco IOS, Aruba AOS-CX | `hier_config.platforms.utils.split_vlan_id_lists` | Expands `vlan 1,3-5`-style ID lists into one node per VLAN |
+| Cisco XR | `hier_config.platforms.cisco_xr.driver.fixup_xr_comments` | Moves `!` comment lines into the next sibling's comments set |
+| HP ProCurve | `hier_config.platforms.hp_procurve.driver.fixup_hp_procurve_aaa_port_access` | Expands the interface ranges in `aaa port-access` commands |
+| HP ProCurve | `hier_config.platforms.hp_procurve.driver.fixup_hp_procurve_device_profile` | Separates `device-profile` tagged-vlans onto individual lines |
+| HP ProCurve | `hier_config.platforms.hp_procurve.driver.fixup_hp_procurve_vlan` | Moves native/tagged VLAN membership onto the interface config |
+| Aruba AOS-CX | `hier_config.platforms.aruba_aoscx.driver.split_interface_vlan_trunk_allowed` | Expands `vlan trunk allowed` lists into one node per VLAN |
+
+No built-in driver populates `remediation_transform_callbacks`; the list exists for customized and custom drivers.
+
 ---
 
 ## Rendering

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -20,6 +20,18 @@ A Python class that encodes all operating-system-specific behaviour for one netw
 
 ---
 
+## Driver registry / canonical platform name
+
+The runtime mapping from platform identifiers to driver classes (`hier_config/registry.py`): `register_driver()`, `unregister_driver()`, `get_registered_platforms()`, `get_hconfig_driver()`. Keys are canonicalized to the uppercase platform *name* (`Platform.CISCO_IOS.name` → `"CISCO_IOS"`), and string lookups are case-insensitive. Custom drivers registered under a string name coexist with the built-ins.
+
+---
+
+## Future config / FutureReport
+
+`HConfig.future(config)` predicts the configuration a device will have after a change is applied — used to validate remediations and build rollbacks offline. `HConfig.future_with_report(config)` returns the same tree plus a `FutureReport` naming the nodes where negation resolution was ambiguous (`unresolved_negations`) or an idempotent command was silently replaced (`idempotency_replacements`). See [Predicting Future Configs](user/future-config.md).
+
+---
+
 ## Idempotent command
 
 A configuration command where only the *last* value applied takes effect — applying the same command twice with different values results in only the second value being active. Typical examples: `hostname`, `ip address`, `description`.
@@ -50,6 +62,12 @@ A set of `IdempotentCommandsAvoidRule` entries that *prevent* specific commands 
 ## Indent adjust
 
 A pair of `IndentAdjustRule` entries (`start_expression` / `end_expression`) that temporarily shift the indentation level between the two markers. Used on Cisco IOS XR for inline templates whose body is indented differently from the surrounding context.
+
+---
+
+## List keys (`list_keys`)
+
+The tuple of leaf names that identify entries in structured (JSON/XML) list data — default `("name", "id")`. Used by `HConfig.from_json()` / `from_xml()` to give keyed list entries stable identities, and by `remediation_netconf_xml()` / `remediation_json()` to render deletions by key selector. Pass `list_keys=` when your data model keys lists on something else.
 
 ---
 
@@ -111,6 +129,18 @@ PerLineSubRule(search="^Building configuration.*", replace="")
 
 ---
 
+## Post-load / remediation-transform callbacks
+
+Two callback lists on `HConfigDriverRules`, each holding `Callable[[HConfig], None]` transforms that mutate a tree in place. `post_load_callbacks` run right after a config is parsed (built-in examples: `remove_ipv4_acl_remarks` on Cisco IOS, `fixup_xr_comments` on Cisco XR); the built-ins are public functions, so they can be removed by identity (`rules.post_load_callbacks.remove(...)`). `remediation_transform_callbacks` run over a freshly computed remediation — no built-in driver populates this list; it exists for customized drivers. See [Customizing Driver Rules](admin/customizing-rules.md).
+
+---
+
+## RemediationPlugin
+
+The abstract base class (`hier_config/plugins.py`) for reusable, named remediation transforms. Subclasses implement `name`, `description`, and `transform(remediation)`; instances are callable, so they work anywhere a plain `Callable[[HConfig], None]` does — most commonly the `plugins=` argument of `WorkflowRemediation`. Plugins express user/workflow policy; driver-level fixups belong in `remediation_transform_callbacks` instead. See [Remediation Workflows](user/remediation-workflows.md).
+
+---
+
 ## Sectional exiting
 
 A `SectionalExitingRule` that instructs hier_config to emit a closing token at the end of a configuration section when rendering output. Different platforms require different exit syntax.
@@ -158,6 +188,7 @@ The primary user-facing class for computing the delta between a running and an i
 - `remediation_config` — the commands to apply to bring the device into compliance.
 - `rollback_config` — the commands to revert the device back to its original state.
 - `remediation_netconf_xml()` — the remediation rendered as a NETCONF `edit-config` payload (for XML-sourced configs).
+- `remediation_json()` — the remediation rendered as a gNMI-SetRequest-style dict of update/delete sets (for JSON-sourced configs).
 - `apply_remediation_tag_rules()` — annotate remediation lines with tags.
 - `remediation_config_filtered_text()` — render a tagged subset of the remediation.
 - `plugins` — user-supplied transforms applied to the computed remediation.

--- a/docs/user/config-views.md
+++ b/docs/user/config-views.md
@@ -34,7 +34,7 @@ hconfig = HConfig.from_text(Platform.CISCO_IOS, raw_config)
 config_view = get_hconfig_view(hconfig)
 ```
 
-Platforms without a view raise `DriverNotFoundError`. Views are currently provided for Cisco IOS, Arista EOS, Cisco NX-OS, Cisco IOS XR, and HP ProCurve. (You can also import a platform view class directly, e.g. `from hier_config.platforms.cisco_ios.view import HConfigViewCiscoIOS`.)
+Platforms without a view raise `DriverNotFoundError`. Views are currently provided for Cisco IOS, Arista EOS, Cisco NX-OS, Cisco IOS XR, Aruba AOS-CX, and HP ProCurve. (You can also import a platform view class directly, e.g. `from hier_config.platforms.cisco_ios.view import HConfigViewCiscoIOS`.)
 
 ## The capability mixin model
 
@@ -55,7 +55,7 @@ for interface_view in config_view.interface_views:
         print(interface_view.name, interface_view.native_vlan)
 ```
 
-Current platform capabilities: Cisco IOS and HP ProCurve inherit all four mixins; Arista EOS, Cisco NX-OS, and Cisco IOS XR inherit the bundle and VLAN mixins.
+Current platform capabilities: Cisco IOS, HP ProCurve, and Aruba AOS-CX inherit all four mixins; Arista EOS, Cisco NX-OS, and Cisco IOS XR inherit the bundle and VLAN mixins.
 
 ## Device-level view properties
 
@@ -163,7 +163,6 @@ interface GigabitEthernet0/1
  description Uplink to Switch
  switchport access vlan 10
  switchport mode access
- ip address 192.168.1.1 255.255.255.0
  shutdown
 !
 interface GigabitEthernet0/2
@@ -196,11 +195,11 @@ Enabled: False
 Dot1Q Mode: InterfaceDot1qMode.ACCESS
 Native VLAN: 10
 Tagged VLANs: ()
-IP Address: 192.168.1.1/24
+IP Address: None
 Is Subinterface: False
 ----------------------------------------
 Interface Name: GigabitEthernet0/2
-Description: None
+Description: 
 Enabled: True
 Dot1Q Mode: InterfaceDot1qMode.TAGGED
 Native VLAN: None
@@ -209,6 +208,8 @@ IP Address: None
 Is Subinterface: False
 ----------------------------------------
 ```
+
+Note that `description` returns an empty string (not `None`) when no description is configured, and an interface configured as a routed port (with an `ip address`) reports `dot1q_mode` and `native_vlan` as `None` even if stale `switchport` lines remain.
 
 ## Next steps
 

--- a/docs/user/getting-started.md
+++ b/docs/user/getting-started.md
@@ -21,7 +21,7 @@ Use `HConfig.from_text()` to parse each configuration. The first argument select
 ```python
 # Load running and intended configurations from files
 >>> running_config_text = read_text_from_file("./tests/fixtures/running_config.conf")
->>> generated_config_text = read_text_from_file("./tests/fixtures/remediation_config.conf")
+>>> generated_config_text = read_text_from_file("./tests/fixtures/generated_config.conf")
 >>>
 
 # Create HConfig objects for running and intended configurations

--- a/docs/user/install.md
+++ b/docs/user/install.md
@@ -12,16 +12,16 @@ pip install hier-config
 
 ### Installing a prerelease (v4)
 
-Version 4 is currently published as a prerelease (`4.0.0b1`). Pip skips prereleases by default, so pass `--pre` to install it:
+Version 4 is currently published as a prerelease. Pip skips prereleases by default, so pass `--pre` to install it:
 
 ```bash
 pip install --pre hier-config
 ```
 
-Or pin the exact version:
+Or pin an exact version (see the [release history on PyPI](https://pypi.org/project/hier-config/#history) for the current prerelease):
 
 ```bash
-pip install hier-config==4.0.0b1
+pip install hier-config==<version>
 ```
 
 ## Install from source

--- a/docs/user/loading-configs.md
+++ b/docs/user/loading-configs.md
@@ -115,7 +115,7 @@ Entries without any of the named keys raise `InvalidConfigError`.
 
 Both mappings are invertible via `to_json()` / `to_xml()`, with a few caveats (documented in `hier_config.formats`): a single-item scalar list renders back as a bare scalar, and empty lists are dropped.
 
-Remediation between two `from_xml()` trees can also be rendered as a NETCONF `edit-config` payload — see [Remediation Workflows](remediation-workflows.md#netconf-remediation-payloads).
+Remediation between two `from_xml()` trees can also be rendered as a NETCONF `edit-config` payload, and remediation between two `from_json()` trees as a gNMI-style JSON payload — see [Remediation Workflows](remediation-workflows.md#netconf-remediation-payloads) and [gNMI-style JSON payloads](remediation-workflows.md#gnmi-style-json-remediation-payloads).
 
 ## Format detection errors
 

--- a/docs/user/migrating-from-v3.md
+++ b/docs/user/migrating-from-v3.md
@@ -185,5 +185,6 @@ Not required for migration, but these are the headline additions:
 - [Getting Started](getting-started.md) — the v4 workflow end to end.
 - [Customizing Driver Rules](../admin/customizing-rules.md) — if you carried
   v3 driver customizations.
-- Full change list: the 4.0.0 section of the
-  [CHANGELOG](https://github.com/netdevops/hier_config/blob/next/CHANGELOG.md).
+- Full change list: the Unreleased section of the
+  [CHANGELOG](https://github.com/netdevops/hier_config/blob/next/CHANGELOG.md)
+  (it becomes the 4.0.0 section at release).

--- a/docs/user/remediation-workflows.md
+++ b/docs/user/remediation-workflows.md
@@ -134,7 +134,7 @@ ip access-list extended TEST
 
 ```python
 invalid_remediation = wfr.remediation_config.get_child(equals="ip access-list extended TEST")
-wfr.remediation_config.delete_child(invalid_remediation)
+invalid_remediation.delete()
 wfr.remediation_config.merge(custom_remediation)
 ```
 
@@ -144,7 +144,7 @@ wfr.remediation_config.merge(custom_remediation)
 
 When `remediation_config` is first computed, hier_config runs two ordered sets of transforms over the result, each receiving the remediation `HConfig` and mutating it in place:
 
-1. **Driver-level transforms** — `driver.rules.remediation_transform_callbacks`, populated by platform drivers (or your customized driver) for platform-wide fixups.
+1. **Driver-level transforms** — `driver.rules.remediation_transform_callbacks`, a hook for platform-wide fixups. No built-in driver populates it today; it exists for customized and custom drivers.
 2. **User plugins** — the `plugins` argument of `WorkflowRemediation`, for organization policies and per-workflow behavior.
 
 ### Plain-callable plugins

--- a/docs/user/set-style-platforms.md
+++ b/docs/user/set-style-platforms.md
@@ -164,6 +164,12 @@ set interfaces irb unit 4 family inet address 10.0.4.1/16
 set interfaces irb unit 4 family inet filter input TEST
 set interfaces irb unit 4 family inet mtu 9000
 set interfaces irb unit 4 family inet description "switch_mgmt_10.0.4.0/24"
+set interfaces xe-0/0/0 description "bb01.lax01:Ethernet2; ID:YT661812121"
+set interfaces xe-0/0/0 mtu 9160
+set interfaces xe-0/0/0 unit 0 family iso
+set interfaces xe-0/0/0 unit 0 family mpls
+set interfaces xe-0/0/0 unit 0 family inet address 10.0.5.0/31
+set interfaces xe-0/0/0 unit 0 family inet6 address 2001:db8:5695::1/64
 >>>
 ```
 

--- a/docs/user/tags.md
+++ b/docs/user/tags.md
@@ -80,30 +80,21 @@ With a solid understanding of MatchRules, you can unlock more advanced capabilit
 
 Tagging builds on MatchRules by adding the **apply_tags** keyword to target specific configurations.
 
-For example, suppose your running configuration contains an NTP server setup like this:
-
-```text
-ntp server 192.0.2.1 prefer version 2
-```
-
-But your intended configuration uses publicly available NTP servers:
-
-```text
-ip name-server 1.1.1.1
-ip name-server 8.8.8.8
-ntp server time.nist.gov
-```
-
-You can create a MatchRule to tag this specific remediation with "ntp" as follows:
+For example, the repository's `tests/fixtures/tag_rules_ios.yml` labels low-risk changes (VLAN declarations, interface descriptions) with a `safe` tag and riskier changes (ACLs, IP addressing, MTU, shutdown state) with a `manual` tag. The `safe` rules look like this:
 
 ```yaml
 - match_rules:
+  - equals:
+    - no ip http secure-server
+    - no ip http server
+    - vlan
+    - no vlan
+  apply_tags: [safe]
+- match_rules:
+  - startswith: interface Vlan
   - startswith:
-    - ip name-server
-    - no ip name-server
-    - ntp
-    - no ntp
-  apply_tags: [ntp]
+    - description
+  apply_tags: [safe]
 ```
 
 With the tags loaded, you can create a targeted remediation based on those tags as follows:
@@ -130,17 +121,17 @@ wfr = WorkflowRemediation(
 # Apply the tag rules to label matching remediation sections
 wfr.apply_remediation_tag_rules(tags)
 
-# Display remediation steps filtered to include only the "ntp" tag
-print(wfr.remediation_config_filtered_text(include_tags={"ntp"}, exclude_tags={}))
+# Display remediation steps filtered to include only the "safe" tag
+print(wfr.remediation_config_filtered_text(include_tags={"safe"}, exclude_tags=set()))
 ```
 
-The resulting remediation output appears as follows:
+The resulting remediation output contains only the low-risk changes:
 
 ```text
-no ntp server 192.0.2.1 prefer version 2
-ip name-server 1.1.1.1
-ip name-server 8.8.8.8
-ntp server time.nist.gov
+interface Vlan3
+  description switch_mgmt_10.0.3.0/24
+interface Vlan4
+  description switch_mgmt_10.0.4.0/24
 ```
 
 `remediation_config_filtered_text()` accepts both `include_tags` and `exclude_tags`, so you can also render everything *except* a tag (for example, hold back `critical` changes).

--- a/hier_config/base.py
+++ b/hier_config/base.py
@@ -50,21 +50,21 @@ class HConfigBase(ABC):  # ruff:ignore[too-many-public-methods]
     @property
     @abstractmethod
     def root(self) -> HConfig:
-        pass
+        """The `HConfig` object at the base of the tree."""
 
     @property
     @abstractmethod
     def driver(self) -> HConfigDriverBase:
-        pass
+        """The platform driver associated with this tree."""
 
     @abstractmethod
     def lineage(self) -> Iterator[HConfigChild]:
-        pass
+        """Yield the lineage of parent objects, up to but excluding the root."""
 
     @property
     @abstractmethod
     def depth(self) -> int:
-        pass
+        """The distance to the root HConfig object i.e. indent level."""
 
     def add_children(self, lines: Iterable[str]) -> None:
         """Add child instances of HConfigChild."""
@@ -98,6 +98,7 @@ class HConfigBase(ABC):  # ruff:ignore[too-many-public-methods]
         return new_child
 
     def path(self) -> Iterator[str]:  # ruff:ignore[no-self-use]
+        """Yield the text of each lineage node; the root itself yields nothing."""
         yield from ()
 
     def add_deep_copy_of(
@@ -275,7 +276,10 @@ class HConfigBase(ABC):  # ruff:ignore[too-many-public-methods]
 
     @abstractmethod
     def instantiate_child(self, text: str) -> HConfigChild:
-        pass
+        """Create a new `HConfigChild` with self as the parent.
+
+        The child is not appended to `self.children`; use `add_child` for that.
+        """
 
     @abstractmethod
     def _is_duplicate_child_allowed(self) -> bool:

--- a/hier_config/child.py
+++ b/hier_config/child.py
@@ -90,10 +90,12 @@ class HConfigChild(  # ruff:ignore[too-many-public-methods]  pylint: disable=too
 
     @property
     def driver(self) -> HConfigDriverBase:
+        """The platform driver, inherited from the root HConfig object."""
         return self.root.driver
 
     @property
     def text(self) -> str:
+        """The configuration text of this node, stripped of surrounding whitespace."""
         return self._text
 
     @text.setter
@@ -106,6 +108,7 @@ class HConfigChild(  # ruff:ignore[too-many-public-methods]  pylint: disable=too
 
     @property
     def text_without_negation(self) -> str:
+        """The text with the driver's negation prefix removed, if present."""
         return self.text.removeprefix(self.driver.negation_prefix)
 
     @property
@@ -114,6 +117,11 @@ class HConfigChild(  # ruff:ignore[too-many-public-methods]  pylint: disable=too
         return self.parent.root
 
     def lines(self, *, sectional_exiting: bool = False) -> Iterable[str]:
+        """Yield the indented config lines of self and its children.
+
+        With `sectional_exiting`, the driver's exit token is appended after
+        each section that requires one.
+        """
         yield self.indented_text()
         for child in sorted(self.children):
             yield from child.lines(sectional_exiting=sectional_exiting)
@@ -126,10 +134,16 @@ class HConfigChild(  # ruff:ignore[too-many-public-methods]  pylint: disable=too
 
     @property
     def sectional_exit(self) -> str | None:
+        """The driver-determined exit token for this section, if any."""
         return self.driver.sectional_exit(self)
 
     @property
     def sectional_exit_text_parent_level(self) -> bool:
+        """Whether the exit token renders at the parent's indentation level.
+
+        Determined by the first matching sectional-exiting rule; defaults
+        to False.
+        """
         for rule in self.driver.rules.sectional_exiting:
             if self.is_lineage_match(rule.match_rules):
                 return rule.exit_text_parent_level
@@ -137,6 +151,11 @@ class HConfigChild(  # ruff:ignore[too-many-public-methods]  pylint: disable=too
         return False
 
     def delete_sectional_exit(self) -> None:
+        """Remove the last child if it matches this section's exit token.
+
+        Used after parsing so that stored trees do not retain explicit exit
+        lines.
+        """
         try:
             potential_exit = self.children[-1]
         except IndexError:
@@ -209,6 +228,7 @@ class HConfigChild(  # ruff:ignore[too-many-public-methods]  pylint: disable=too
 
     @property
     def indentation(self) -> str:
+        """The leading whitespace rendered before this node's text."""
         return " " * self.driver.rules.indentation * (self.depth - 1)
 
     def delete(self) -> None:
@@ -379,6 +399,10 @@ class HConfigChild(  # ruff:ignore[too-many-public-methods]  pylint: disable=too
 
     @property
     def instance(self) -> Instance:
+        """The `Instance` record for this node (root config id, comments, and tags).
+
+        Used to track the origin of a child when merging multiple configs.
+        """
         return Instance(
             id=id(self.root),
             comments=frozenset(self.comments),
@@ -494,6 +518,7 @@ class HConfigChild(  # ruff:ignore[too-many-public-methods]  pylint: disable=too
         return self
 
     def instantiate_child(self, text: str) -> HConfigChild:
+        """Create a new `HConfigChild` with self as the parent."""
         return HConfigChild(self, text)
 
     def _is_duplicate_child_allowed(self) -> bool:

--- a/hier_config/children.py
+++ b/hier_config/children.py
@@ -90,6 +90,11 @@ class HConfigChildren:
         *,
         update_mapping: bool = True,
     ) -> HConfigChild:
+        """Append a child and return it.
+
+        With `update_mapping=False`, the child is added to the ordered list
+        only (used for allowed duplicate children).
+        """
         self._data.append(child)
         if update_mapping:
             self._mapping.setdefault(child.text, child)
@@ -120,9 +125,11 @@ class HConfigChildren:
             self._mapping.setdefault(child.text, child)
 
     def get(self, key: str, default: _D | None = None) -> HConfigChild | _D | None:
+        """Return the child whose text equals `key`, or `default` if not found."""
         return self._mapping.get(key, default)
 
     def index(self, child: HConfigChild) -> int:
+        """Return the position of `child` in the ordered list."""
         return self._data.index(child)
 
     def rebuild_mapping(self) -> None:

--- a/hier_config/constructors.py
+++ b/hier_config/constructors.py
@@ -61,6 +61,12 @@ def hconfig_from_text(
     platform_or_driver: Platform | str | HConfigDriverBase,
     config_raw: Path | str = "",
 ) -> HConfig:
+    """Create an HConfig from raw configuration text (or a Path to it).
+
+    Applies the driver's full-text substitutions, parses the text into a
+    tree (including banner handling), strips sectional-exit lines, and runs
+    post-load callbacks.
+    """
     if isinstance(config_raw, Path):
         config_raw = config_raw.read_text(encoding="utf8")
 
@@ -113,6 +119,12 @@ def hconfig_from_lines(
     platform_or_driver: Platform | str | HConfigDriverBase,
     lines: list[str] | tuple[str, ...] | str,
 ) -> HConfig:
+    """Create an HConfig from pre-split configuration lines (fast load).
+
+    Applies per-line substitutions and indentation analysis but skips the
+    full-text substitutions, config preprocessor, and banner handling of
+    `hconfig_from_text`.
+    """
     driver = resolve_driver(platform_or_driver)
     config = HConfig(driver)
     if isinstance(lines, str):

--- a/hier_config/platforms/driver_base.py
+++ b/hier_config/platforms/driver_base.py
@@ -152,6 +152,12 @@ class HConfigDriverBase(ABC):
         config: HConfigChild,
         other_children: Iterable[HConfigChild],
     ) -> HConfigChild | None:
+        """Return the child in `other_children` that `config` idempotently overwrites.
+
+        The default implementation derives a structural idempotency key from
+        the lineage and the `idempotent_commands` match rules. Override for
+        imperative idempotency logic.
+        """
         for rule in self.rules.idempotent_commands:
             if not config.is_lineage_match(rule.match_rules):
                 continue
@@ -181,6 +187,12 @@ class HConfigDriverBase(ABC):
         return None
 
     def sectional_exit(self, config: HConfigChild) -> str | None:
+        """Return the exit token to render at the end of `config`'s section.
+
+        Sectional-exiting rules are consulted first; a matching rule without
+        `exit_text` suppresses the token. Otherwise, sections with children
+        default to `exit` and leaves to None.
+        """
         for exit_rule in self.rules.sectional_exiting:
             if config.is_lineage_match(exit_rule.match_rules):
                 if exit_text := exit_rule.exit_text:
@@ -437,14 +449,31 @@ class HConfigDriverBase(ABC):
 
     @property
     def declaration_prefix(self) -> str:
+        """The string prepended to positive commands on set-style platforms.
+
+        Defaults to an empty string; set-style drivers override this with
+        e.g. `set `.
+        """
         return ""
 
     @property
     def negation_prefix(self) -> str:
+        """The string prepended to a command to negate it.
+
+        Defaults to `no `; drivers override this with e.g. `undo ` or
+        `delete `.
+        """
         return "no "
 
     @staticmethod
     def config_preprocessor(config_text: str) -> str:
+        """Transform raw config text before parsing.
+
+        The default is a no-op. Override to convert a platform's native
+        rendering into parseable lines (e.g. flattening JunOS curly-brace
+        config into `set` commands). Runs inside `HConfig.from_text()` after
+        full-text substitutions and before tree construction.
+        """
         return config_text
 
     @staticmethod

--- a/hier_config/platforms/view_base.py
+++ b/hier_config/platforms/view_base.py
@@ -305,6 +305,7 @@ class HConfigViewBase(ABC):
 
     @property
     def bundle_interface_views(self) -> Iterable[InterfaceBundleViewMixin]:
+        """The interface views that represent bundle (LAG) interfaces."""
         for interface_view in self.interface_views:
             if (
                 isinstance(interface_view, InterfaceBundleViewMixin)
@@ -331,7 +332,7 @@ class HConfigViewBase(ABC):
     @property
     @abstractmethod
     def hostname(self) -> str | None:
-        pass
+        """Determine the configured hostname, or None if not set."""
 
     @property
     def interface_names_mentioned(self) -> frozenset[str]:
@@ -339,6 +340,7 @@ class HConfigViewBase(ABC):
         return frozenset(model.name for model in self.interface_views)
 
     def interface_view_by_name(self, name: str) -> ConfigViewInterfaceBase | None:
+        """Return the interface view for the given interface name, if any."""
         for interface_view in self.interface_views:
             if interface_view.name == name:
                 return interface_view
@@ -347,22 +349,23 @@ class HConfigViewBase(ABC):
     @property
     @abstractmethod
     def interface_views(self) -> Iterable[ConfigViewInterfaceBase]:
-        pass
+        """A platform-specific interface view for each interface in the config."""
 
     @property
     @abstractmethod
     def interfaces(self) -> Iterable[HConfigChild]:
-        pass
+        """The config children defining the device's interfaces."""
 
     @property
     def interfaces_names(self) -> Iterable[str]:
+        """The name of each interface."""
         for interface_view in self.interface_views:
             yield interface_view.name
 
     @property
     @abstractmethod
     def ipv4_default_gw(self) -> IPv4Address | None:
-        pass
+        """Determine the IPv4 default gateway address, if configured."""
 
     @property
     def location(self) -> str:
@@ -373,6 +376,7 @@ class HConfigViewBase(ABC):
 
     @property
     def module_numbers(self) -> Iterable[int]:
+        """The unique module numbers of physical interfaces, in order seen."""
         seen: set[int] = set()
         for interface_view in self.interface_views:
             if not isinstance(interface_view, InterfacePhysicalViewMixin):

--- a/hier_config/root.py
+++ b/hier_config/root.py
@@ -150,14 +150,17 @@ class HConfig(HConfigBase):  # ruff:ignore[too-many-public-methods]
 
     @property
     def driver(self) -> HConfigDriverBase:
+        """The platform driver this config was created with."""
         return self._driver
 
     @property
     def real_indent_level(self) -> int:
+        """The indentation level used during parsing; always -1 for the root."""
         return -1
 
     @property
     def parent(self) -> HConfig:
+        """The root is its own parent."""
         return self
 
     @property
@@ -176,6 +179,7 @@ class HConfig(HConfigBase):  # ruff:ignore[too-many-public-methods]
         return True
 
     def instantiate_child(self, text: str) -> HConfigChild:
+        """Create a new `HConfigChild` with self as the parent."""
         return HConfigChild(self, text)
 
     @property
@@ -217,10 +221,16 @@ class HConfig(HConfigBase):  # ruff:ignore[too-many-public-methods]
         yield from ()
 
     def lines(self, *, sectional_exiting: bool = False) -> Iterable[str]:
+        """Yield the indented config lines of the tree, sorted at each level.
+
+        With `sectional_exiting`, the driver's exit token is appended after
+        each section that requires one.
+        """
         for child in sorted(self.children):
             yield from child.lines(sectional_exiting=sectional_exiting)
 
     def to_lines(self, *, sectional_exiting: bool = False) -> tuple[str, ...]:
+        """Return the rendered config lines as a tuple."""
         return tuple(self.lines(sectional_exiting=sectional_exiting))
 
     def dump(self) -> Dump:

--- a/hier_config/tree_algorithms.py
+++ b/hier_config/tree_algorithms.py
@@ -29,7 +29,12 @@ class FutureReport:
     """
 
     unresolved_negations: tuple[HConfigChild, ...]
+    """Kept negation lines whose positive form matched nothing in the source
+    config — the change did not apply cleanly."""
+
     idempotency_replacements: tuple[HConfigChild, ...]
+    """Negation lines that persisted by replacing an idempotency-tracked
+    counterpart (e.g. IOS `no logging console`)."""
 
 
 def _new_child_list() -> list[HConfigChild]:

--- a/hier_config/workflows.py
+++ b/hier_config/workflows.py
@@ -25,15 +25,15 @@ class WorkflowRemediation:
         generated_config (HConfig): The target configuration for the network device.
 
     Raises:
-        ValueError: If `running_config` and `generated_config` have different drivers.
+        IncompatibleDriverError: If `running_config` and `generated_config` have
+            different drivers.
 
     Example:
         Initialize `WorkflowRemediation` with the running and generated configurations
         and generate remediation and rollback configurations.
 
         ```python
-        from hier_config import WorkflowRemediation, get_hconfig
-        from hier_config.model import Platform
+        from hier_config import HConfig, Platform, WorkflowRemediation
 
         # Create running and generated configurations as HConfig objects
         running_config = HConfig.from_text(Platform.CISCO_IOS, "running_config_text")

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -17,7 +17,7 @@ plugins:
       redirect_maps:
         install.md: user/install.md
         getting-started.md: user/getting-started.md
-        utilities.md: user/loading-configs.md
+        utilities.md: admin/rules-from-files.md
         drivers.md: admin/platforms.md
         future-config.md: user/future-config.md
         unified-diff.md: user/unified-diff.md
@@ -28,7 +28,7 @@ plugins:
         config-view.md: user/config-views.md
         api-reference.md: dev/api-reference.md
         architecture.md: dev/architecture.md
-        user/utilities.md: user/loading-configs.md
+        user/utilities.md: admin/rules-from-files.md
         user/drivers.md: admin/platforms.md
         user/custom-drivers.md: admin/custom-drivers.md
         user/custom-workflows.md: user/remediation-workflows.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -150,7 +150,7 @@ parametrize-values-type = "tuple"
 
 [tool.ruff.lint.per-file-ignores]
 "**/tests/*" = ["PLC2701", "S101"]
-"tests/test_benchmarks.py" = ["T201", "PLR6301", "PERF401"]
+"tests/benchmarks/test_benchmarks.py" = ["T201", "PLR6301", "PERF401"]
 # HConfig's classmethod constructors and WorkflowRemediation's format
 # renderers defer their loader imports to call time to avoid circular
 # imports and keep `import hier_config` light.

--- a/tests/benchmarks/test_benchmarks.py
+++ b/tests/benchmarks/test_benchmarks.py
@@ -155,7 +155,7 @@ class TestParsingBenchmarks:
         config_text = _generate_large_ios_config()
         elapsed = _time_fn(lambda: HConfig.from_text(Platform.CISCO_IOS, config_text))
         line_count = config_text.count("\n")
-        print(f"\nget_hconfig: {line_count} lines in {elapsed:.4f}s")  # ruff:ignore[print]
+        print(f"\nget_hconfig: {line_count} lines in {elapsed:.4f}s")
         assert elapsed < 5.0, f"Parsing took {elapsed:.2f}s, expected < 5s"
 
     @staticmethod
@@ -164,7 +164,7 @@ class TestParsingBenchmarks:
         config_text = _generate_large_xr_config()
         elapsed = _time_fn(lambda: HConfig.from_text(Platform.CISCO_XR, config_text))
         line_count = config_text.count("\n")
-        print(f"\nget_hconfig (XR): {line_count} lines in {elapsed:.4f}s")  # ruff:ignore[print]
+        print(f"\nget_hconfig (XR): {line_count} lines in {elapsed:.4f}s")
         assert elapsed < 5.0, f"Parsing took {elapsed:.2f}s, expected < 5s"
 
     @staticmethod
@@ -175,7 +175,7 @@ class TestParsingBenchmarks:
         elapsed = _time_fn(
             lambda: HConfig.from_lines(Platform.CISCO_IOS, config_lines),
         )
-        print(f"\nget_hconfig_fast_load: {len(config_lines)} lines in {elapsed:.4f}s")  # ruff:ignore[print]
+        print(f"\nget_hconfig_fast_load: {len(config_lines)} lines in {elapsed:.4f}s")
         assert elapsed < 5.0, f"Fast load took {elapsed:.2f}s, expected < 5s"
 
     @staticmethod
@@ -189,7 +189,7 @@ class TestParsingBenchmarks:
             lambda: HConfig.from_lines(Platform.CISCO_IOS, config_lines),
         )
         ratio = time_full / time_fast if time_fast > 0 else float("inf")
-        print(  # ruff:ignore[print]
+        print(
             f"\nget_hconfig: {time_full:.4f}s, "
             f"fast_load: {time_fast:.4f}s, "
             f"ratio: {ratio:.1f}x"
@@ -216,7 +216,7 @@ class TestRemediationBenchmarks:
         generated = HConfig.from_text(Platform.CISCO_IOS, generated_text)
 
         elapsed = _time_fn(lambda: running.remediation(generated))
-        print(f"\nRemediation (10% diff): {elapsed:.4f}s")  # ruff:ignore[print]
+        print(f"\nRemediation (10% diff): {elapsed:.4f}s")
         assert elapsed < 5.0, f"Remediation took {elapsed:.2f}s, expected < 5s"
 
     @staticmethod
@@ -229,7 +229,7 @@ class TestRemediationBenchmarks:
         generated = HConfig.from_text(Platform.CISCO_IOS, generated_text)
 
         elapsed = _time_fn(lambda: running.remediation(generated))
-        print(f"\nRemediation (100% diff): {elapsed:.4f}s")  # ruff:ignore[print]
+        print(f"\nRemediation (100% diff): {elapsed:.4f}s")
         assert elapsed < 10.0, f"Remediation took {elapsed:.2f}s, expected < 10s"
 
     @staticmethod
@@ -249,7 +249,7 @@ class TestRemediationBenchmarks:
         generated = HConfig.from_text(Platform.CISCO_IOS, "\n".join(lines))
 
         elapsed = _time_fn(lambda: running.remediation(generated))
-        print(f"\nRemediation (completely different): {elapsed:.4f}s")  # ruff:ignore[print]
+        print(f"\nRemediation (completely different): {elapsed:.4f}s")
         assert elapsed < 10.0, f"Remediation took {elapsed:.2f}s, expected < 10s"
 
 
@@ -263,7 +263,7 @@ class TestIterationBenchmarks:
 
         elapsed = _time_fn(lambda: list(config.all_children_sorted()))
         child_count = len(list(config.all_children()))
-        print(f"\nall_children_sorted: {child_count} nodes in {elapsed:.4f}s")  # ruff:ignore[print]
+        print(f"\nall_children_sorted: {child_count} nodes in {elapsed:.4f}s")
         assert elapsed < 2.0, f"Iteration took {elapsed:.2f}s, expected < 2s"
 
     @staticmethod
@@ -273,7 +273,7 @@ class TestIterationBenchmarks:
 
         elapsed = _time_fn(config.to_lines)
         line_count = len(config.to_lines())
-        print(f"\nto_lines: {line_count} lines in {elapsed:.4f}s")  # ruff:ignore[print]
+        print(f"\nto_lines: {line_count} lines in {elapsed:.4f}s")
         assert elapsed < 2.0, f"to_lines took {elapsed:.2f}s, expected < 2s"
 
     @staticmethod
@@ -282,5 +282,5 @@ class TestIterationBenchmarks:
         config = HConfig.from_text(Platform.CISCO_IOS, _generate_large_ios_config())
 
         elapsed = _time_fn(config.deep_copy)
-        print(f"\ndeep_copy: {elapsed:.4f}s")  # ruff:ignore[print]
+        print(f"\ndeep_copy: {elapsed:.4f}s")
         assert elapsed < 5.0, f"deep_copy took {elapsed:.2f}s, expected < 5s"


### PR DESCRIPTION
# Summary

Closes the gaps found in a full audit of the documentation and agent-facing instruction files against the code on `next`. Four commits, one per surface:

**Agent instruction files** (`c222257`) — AGENTS.md/copilot-instructions/skills contradicted or omitted repo reality:

- Hard Rule #1 ("immutable collections only") contradicted the deliberate `list[...]` fields on `HConfigDriverRules` (#286 removal-by-identity); an agent following it literally would break that public API. The carve-out is now documented in AGENTS.md, copilot-instructions, code-style.md, and both affected skills.
- The `hier-config-review` skill diffed against `master`, which on any `next`-based branch pulls in all of v4 — it now uses the merge-base with the actual base branch.
- AGENTS.md had no branching strategy at all (only CLAUDE.md did, so non-Claude agents would target `master` for v4 work). Also added: the CI Python matrix (3.10–3.14), the unconditional docs `--strict` job and its separate `docs/requirements.txt`, the formats/plugins/constructors modules, `future_with_report()`, and the #284/#295 registry canonicalization (including the `Platform.X.name` key requirement in the new-driver skill).
- CONTRIBUTING.md referenced a nonexistent test file, omitted yamllint/flynt, the changelog requirement, and branch-base guidance.

**User docs + README** (`ff7007b`) — five documented examples were verifiably broken (nonexistent fixture in getting-started, tags.md filtering on a tag its fixture never defines, a nonexistent `delete_child()` method, wrong config-view outputs, six missing JunOS output lines). All replacement outputs were produced by running the snippets against the real fixtures. Also: `--pre` in the README install (its Quick Start uses the v4-only API), de-pinned the drifted `4.0.0b1` from install.md, propagated Aruba AOS-CX into architecture/config-view docs, corrected the `HConfigViewBase` abstract-member lists, added the formats module / Future Config section / `resolve_driver` / view data models / all nine built-in post-load callbacks to the API reference, five new glossary entries, and pointed the legacy `utilities.md` redirects at `admin/rules-from-files.md`.

**CHANGELOG** (`480d04d`) — `[Unreleased]` had duplicate Added/Changed/Fixed headings, Added entries misfiled under Fixed, a non-standard "v4 design decisions" heading, and a self-contradiction (JSON/XML ingestion described as both shipped and post-4.0 roadmap). Merged to one heading per category with all 59 entries and every `(#NNN)` reference preserved. Also fixed the stale benchmarks per-file-ignore path in pyproject.toml (`tests/test_benchmarks.py` → `tests/benchmarks/test_benchmarks.py`) and removed the ten inline suppressions that fix makes redundant.

**Docstrings** (`be650e4`) — the `WorkflowRemediation` class docstring (rendered on the public API reference) showed a v3 example importing the removed `get_hconfig` from the nonexistent `hier_config.model` module and claimed `Raises: ValueError` where the code raises `IncompatibleDriverError`. Documented the `FutureReport` fields and 33 previously undocumented public members on autodoc'd classes. No code behavior changed.

## Self-Review Checklist

- [x] `poetry run ./scripts/build.py lint-and-test` passes locally (lint + 95% test coverage).
- [x] Tests were written first (TDD) and cover the change, following the [testing conventions](https://hier-config.readthedocs.io/en/latest/dev/testing/). *(No behavior change in this PR — library edits are docstring-only; the doc examples were verified by executing them against the repo fixtures.)*
- [x] `CHANGELOG.md` has an entry under `## [Unreleased]` referencing this issue/PR (`(#297)`).
- [x] Documentation is updated if public API or driver behavior changed (and `mkdocs build --strict` passes if docs were touched).
- [x] Commit messages follow the [contributing guide](https://github.com/netdevops/hier_config/blob/master/CONTRIBUTING.md): imperative mood, subject ≤72 characters, body explains *why*.

## AI-Assisted Contributions

Written with Claude Code; the `hier-config-review` skill was run against the final diff (using the corrected `next` merge-base this PR introduces) — gates green, no blockers or should-fix findings.

## Noted but out of scope

- The docs CI job runs `mkdocs build --strict` without installing the package (fragile if griffe ever falls back to dynamic import); the `include-markdown` plugin is loaded but unused.
- `poetry.lock` currently resolves `mkdocs-redirects` → `properdocs` and `mkdocstrings-python` → `griffelib` (forks that arrived transitively via #290's lock change; `properdocs` injects an "MkDocs is abandoned" banner into every build). Worth a separate review of those pins.
- Empty `tests/circular/` and `tests/config_view/` directories remain from the test-layout move.
