### PR TITLE
add claude review agent

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -22,6 +22,8 @@ jobs:
       pull-requests: write
       issues: write
       actions: read
+      # claude-code-action exchanges an OIDC token for its GitHub App token.
+      id-token: write
     steps:
     - uses: actions/checkout@v6
       with:

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,74 @@
+name: Claude PR review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+# Cancel a superseded review when the branch is pushed again.
+concurrency:
+  group: claude-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    # Secrets, including CLAUDE_CODE_OAUTH_TOKEN, are unavailable to fork
+    # pull requests.
+    if: >-
+      github.event.pull_request.draft == false &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      actions: read
+    steps:
+    - uses: actions/checkout@v6
+      with:
+        fetch-depth: 0
+
+    - name: Fetch the base branch
+      run: |
+        git fetch --no-tags origin \
+          +refs/heads/${{ github.event.pull_request.base.ref }}:refs/heads/${{ github.event.pull_request.base.ref }} || true
+
+    - name: Set up Python
+      uses: actions/setup-python@v6
+      with:
+        python-version: "3.12"
+
+    - name: Install poetry
+      uses: snok/install-poetry@v1
+      with:
+        version: 1.5.1
+
+    - name: Install the project dependencies
+      run: poetry install --no-interaction --no-root
+
+    - name: Install the docs dependencies
+      run: pip install -r docs/requirements.txt
+
+    - name: Run the hier-config-review skill
+      uses: anthropics/claude-code-action@v1
+      with:
+        claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+        track_progress: true
+        prompt: |
+          /hier-config-review
+
+          Review this pull request. The base branch is
+          `${{ github.event.pull_request.base.ref }}`, so use
+          `git diff ${{ github.event.pull_request.base.ref }}...HEAD` for the diff.
+
+          The Python environment is ready. Do not run `poetry install`.
+
+          Report only. Do not change, stage, or commit any file.
+
+          Post the full report as your pull request comment. Group the findings
+          by severity (Blockers, Should fix, Nits). Give each finding a
+          `file:line` reference and name the standard it violates. End with the
+          pass/fail verdict against the "Before Opening a PR" checklist in
+          AGENTS.md.
+        claude_args: |
+          --max-turns 60
+          --allowedTools Read,Grep,Glob,Bash,mcp__github_comment__update_claude_comment

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `.github/workflows/claude-review.yml`: a GitHub Actions workflow that runs
+  the in-repo `hier-config-review` skill against every pull request through
+  `anthropics/claude-code-action` and posts the findings as a PR comment. The
+  job installs the poetry and docs environments first, so the skill's lint,
+  test, and `mkdocs build --strict` gates run for real. It is skipped for draft
+  and fork pull requests, where `CLAUDE_CODE_OAUTH_TOKEN` is unavailable.
 - Aruba AOS-CX platform support (`Platform.ARUBA_AOSCX`): a new driver and
   config view covering AOS-CX's Cisco/EOS-like hierarchical CLI. Because
   `vlan trunk allowed` is additive on AOS-CX rather than declarative, collapsed


### PR DESCRIPTION
# Summary

<!-- What does this PR change, and why? Link the related issue, e.g. "Closes #123". -->

## Self-Review Checklist

<!-- The full standards live in AGENTS.md and https://hier-config.readthedocs.io/en/latest/dev/contributing/ -->

- [ ] `poetry run ./scripts/build.py lint-and-test` passes locally (lint + 95% test coverage).
- [ ] Tests were written first (TDD) and cover the change, following the [testing conventions](https://hier-config.readthedocs.io/en/latest/dev/testing/).
- [ ] `CHANGELOG.md` has an entry under `## [Unreleased]` referencing this issue/PR (`(#NNN)`).
- [ ] Documentation is updated if public API or driver behavior changed (and `mkdocs build --strict` passes if docs were touched).
- [ ] Commit messages follow the [contributing guide](https://github.com/netdevops/hier_config/blob/master/CONTRIBUTING.md): imperative mood, subject ≤72 characters, body explains *why*.

## AI-Assisted Contributions

If this PR was written with an AI coding tool, review it against the repo standards before requesting review: Claude Code users can run the `hier-config-review` skill; other tools should be pointed at `AGENTS.md` and the [developer docs](https://hier-config.readthedocs.io/en/latest/dev/contributing/).
